### PR TITLE
fix: Issue confirmation via ✅ reaction instead of text reply

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { after } from "next/server";
-import { verifySlackSignature, replyInThread } from "@/lib/slack";
+import {
+  verifySlackSignature,
+  replyInThread,
+  fetchMessage,
+  getBotUserId,
+} from "@/lib/slack";
 import { runAgent } from "@/lib/claude";
+import { createIssue } from "@/lib/github";
+import { parseProposalFromMessage } from "@/tools/create-issue";
 
 /**
  * Slack Events API webhook handler.
@@ -72,7 +79,7 @@ export async function POST(request: NextRequest) {
               "",
               proposal.body,
               "",
-              '👆 Reply *"yes"* or *"create it"* to confirm, or *"no"* to cancel.',
+              "React with :white_check_mark: to create this issue, or ignore to cancel.",
             ].join("\n"),
           );
         } else {
@@ -86,6 +93,67 @@ export async function POST(request: NextRequest) {
           threadTs,
           `Something went wrong while processing your request. Error: ${msg}`,
         );
+      }
+    });
+
+    return NextResponse.json({ ok: true });
+  }
+
+  // ── Handle ✅ reaction on proposal messages → create the issue ─────
+  if (event.type === "reaction_added" && event.reaction === "white_check_mark") {
+    const item = event.item;
+    if (item?.type !== "message") return NextResponse.json({ ok: true });
+
+    const channel: string = item.channel;
+    const messageTs: string = item.ts;
+    const reactingUser: string = event.user;
+
+    after(async () => {
+      try {
+        // Ignore reactions from the bot itself
+        const botId = await getBotUserId();
+        if (botId && reactingUser === botId) return;
+
+        // Fetch the message that was reacted to
+        const msg = await fetchMessage(channel, messageTs);
+        if (!msg) return;
+
+        // Only act on our own messages (proposals posted by the bot)
+        if (msg.user !== botId) return;
+
+        // Parse the proposal from the message text
+        const proposal = parseProposalFromMessage(msg.text);
+        if (!proposal) return; // Not a proposal message — ignore
+
+        // Create the issue on GitHub
+        const issue = await createIssue(
+          proposal.title,
+          proposal.body,
+          proposal.labels,
+        );
+
+        // Reply in the same thread with the new issue link
+        const threadTs = msg.thread_ts || messageTs;
+        await replyInThread(
+          channel,
+          threadTs,
+          `:white_check_mark: Created issue *#${issue.number}*: <${issue.url}|${issue.title}>`,
+        );
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : "Unknown error";
+        console.error("Battle Mage reaction handler error:", errMsg);
+        // Best-effort reply — use thread_ts if available
+        try {
+          const msg = await fetchMessage(channel, messageTs);
+          const threadTs = msg?.thread_ts || messageTs;
+          await replyInThread(
+            channel,
+            threadTs,
+            `Failed to create issue: ${errMsg}`,
+          );
+        } catch {
+          // Can't reply — just log
+        }
       }
     });
 

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -54,3 +54,39 @@ export async function replyInThread(
     text,
   });
 }
+
+// ── Fetch a single message by channel + ts ───────────────────────────
+// Works for both thread parents and threaded replies.
+// Uses conversations.replies which accepts any message ts in a thread.
+export async function fetchMessage(
+  channel: string,
+  ts: string,
+): Promise<{ text: string; user?: string; thread_ts?: string } | null> {
+  try {
+    const result = await slack.conversations.replies({
+      channel,
+      ts,
+      inclusive: true,
+      limit: 1,
+    });
+    const msg = result.messages?.[0];
+    if (!msg) return null;
+    return { text: msg.text ?? "", user: msg.user, thread_ts: msg.thread_ts };
+  } catch {
+    return null;
+  }
+}
+
+// ── Get bot's own user ID (cached per cold start) ────────────────────
+let cachedBotUserId: string | undefined;
+
+export async function getBotUserId(): Promise<string | undefined> {
+  if (cachedBotUserId) return cachedBotUserId;
+  try {
+    const result = await slack.auth.test();
+    cachedBotUserId = result.user_id ?? undefined;
+    return cachedBotUserId;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/tools/create-issue.ts
+++ b/src/tools/create-issue.ts
@@ -45,3 +45,38 @@ export function extractIssueProposal(
     labels: input.labels as string[] | undefined,
   };
 }
+
+// ── Parse a proposal from the bot's own Slack message text ────────────
+// The bot posts proposals in a known format (see route.ts). This parses
+// the title, labels, and body back out so we can create the issue when
+// the user confirms via ✅ reaction.
+
+const PROPOSAL_TITLE_RE = /\*Proposed Issue:\*\s*(.+)/;
+const PROPOSAL_LABELS_RE = /\*Labels:\*\s*(.+)/;
+const PROPOSAL_CONFIRM_LINE = "React with :white_check_mark: to create this issue";
+
+export function parseProposalFromMessage(
+  text: string,
+): IssueProposal | null {
+  const titleMatch = text.match(PROPOSAL_TITLE_RE);
+  if (!titleMatch) return null;
+
+  const title = titleMatch[1].trim();
+
+  const labelsMatch = text.match(PROPOSAL_LABELS_RE);
+  const labels = labelsMatch
+    ? labelsMatch[1].split(",").map((l) => l.trim()).filter(Boolean)
+    : undefined;
+
+  // Body sits between the labels/title line and the confirmation prompt
+  const anchorLine = labelsMatch ? labelsMatch[0] : titleMatch[0];
+  const bodyStart = text.indexOf(anchorLine) + anchorLine.length;
+  const bodyEnd = text.lastIndexOf(PROPOSAL_CONFIRM_LINE);
+
+  if (bodyEnd === -1) return null;
+
+  const body = text.slice(bodyStart, bodyEnd).trim();
+  if (!body) return null;
+
+  return { title, body, labels };
+}


### PR DESCRIPTION
## Summary

- Replace broken "reply yes" confirmation with ✅ emoji reaction flow
- Add `fetchMessage()` and `getBotUserId()` helpers to `slack.ts`
- Add `parseProposalFromMessage()` to parse proposal from bot's own message text
- Add `reaction_added` event handler in route.ts that creates the GitHub issue on ✅

The previous confirmation UX asked users to reply "yes" but the bot only subscribes to `app_mention` events — text replies were never received. Now the bot listens for `reaction_added` events and creates the issue when a user reacts ✅ on a proposal message.

**Safety guards:**
- Only triggers on ✅ (`white_check_mark`) reactions
- Only acts on the bot's own messages
- Only parses messages containing the `*Proposed Issue:*` format
- Ignores reactions from the bot itself

## Files changed

| File | Change |
|------|--------|
| `src/app/api/slack/route.ts` | `reaction_added` handler + updated proposal prompt |
| `src/lib/slack.ts` | `fetchMessage()` and `getBotUserId()` helpers |
| `src/tools/create-issue.ts` | `parseProposalFromMessage()` parser |

## Test plan

- [ ] Propose an issue via `@bm create an issue for X`
- [ ] Verify proposal message says "React with ✅ to create this issue"
- [ ] React with ✅ — verify issue is created and link posted in thread
- [ ] React ✅ on a non-proposal bot message — verify no action taken
- [ ] React ✅ on another user's message — verify no action taken

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)