### PR TITLE
feat: Thumbs up/down reaction feedback to tune future answers

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -10,6 +10,7 @@ import {
 import { runAgent } from "@/lib/claude";
 import { createIssue } from "@/lib/github";
 import { parseProposalFromMessage } from "@/tools/create-issue";
+import { storeQAContext, getQAContext, saveFeedback } from "@/lib/feedback";
 
 import type { Reference } from "@/tools";
 
@@ -108,7 +109,16 @@ export async function POST(request: NextRequest) {
             ].join("\n") + refsFooter,
           );
         } else {
-          await replyInThread(channel, threadTs, text + refsFooter);
+          const replyTs = await replyInThread(channel, threadTs, text + refsFooter);
+
+          // Store Q&A context so 👍/👎 reactions can reference it
+          if (replyTs) {
+            await storeQAContext(channel, replyTs, {
+              question: cleanMessage,
+              answer: result.text.slice(0, 500),
+              references: result.references.map((r) => r.label),
+            });
+          }
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Unknown error";
@@ -175,7 +185,15 @@ export async function POST(request: NextRequest) {
             ].join("\n") + refsFooter,
           );
         } else {
-          await replyInThread(channel, threadTs, text + refsFooter);
+          const replyTs = await replyInThread(channel, threadTs, text + refsFooter);
+
+          if (replyTs) {
+            await storeQAContext(channel, replyTs, {
+              question: cleanMessage,
+              answer: result.text.slice(0, 500),
+              references: result.references.map((r) => r.label),
+            });
+          }
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Unknown error";
@@ -246,6 +264,88 @@ export async function POST(request: NextRequest) {
         } catch {
           // Can't reply — just log
         }
+      }
+    });
+
+    return NextResponse.json({ ok: true });
+  }
+
+  // ── Handle 👍 reaction → save positive feedback ─────────────────────
+  if (event.type === "reaction_added" && event.reaction === "+1") {
+    const item = event.item;
+    if (item?.type !== "message") return NextResponse.json({ ok: true });
+
+    const channel: string = item.channel;
+    const messageTs: string = item.ts;
+
+    after(async () => {
+      try {
+        const botId = await getBotUserId();
+        if (botId && event.user === botId) return;
+
+        // Only act on bot messages
+        const msg = await fetchMessage(channel, messageTs);
+        if (!msg || msg.user !== botId) return;
+
+        const context = await getQAContext(channel, messageTs);
+        if (!context) return; // No Q&A context — probably not an answer message
+
+        await saveFeedback({
+          type: "positive",
+          question: context.question,
+          detail: `Good answer approach. Referenced: ${context.references.join(", ") || "general knowledge"}`,
+          timestamp: new Date().toISOString().split("T")[0],
+        });
+
+        // Silent acknowledgment — just add a checkmark reaction
+        try {
+          const { slack } = await import("@/lib/slack");
+          await slack.reactions.add({ channel, name: "brain", timestamp: messageTs });
+        } catch { /* already reacted or can't react — ignore */ }
+      } catch (err) {
+        console.error("Battle Mage 👍 handler error:", err instanceof Error ? err.message : err);
+      }
+    });
+
+    return NextResponse.json({ ok: true });
+  }
+
+  // ── Handle 👎 reaction → ask for correction, save negative feedback ─
+  if (event.type === "reaction_added" && event.reaction === "-1") {
+    const item = event.item;
+    if (item?.type !== "message") return NextResponse.json({ ok: true });
+
+    const channel: string = item.channel;
+    const messageTs: string = item.ts;
+
+    after(async () => {
+      try {
+        const botId = await getBotUserId();
+        if (botId && event.user === botId) return;
+
+        const msg = await fetchMessage(channel, messageTs);
+        if (!msg || msg.user !== botId) return;
+
+        const context = await getQAContext(channel, messageTs);
+        if (!context) return;
+
+        // Save immediate negative feedback
+        await saveFeedback({
+          type: "negative",
+          question: context.question,
+          detail: `Answer was thumbs-downed. Original answer used: ${context.references.join(", ") || "general knowledge"}. Review approach for this type of question.`,
+          timestamp: new Date().toISOString().split("T")[0],
+        });
+
+        // Ask the user what was wrong so they can provide a correction
+        const threadTs = msg.thread_ts || messageTs;
+        await replyInThread(
+          channel,
+          threadTs,
+          `:thinking_face: Thanks for the feedback. What was wrong with this answer? Reply here and I'll save the correction to my knowledge base.`,
+        );
+      } catch (err) {
+        console.error("Battle Mage 👎 handler error:", err instanceof Error ? err.message : err);
       }
     });
 

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -3,6 +3,7 @@ import { tools, executeTool, type ToolResult, type Reference } from "@/tools";
 import type { IssueProposal } from "@/tools/create-issue";
 import { readFile } from "@/lib/github";
 import { getKnowledgeAsMarkdown } from "@/lib/knowledge";
+import { getFeedbackAsMarkdown } from "@/lib/feedback";
 
 // ── Anthropic client ──────────────────────────────────────────────────
 const anthropic = new Anthropic(); // reads ANTHROPIC_API_KEY from env
@@ -44,11 +45,15 @@ async function buildSystemPrompt(): Promise<string> {
 
   const claudeMd = await getClaudeMd();
   const knowledge = await getKnowledge();
+  const feedback = await getFeedbackAsMarkdown();
   const contextSection = claudeMd
     ? `\n## Project Context (from CLAUDE.md)\n\n${claudeMd}\n`
     : "";
   const knowledgeSection = knowledge
     ? `\n## Knowledge Base (learned corrections)\n\nThese are facts you learned from prior conversations. Trust these over your own assumptions — they are corrections from the team.\n\n${knowledge}\n`
+    : "";
+  const feedbackSection = feedback
+    ? `\n## User Feedback (from 👍/👎 reactions)\n\nThis is feedback from the team on your past answers. Use it to calibrate your approach — repeat patterns that got 👍, avoid patterns that got 👎.\n\n${feedback}\n`
     : "";
 
   return `You are Battle Mage (@bm), an AI assistant embedded in Slack with read access to the ${owner}/${repo} GitHub repository.
@@ -111,7 +116,7 @@ You are writing for Slack mrkdwn, NOT standard Markdown. Slack will show raw cha
 
 Owner: ${owner}
 Repository: ${repo}
-${contextSection}${knowledgeSection}`;
+${contextSection}${knowledgeSection}${feedbackSection}`;
 }
 
 // ── Agent loop: message → tool calls → final answer ───────────────────

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -1,0 +1,115 @@
+import { kv } from "@vercel/kv";
+
+/**
+ * Feedback System — Vercel KV storage
+ *
+ * Stores 👍/👎 reaction feedback on bot responses.
+ * Feedback shapes future answers via the system prompt.
+ *
+ * Two data structures:
+ * 1. "feedback:context:{channel}:{ts}" — stores the Q&A context for each bot message
+ * 2. "feedback:entries" — sorted set of feedback entries (like knowledge base)
+ */
+
+const CONTEXT_PREFIX = "feedback:context";
+const FEEDBACK_KEY = "feedback:entries";
+const CONTEXT_TTL = 86400 * 7; // 7 days — after that, reactions are ignored
+
+export interface QAContext {
+  question: string;
+  answer: string;
+  references: string[]; // file paths or issue numbers accessed
+}
+
+export interface FeedbackEntry {
+  type: "positive" | "negative";
+  question: string;
+  detail: string; // what worked (positive) or what was wrong (negative)
+  timestamp: string;
+}
+
+/**
+ * Store the Q&A context for a bot message so we can retrieve it on reaction.
+ */
+export async function storeQAContext(
+  channel: string,
+  messageTs: string,
+  context: QAContext,
+): Promise<void> {
+  const key = `${CONTEXT_PREFIX}:${channel}:${messageTs}`;
+  await kv.set(key, JSON.stringify(context), { ex: CONTEXT_TTL });
+}
+
+/**
+ * Retrieve the Q&A context for a bot message.
+ */
+export async function getQAContext(
+  channel: string,
+  messageTs: string,
+): Promise<QAContext | null> {
+  const key = `${CONTEXT_PREFIX}:${channel}:${messageTs}`;
+  const raw = await kv.get<string>(key);
+  if (!raw) return null;
+  try {
+    return typeof raw === "string" ? JSON.parse(raw) : (raw as QAContext);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save a feedback entry (positive or negative).
+ */
+export async function saveFeedback(entry: FeedbackEntry): Promise<void> {
+  const timestamp = Date.now();
+  await kv.zadd(FEEDBACK_KEY, {
+    score: timestamp,
+    member: JSON.stringify(entry),
+  });
+}
+
+/**
+ * Get all feedback entries formatted as markdown for the system prompt.
+ * Returns null if no entries exist.
+ */
+export async function getFeedbackAsMarkdown(): Promise<string | null> {
+  try {
+    const raw = await kv.zrange(FEEDBACK_KEY, 0, -1, { rev: true });
+    const entries = (raw as string[]).map((item) => {
+      try {
+        return JSON.parse(item) as FeedbackEntry;
+      } catch {
+        return null;
+      }
+    }).filter(Boolean) as FeedbackEntry[];
+
+    if (entries.length === 0) return null;
+
+    // Limit to most recent 30 entries to keep prompt size manageable
+    const recent = entries.slice(0, 30);
+
+    const positives = recent.filter((e) => e.type === "positive");
+    const negatives = recent.filter((e) => e.type === "negative");
+
+    const lines: string[] = [];
+
+    if (positives.length > 0) {
+      lines.push("*What worked well (do more of this):*");
+      for (const e of positives) {
+        lines.push(`- [${e.timestamp}] Q: "${e.question.slice(0, 80)}" → ${e.detail}`);
+      }
+    }
+
+    if (negatives.length > 0) {
+      if (lines.length > 0) lines.push("");
+      lines.push("*What needed correction (avoid repeating):*");
+      for (const e of negatives) {
+        lines.push(`- [${e.timestamp}] Q: "${e.question.slice(0, 80)}" → ${e.detail}`);
+      }
+    }
+
+    return lines.join("\n");
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -47,12 +47,13 @@ export async function replyInThread(
   channel: string,
   threadTs: string,
   text: string,
-): Promise<void> {
-  await slack.chat.postMessage({
+): Promise<string | undefined> {
+  const result = await slack.chat.postMessage({
     channel,
     thread_ts: threadTs,
     text,
   });
+  return result.ts; // message timestamp — used to track Q&A context for feedback
 }
 
 // ── Fetch a single message by channel + ts ───────────────────────────


### PR DESCRIPTION
## Summary

Users can react to any bot answer with 👍 or 👎 to provide quick feedback:

- **👍** — saves positive signal ("this approach worked well for this question type")
- **👎** — saves negative signal + bot asks "what was wrong?" in thread for a correction

Feedback shapes future answers via the system prompt, separate from the knowledge base.

## How it works

1. After each bot reply, the Q&A context (question, answer summary, references) is stored in Vercel KV keyed by message timestamp (7-day TTL)
2. **👍 reaction** → fetch context → save as positive feedback → add 🧠 reaction as silent ack
3. **👎 reaction** → fetch context → save as negative feedback → reply in thread asking what was wrong
4. Feedback entries (most recent 30) loaded into system prompt with "do more of this" / "avoid repeating" sections

## Data model

| Store | Key | TTL | Purpose |
|-------|-----|-----|---------|
| `feedback:context:{channel}:{ts}` | Per-message | 7 days | Links reactions back to the original Q&A |
| `feedback:entries` | Sorted set | Permanent | Accumulated feedback signals |

## Feedback vs Knowledge

- **Knowledge** = factual corrections ("auth is in app/Services not app/Http")
- **Feedback** = quality signals ("good approach for architecture questions" / "don't summarize PRs that way")

## Slack app changes needed

Add `reaction_added` to bot event subscriptions if not already present (it's in the manifest for ✅ issue creation).