### PR TITLE
ci: GitHub Actions test runner as required PR status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test & Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` — runs typecheck, tests, and build on every PR and push to main
- Node.js 22, npm cache, single job with 3 steps

## After merge

Configure as a required status check:
1. Go to **Settings > Branches > main** branch protection rule
2. Enable **Require status checks to pass before merging**
3. Search for and select **"Test & Build"**

This ensures no PR can merge with failing tests, typecheck errors, or broken builds.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)