### PR TITLE
feat: Smart search strategy — budget tool rounds, answer faster

### DIFF
--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { assembleSystemPrompt } from "./claude";
+import { assembleSystemPrompt, MAX_TOOL_ROUNDS } from "./claude";
 
 describe("assembleSystemPrompt", () => {
   const baseArgs = {
@@ -110,6 +110,42 @@ describe("assembleSystemPrompt", () => {
       const prompt = assembleSystemPrompt(baseArgs);
       expect(prompt).toContain("acme");
       expect(prompt).toContain("backend");
+    });
+  });
+
+  describe("search strategy", () => {
+    it("includes search strategy section in the prompt", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      expect(prompt).toMatch(/search strategy/i);
+    });
+
+    it("instructs to use search_code before read_file", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      // search_code must be recommended as the first step
+      expect(prompt).toMatch(/search.*before.*read|search.*first|search_code.*before.*read_file/i);
+    });
+
+    it("instructs to synthesize early, not exhaust all rounds", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      // Must mention answering with what you have rather than exhausting tool calls
+      expect(prompt).toMatch(/synthesize|answer.*early|partial answer|don.t.*exhaust|budget/i);
+    });
+
+    it("instructs to suggest follow-ups for broad questions", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      expect(prompt).toMatch(/follow.up|narrow.*question|suggest.*specific|dig deeper/i);
+    });
+
+    it("mentions the tool round limit explicitly", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      // The agent should know how many rounds it has
+      expect(prompt).toContain(String(MAX_TOOL_ROUNDS));
+    });
+  });
+
+  describe("MAX_TOOL_ROUNDS", () => {
+    it("is set to 15", () => {
+      expect(MAX_TOOL_ROUNDS).toBe(15);
     });
   });
 

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -9,7 +9,7 @@ import { getFeedbackAsMarkdown } from "@/lib/feedback";
 const anthropic = new Anthropic(); // reads ANTHROPIC_API_KEY from env
 
 const MODEL = "claude-sonnet-4-20250514";
-const MAX_TOOL_ROUNDS = 10;
+export const MAX_TOOL_ROUNDS = 15;
 
 // ── Fetch context files from target repo (cached per cold start) ─────
 let cachedClaudeMd: string | null | undefined;
@@ -93,6 +93,26 @@ You have access to these GitHub tools:
 - **list_issues**: List or look up GitHub issues
 - **create_issue**: Propose a new GitHub issue (requires user confirmation)
 - **save_knowledge**: Save a correction or fact to the persistent knowledge base
+
+## Search Strategy — CRITICAL
+
+You have a maximum of ${MAX_TOOL_ROUNDS} tool rounds per question. Budget them wisely.
+
+*Step 1: Plan* — Before calling any tool, decide what you're looking for. Formulate 1-2 targeted search queries.
+
+*Step 2: Search first, read second* — Always use \`search_code\` before \`read_file\`. A single search returns multiple file paths with context. Don't blindly read files — search to narrow down which files matter.
+
+*Step 3: Read selectively* — Only \`read_file\` for the 2-3 most relevant results from your search. Don't read every match.
+
+*Step 4: Synthesize early* — Start forming your answer after 3-5 tool rounds. Don't exhaust all ${MAX_TOOL_ROUNDS} rounds trying to be exhaustive. A good partial answer is better than hitting the tool limit with no answer.
+
+*Step 5: For broad questions* — If the question is wide-ranging ("what's in our stack?", "how does everything connect?"), give the best answer you can with what you've found, then suggest specific follow-up questions the user can ask to dig deeper into particular areas. Don't try to read the entire codebase.
+
+*Anti-patterns to avoid:*
+- Reading files one by one without searching first
+- Reading 5+ files in a single question
+- Hitting the tool limit without producing an answer
+- Trying to give an exhaustive answer to a vague question
 
 ## Knowledge Base — IMPORTANT
 


### PR DESCRIPTION
## Summary

- Add "Search Strategy" section to system prompt with explicit tool budgeting rules
- Teaches the agent to: search first, read selectively, synthesize early, suggest follow-ups
- Bump MAX_TOOL_ROUNDS from 10 → 15 (more breathing room, but the strategy prevents waste)
- Export MAX_TOOL_ROUNDS for testability

## What this fixes

Before: broad questions like "what operating systems are in our stack?" caused the agent to read docs one by one, exhaust all 10 rounds, and return no answer.

After: the agent searches strategically, reads 2-3 key files, answers with what it found, and suggests follow-up questions for areas it didn't cover.

## Test plan

- [x] 6 new tests (20 total):
  - Search strategy section present
  - search_code-before-read_file instruction present
  - Early synthesis instruction present
  - Follow-up suggestion instruction present
  - Tool round limit mentioned in prompt
  - MAX_TOOL_ROUNDS is 15
- [x] `npm run typecheck` passes
- [x] `npm run build` passes

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)