### PR TITLE
feat: Auto-correction on 👎 — remove stale KB entries, flag docs

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -12,6 +12,8 @@ import { createIssue } from "@/lib/github";
 import { parseProposalFromMessage } from "@/tools/create-issue";
 import { storeQAContext, getQAContext, saveFeedback } from "@/lib/feedback";
 import { formatReferences } from "@/lib/references";
+import { getAllKnowledge, removeKnowledgeEntry } from "@/lib/knowledge";
+import { buildCorrectionActions } from "@/lib/auto-correct";
 
 // ── Convert GitHub-style markdown to Slack mrkdwn ────────────────────
 function toSlackMrkdwn(text: string): string {
@@ -329,12 +331,37 @@ export async function POST(request: NextRequest) {
           timestamp: new Date().toISOString().split("T")[0],
         });
 
-        // Ask the user what was wrong so they can provide a correction
         const threadTs = msg.thread_ts || messageTs;
+
+        // Auto-correction: check for stale KB entries and doc references
+        const kbEntries = await getAllKnowledge();
+        const actions = buildCorrectionActions(context.references, kbEntries);
+
+        const correctionNotes: string[] = [];
+
+        // Remove stale KB entries
+        for (const staleEntry of actions.kbEntriesToRemove) {
+          const removed = await removeKnowledgeEntry(staleEntry.entry);
+          if (removed) {
+            correctionNotes.push(`Removed stale KB entry: "${staleEntry.entry}"`);
+          }
+        }
+
+        // Propose doc fixes (inform user, don't auto-create issues)
+        if (actions.docsToProposeFix.length > 0) {
+          const docList = actions.docsToProposeFix.map((d) => `\`${d}\``).join(", ");
+          correctionNotes.push(`These docs may be outdated: ${docList} — reply *"create issue"* if you'd like me to propose a doc-fix issue`);
+        }
+
+        // Reply with corrections taken + ask for more context
+        const correctionText = correctionNotes.length > 0
+          ? `\n\n*Auto-corrections taken:*\n${correctionNotes.map((n) => `• ${n}`).join("\n")}`
+          : "";
+
         await replyInThread(
           channel,
           threadTs,
-          `:thinking_face: Thanks for the feedback. What was wrong with this answer? Reply here and I'll save the correction to my knowledge base.`,
+          `:thinking_face: Thanks for the feedback.${correctionText}\n\nWhat was wrong with this answer? Reply here and I'll save the correction to my knowledge base.`,
         );
       } catch (err) {
         console.error("Battle Mage 👎 handler error:", err instanceof Error ? err.message : err);

--- a/src/lib/auto-correct.test.ts
+++ b/src/lib/auto-correct.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import {
+  identifyStaleKBEntries,
+  identifyStaleDocReferences,
+  type CorrectionActions,
+  buildCorrectionActions,
+} from "./auto-correct";
+import type { KnowledgeEntry } from "./knowledge";
+
+describe("identifyStaleKBEntries", () => {
+  it("returns KB entries that mention referenced file paths", () => {
+    const references = ["app/Services/Auth/LoginService.php", "config/auth.php"];
+    const kbEntries: KnowledgeEntry[] = [
+      { entry: "The auth module lives in app/Services/Auth, not app/Http/Auth", timestamp: "2026-03-28" },
+      { entry: "Database migrations use timestamps not sequential IDs", timestamp: "2026-03-29" },
+    ];
+
+    const stale = identifyStaleKBEntries(references, kbEntries);
+    expect(stale).toHaveLength(1);
+    expect(stale[0].entry).toContain("auth");
+  });
+
+  it("matches KB entries by topic keywords, not just exact paths", () => {
+    const references = ["app/Http/Controllers/AuthController.php"];
+    const kbEntries: KnowledgeEntry[] = [
+      { entry: "Auth uses Laravel Sanctum, not Passport", timestamp: "2026-03-28" },
+      { entry: "Redis cache TTL is 3600 seconds", timestamp: "2026-03-29" },
+    ];
+
+    const stale = identifyStaleKBEntries(references, kbEntries);
+    expect(stale).toHaveLength(1);
+    expect(stale[0].entry).toContain("Auth");
+  });
+
+  it("returns empty array when no KB entries match", () => {
+    const references = ["app/Models/User.php"];
+    const kbEntries: KnowledgeEntry[] = [
+      { entry: "Deploy uses Docker Alpine, not Ubuntu", timestamp: "2026-03-28" },
+    ];
+
+    const stale = identifyStaleKBEntries(references, kbEntries);
+    expect(stale).toHaveLength(0);
+  });
+
+  it("returns empty array when no KB entries exist", () => {
+    const stale = identifyStaleKBEntries(["app/Models/User.php"], []);
+    expect(stale).toHaveLength(0);
+  });
+
+  it("returns empty array when no references exist", () => {
+    const kbEntries: KnowledgeEntry[] = [
+      { entry: "Some fact", timestamp: "2026-03-28" },
+    ];
+    const stale = identifyStaleKBEntries([], kbEntries);
+    expect(stale).toHaveLength(0);
+  });
+});
+
+describe("identifyStaleDocReferences", () => {
+  it("returns references that are doc/markdown files", () => {
+    const references = [
+      "app/Models/User.php",
+      "docs/deployment/gcp-cloud-run.md",
+      "README.md",
+      "config/auth.php",
+    ];
+
+    const stale = identifyStaleDocReferences(references);
+    expect(stale).toContain("docs/deployment/gcp-cloud-run.md");
+    expect(stale).toContain("README.md");
+    expect(stale).not.toContain("app/Models/User.php");
+    expect(stale).not.toContain("config/auth.php");
+  });
+
+  it("returns empty array when no doc references", () => {
+    const stale = identifyStaleDocReferences(["app/Models/User.php", "config/auth.php"]);
+    expect(stale).toHaveLength(0);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(identifyStaleDocReferences([])).toHaveLength(0);
+  });
+});
+
+describe("buildCorrectionActions", () => {
+  it("returns KB removals when stale KB entries found", () => {
+    const actions = buildCorrectionActions(
+      ["app/Services/Auth/LoginService.php"],
+      [{ entry: "Auth lives in app/Services/Auth", timestamp: "2026-03-28" }],
+    );
+    expect(actions.kbEntriesToRemove).toHaveLength(1);
+    expect(actions.kbEntriesToRemove[0].entry).toContain("Auth");
+  });
+
+  it("returns doc fix proposals when doc references found", () => {
+    const actions = buildCorrectionActions(
+      ["docs/deployment/gcp-cloud-run.md", "app/Models/User.php"],
+      [],
+    );
+    expect(actions.docsToProposeFix).toContain("docs/deployment/gcp-cloud-run.md");
+    expect(actions.docsToProposeFix).not.toContain("app/Models/User.php");
+  });
+
+  it("returns both KB removals and doc proposals when both apply", () => {
+    const actions = buildCorrectionActions(
+      ["docs/deployment/gcp-cloud-run.md", "app/Services/Auth/LoginService.php"],
+      [{ entry: "Auth uses Sanctum", timestamp: "2026-03-28" }],
+    );
+    expect(actions.kbEntriesToRemove.length).toBeGreaterThan(0);
+    expect(actions.docsToProposeFix.length).toBeGreaterThan(0);
+  });
+
+  it("returns empty actions when nothing to correct", () => {
+    const actions = buildCorrectionActions(
+      ["app/Models/User.php"],
+      [{ entry: "Redis TTL is 3600", timestamp: "2026-03-28" }],
+    );
+    expect(actions.kbEntriesToRemove).toHaveLength(0);
+    expect(actions.docsToProposeFix).toHaveLength(0);
+  });
+
+  it("hasActions is true when there are corrections", () => {
+    const actions = buildCorrectionActions(
+      ["docs/README.md"],
+      [],
+    );
+    expect(actions.hasActions).toBe(true);
+  });
+
+  it("hasActions is false when empty", () => {
+    const actions = buildCorrectionActions(
+      ["app/Models/User.php"],
+      [],
+    );
+    expect(actions.hasActions).toBe(false);
+  });
+});

--- a/src/lib/auto-correct.ts
+++ b/src/lib/auto-correct.ts
@@ -1,0 +1,86 @@
+import type { KnowledgeEntry } from "./knowledge";
+
+/**
+ * Auto-Correction Logic — Pure functions (no KV, no side effects)
+ *
+ * When a user 👎 an answer, these functions analyze the Q&A context
+ * to determine what corrective actions to take:
+ * 1. Identify stale KB entries that may have contributed to the bad answer
+ * 2. Identify doc files that may need updating
+ *
+ * The actual KV writes and Slack replies happen in route.ts.
+ */
+
+// ── Identify stale KB entries ────────────────────────────────────────
+// A KB entry is "stale" if it mentions the same files or topics as the
+// answer's references. This is a heuristic — it catches entries like
+// "Auth uses Sanctum" when the answer referenced auth files.
+
+function extractKeywords(path: string): string[] {
+  // Extract meaningful words from a file path, splitting camelCase/PascalCase
+  return path
+    .replace(/[^a-zA-Z0-9]/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2") // camelCase → camel Case
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2") // HTMLParser → HTML Parser
+    .split(/\s+/)
+    .filter((w) => w.length > 2)
+    .map((w) => w.toLowerCase());
+}
+
+export function identifyStaleKBEntries(
+  references: string[],
+  kbEntries: KnowledgeEntry[],
+): KnowledgeEntry[] {
+  if (references.length === 0 || kbEntries.length === 0) return [];
+
+  // Build a keyword set from all referenced file paths
+  const refKeywords = new Set<string>();
+  for (const ref of references) {
+    for (const keyword of extractKeywords(ref)) {
+      refKeywords.add(keyword);
+    }
+  }
+
+  // A KB entry is potentially stale if it shares keywords with the references
+  return kbEntries.filter((entry) => {
+    const entryWords = entry.entry.toLowerCase().replace(/[^a-zA-Z0-9\s]/g, "").split(/\s+/);
+    // Require at least one meaningful keyword match (skip common words)
+    const commonWords = new Set(["the", "is", "in", "not", "and", "or", "a", "an", "to", "of", "for", "it", "was", "that", "with"]);
+    return entryWords.some(
+      (word) => word.length > 2 && !commonWords.has(word) && refKeywords.has(word),
+    );
+  });
+}
+
+// ── Identify doc references that may be stale ────────────────────────
+// If the agent referenced docs/markdown files and the answer was wrong,
+// those docs might need updating.
+
+export function identifyStaleDocReferences(references: string[]): string[] {
+  return references.filter(
+    (ref) => ref.endsWith(".md") || ref.startsWith("docs/"),
+  );
+}
+
+// ── Build correction actions ─────────────────────────────────────────
+// Combines both analyses into a single action plan.
+
+export interface CorrectionActions {
+  kbEntriesToRemove: KnowledgeEntry[];
+  docsToProposeFix: string[];
+  hasActions: boolean;
+}
+
+export function buildCorrectionActions(
+  references: string[],
+  kbEntries: KnowledgeEntry[],
+): CorrectionActions {
+  const kbEntriesToRemove = identifyStaleKBEntries(references, kbEntries);
+  const docsToProposeFix = identifyStaleDocReferences(references);
+
+  return {
+    kbEntriesToRemove,
+    docsToProposeFix,
+    hasActions: kbEntriesToRemove.length > 0 || docsToProposeFix.length > 0,
+  };
+}

--- a/src/lib/knowledge.ts
+++ b/src/lib/knowledge.ts
@@ -31,6 +31,28 @@ export async function saveKnowledgeEntry(entry: string): Promise<void> {
 }
 
 /**
+ * Remove a knowledge entry by matching its entry text.
+ * Returns true if the entry was found and removed.
+ */
+export async function removeKnowledgeEntry(entryText: string): Promise<boolean> {
+  const entries = await getAllKnowledge();
+  // Find the raw JSON member that matches this entry text
+  const raw = await kv.zrange(KNOWLEDGE_KEY, 0, -1);
+  for (const member of raw as string[]) {
+    try {
+      const parsed = JSON.parse(member) as KnowledgeEntry;
+      if (parsed.entry === entryText) {
+        await kv.zrem(KNOWLEDGE_KEY, member);
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
+/**
  * Get all knowledge entries, newest first.
  */
 export async function getAllKnowledge(): Promise<KnowledgeEntry[]> {


### PR DESCRIPTION
## Summary

When a user 👎 an answer, the bot now proactively fixes the root cause instead of just recording the negative feedback:

1. **Stale KB entries removed** — identifies KB entries that share keywords with the referenced files (they likely contributed to the bad answer) and removes them from KV
2. **Stale docs flagged** — if the answer referenced markdown/doc files, flags them as potentially outdated and offers to propose a doc-fix issue

The bot replies with what it did:
```
🤔 Thanks for the feedback.

Auto-corrections taken:
• Removed stale KB entry: "Auth uses Sanctum not Passport"
• These docs may be outdated: `docs/deployment/gcp-cloud-run.md` — reply "create issue" if you'd like me to propose a doc-fix issue

What was wrong with this answer? Reply here and I'll save the correction to my knowledge base.
```

## Architecture

The auto-correction logic is pure functions in `auto-correct.ts` — no KV, no side effects, fully testable:
- `identifyStaleKBEntries(references, kbEntries)` — keyword matching between referenced file paths and KB entry text
- `identifyStaleDocReferences(references)` — filters to .md/docs/ paths
- `buildCorrectionActions(references, kbEntries)` — combines both into an action plan

The 👎 handler in route.ts executes the actions (KV deletes, Slack replies).

## Files

| File | Change |
|------|--------|
| `src/lib/auto-correct.ts` | New — pure correction logic |
| `src/lib/auto-correct.test.ts` | New — 14 tests |
| `src/lib/knowledge.ts` | `removeKnowledgeEntry()` — delete stale entries from KV |
| `src/app/api/slack/route.ts` | 👎 handler wired to auto-correction |

## Test plan

- [x] 14 new tests (60 total):
  - KB entry identification by keyword overlap with file paths
  - CamelCase path splitting (AuthController → auth, controller)
  - Doc reference filtering (.md files, docs/ prefix)
  - buildCorrectionActions combines both analyses
  - Edge cases: empty inputs, no matches, both types at once
- [x] `npm run typecheck` + `npm run build` pass

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)