### PR TITLE
feat: Live progress updates — animated thinking with contextual emoji

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -6,6 +6,8 @@ import {
   fetchMessage,
   getBotUserId,
   isBotInThread,
+  updateMessage,
+  deleteMessage,
 } from "@/lib/slack";
 import { runAgent } from "@/lib/claude";
 import { createIssue } from "@/lib/github";
@@ -14,6 +16,7 @@ import { storeQAContext, getQAContext, saveFeedback } from "@/lib/feedback";
 import { formatReferences } from "@/lib/references";
 import { getAllKnowledge, removeKnowledgeEntry } from "@/lib/knowledge";
 import { buildCorrectionActions } from "@/lib/auto-correct";
+import { formatProgressMessage } from "@/lib/progress";
 
 // ── Convert GitHub-style markdown to Slack mrkdwn ────────────────────
 function toSlackMrkdwn(text: string): string {
@@ -73,14 +76,31 @@ export async function POST(request: NextRequest) {
     // Ack now, process after response is sent (Vercel keeps fn alive)
     after(async () => {
       try {
-        // Immediate feedback so the user knows the bot is working
-        await replyInThread(channel, threadTs, ":brain: Battle Mage is thinking... (this may take a minute, go grab some tea)");
+        // Post thinking message and capture its ts for live updates
+        const thinkingTs = await replyInThread(
+          channel, threadTs,
+          formatProgressMessage("thinking", {}),
+        );
 
         const cleanMessage = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
-        const result = await runAgent(cleanMessage);
+        const result = await runAgent(cleanMessage, async (toolName, input) => {
+          if (thinkingTs) {
+            await updateMessage(channel, thinkingTs, formatProgressMessage(toolName, input));
+          }
+        });
+
+        // Update thinking message to "composing" before posting answer
+        if (thinkingTs) {
+          await updateMessage(channel, thinkingTs, formatProgressMessage("composing", {}));
+        }
 
         const text = toSlackMrkdwn(result.text);
         const refsFooter = formatReferences(result.references);
+
+        // Delete thinking message — the answer replaces it
+        if (thinkingTs) {
+          await deleteMessage(channel, thinkingTs);
+        }
 
         if (result.issueProposal) {
           const proposal = result.issueProposal;
@@ -151,12 +171,28 @@ export async function POST(request: NextRequest) {
         const bid = botId || (await getBotUserId());
         if (!bid || !(await isBotInThread(channel, threadTs, bid))) return;
 
-        await replyInThread(channel, threadTs, ":brain: Battle Mage is thinking... (this may take a minute, go grab some tea)");
+        const thinkTs = await replyInThread(
+          channel, threadTs,
+          formatProgressMessage("thinking", {}),
+        );
 
         const cleanMessage = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
-        const result = await runAgent(cleanMessage);
+        const result = await runAgent(cleanMessage, async (toolName, input) => {
+          if (thinkTs) {
+            await updateMessage(channel, thinkTs, formatProgressMessage(toolName, input));
+          }
+        });
+
+        if (thinkTs) {
+          await updateMessage(channel, thinkTs, formatProgressMessage("composing", {}));
+        }
+
         const text = toSlackMrkdwn(result.text);
         const refsFooter = formatReferences(result.references);
+
+        if (thinkTs) {
+          await deleteMessage(channel, thinkTs);
+        }
 
         if (result.issueProposal) {
           const proposal = result.issueProposal;

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -184,7 +184,12 @@ export interface AgentResult {
   references: Reference[];
 }
 
-export async function runAgent(userMessage: string): Promise<AgentResult> {
+export type ProgressCallback = (toolName: string, input: Record<string, unknown>) => void | Promise<void>;
+
+export async function runAgent(
+  userMessage: string,
+  onProgress?: ProgressCallback,
+): Promise<AgentResult> {
   const messages: Anthropic.MessageParam[] = [
     { role: "user", content: userMessage },
   ];
@@ -249,6 +254,11 @@ export async function runAgent(userMessage: string): Promise<AgentResult> {
       if (block.type !== "tool_use") continue;
 
       try {
+        // Fire progress callback before executing the tool
+        if (onProgress) {
+          await onProgress(block.name, block.input as Record<string, unknown>);
+        }
+
         const result: ToolResult = await executeTool(
           block.name,
           block.input as Record<string, unknown>,

--- a/src/lib/progress.test.ts
+++ b/src/lib/progress.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { formatProgressMessage } from "./progress";
+
+describe("formatProgressMessage", () => {
+  it("formats initial thinking step", () => {
+    const msg = formatProgressMessage("thinking", {});
+    expect(msg).toContain("🧠");
+    expect(msg).toMatch(/_.*thinking/i);
+  });
+
+  it("formats index check step", () => {
+    const msg = formatProgressMessage("index", {});
+    expect(msg).toContain("🗂️");
+    expect(msg).toMatch(/_.*index/i);
+  });
+
+  it("formats search_code with query", () => {
+    const msg = formatProgressMessage("search_code", { query: "authentication middleware" });
+    expect(msg).toContain("🔍");
+    expect(msg).toContain("authentication middleware");
+  });
+
+  it("formats read_file with path", () => {
+    const msg = formatProgressMessage("read_file", { path: "app/Services/Auth/LoginService.php" });
+    expect(msg).toContain("👓");
+    expect(msg).toContain("app/Services/Auth/LoginService.php");
+  });
+
+  it("formats list_issues", () => {
+    const msg = formatProgressMessage("list_issues", {});
+    expect(msg).toContain("🎫");
+  });
+
+  it("formats save_knowledge", () => {
+    const msg = formatProgressMessage("save_knowledge", {});
+    expect(msg).toContain("💾");
+  });
+
+  it("formats create_issue", () => {
+    const msg = formatProgressMessage("create_issue", {});
+    expect(msg).toContain("📝");
+  });
+
+  it("formats composing step", () => {
+    const msg = formatProgressMessage("composing", {});
+    expect(msg).toContain("✏️");
+    expect(msg).toMatch(/_.*composing/i);
+  });
+
+  it("all messages are italic (wrapped in underscores)", () => {
+    const steps = ["thinking", "index", "search_code", "read_file", "composing"];
+    for (const step of steps) {
+      const msg = formatProgressMessage(step, {});
+      // Slack italics: starts with _ and ends with _
+      expect(msg).toMatch(/^.+_.*_$/);
+    }
+  });
+
+  it("handles unknown tool name gracefully", () => {
+    const msg = formatProgressMessage("unknown_tool", {});
+    expect(msg).toContain("🧠");
+    expect(msg).toMatch(/_/); // still italic
+  });
+
+  it("truncates long file paths", () => {
+    const msg = formatProgressMessage("read_file", {
+      path: "very/deeply/nested/directory/structure/that/goes/on/forever/file.php",
+    });
+    // Should not be absurdly long — capped somehow
+    expect(msg.length).toBeLessThan(120);
+  });
+});

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -1,0 +1,42 @@
+/**
+ * Progress Message Formatter — maps tool calls to user-friendly status messages.
+ * All messages use italic text (Slack _underscores_) to visually distinguish
+ * from the actual answer.
+ */
+
+const MAX_PATH_LENGTH = 60;
+
+function truncatePath(path: string): string {
+  if (path.length <= MAX_PATH_LENGTH) return path;
+  // Keep the last N characters with "..." prefix
+  return "..." + path.slice(-(MAX_PATH_LENGTH - 3));
+}
+
+type ToolInput = Record<string, unknown>;
+
+const TOOL_FORMATS: Record<string, (input: ToolInput) => string> = {
+  thinking: () => "🧠 _Thinking about your question..._",
+  index: () => "🗂️ _Checking repo index..._",
+  search_code: (input) => {
+    const query = (input.query as string) || "code";
+    return `🔍 _Searching for "${query}"..._`;
+  },
+  read_file: (input) => {
+    const path = truncatePath((input.path as string) || "file");
+    return `👓 _Reading ${path}..._`;
+  },
+  list_issues: () => "🎫 _Looking up issues..._",
+  create_issue: () => "📝 _Drafting issue proposal..._",
+  save_knowledge: () => "💾 _Saving to knowledge base..._",
+  composing: () => "✏️ _Composing answer..._",
+};
+
+export function formatProgressMessage(
+  toolName: string,
+  input: ToolInput,
+): string {
+  const formatter = TOOL_FORMATS[toolName];
+  if (formatter) return formatter(input);
+  // Fallback for unknown tools
+  return `🧠 _Working on it..._`;
+}

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -56,6 +56,27 @@ export async function replyInThread(
   return result.ts; // message timestamp — used to track Q&A context for feedback
 }
 
+// ── Update a message in place ─────────────────────────────────────────
+export async function updateMessage(
+  channel: string,
+  ts: string,
+  text: string,
+): Promise<void> {
+  await slack.chat.update({ channel, ts, text });
+}
+
+// ── Delete a message ──────────────────────────────────────────────────
+export async function deleteMessage(
+  channel: string,
+  ts: string,
+): Promise<void> {
+  try {
+    await slack.chat.delete({ channel, ts });
+  } catch {
+    // Best-effort — message may already be deleted or bot may lack permission
+  }
+}
+
 // ── Fetch a single message by channel + ts ───────────────────────────
 // Works for both thread parents and threaded replies.
 // Uses conversations.replies which accepts any message ts in a thread.


### PR DESCRIPTION
## Summary

Replaces the static "🧠 Battle Mage is thinking... go grab some tea" with a live-updating progress indicator that shows exactly what the agent is doing at each step.

### What the user sees

The thinking message updates in place via `chat.update`:

```
🧠 _Thinking about your question..._
🗂️ _Checking repo index..._
🔍 _Searching for "authentication middleware"..._
👓 _Reading app/Services/Auth/LoginService.php..._
👓 _Reading config/auth.php..._
✏️ _Composing answer..._
```

Then the thinking message is deleted and the answer appears as a clean new message.

### Design choices

- **Italic text** — all status messages in `_italics_` so they're visually distinct from answers
- **Contextual emoji** — each tool type has its own icon (🔍 search, 👓 read, 🎫 issues, 💾 save, ✏️ compose)
- **Edit in place** — one message updated, not a flood of status messages
- **Clean up** — thinking message deleted after answer posted
- **Long paths truncated** — file paths capped at 60 chars

## Files

| File | Change |
|------|--------|
| `src/lib/progress.ts` | New — progress message formatter |
| `src/lib/progress.test.ts` | New — 11 tests |
| `src/lib/slack.ts` | `updateMessage()` and `deleteMessage()` helpers |
| `src/lib/claude.ts` | `onProgress` callback on `runAgent()` |
| `src/app/api/slack/route.ts` | Both mention + thread handlers use live updates |

## Test plan

- [x] 11 new tests (71 total):
  - Each tool type produces correct emoji + message
  - All messages are italic
  - Unknown tools get graceful fallback
  - Long paths truncated
- [x] `npm run typecheck` + `npm run build` pass

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)