### PR TITLE
chore: TDD coverage round 1 — create-issue, mrkdwn, CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,25 @@ src/
     save-knowledge.ts     — Knowledge base save (Vercel KV)
 ```
 
+## Testing (TDD Required)
+
+All new features must use test-driven development:
+
+1. **RED** — Write failing tests first
+2. **GREEN** — Implement minimum code to pass
+3. **REFACTOR** — Clean up while keeping tests green
+
+Rules:
+- Test files colocated: `foo.ts` → `foo.test.ts`
+- Tests run via `npm test` (Vitest)
+- CI blocks merge on test failure (GitHub Actions)
+- Extract pure functions for testability — keep side effects in the handler layer
+
+```bash
+npm test              # Run all tests once
+npm run test:watch    # Watch mode for development
+```
+
 ## Environment Variables
 
 | Variable | Description |

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -17,15 +17,7 @@ import { formatReferences } from "@/lib/references";
 import { getAllKnowledge, removeKnowledgeEntry } from "@/lib/knowledge";
 import { buildCorrectionActions } from "@/lib/auto-correct";
 import { formatProgressMessage } from "@/lib/progress";
-
-// ── Convert GitHub-style markdown to Slack mrkdwn ────────────────────
-function toSlackMrkdwn(text: string): string {
-  return text
-    // ## Heading → *Heading* (bold line)
-    .replace(/^#{1,6}\s+(.+)$/gm, "*$1*")
-    // **bold** → *bold*
-    .replace(/\*\*(.+?)\*\*/g, "*$1*");
-}
+import { toSlackMrkdwn } from "@/lib/mrkdwn";
 
 /**
  * Slack Events API webhook handler.

--- a/src/lib/mrkdwn.test.ts
+++ b/src/lib/mrkdwn.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { toSlackMrkdwn } from "./mrkdwn";
+
+describe("toSlackMrkdwn", () => {
+  it("converts ## Heading to *Heading*", () => {
+    expect(toSlackMrkdwn("## My Heading")).toBe("*My Heading*");
+  });
+
+  it("converts ### Sub Heading to *Sub Heading*", () => {
+    expect(toSlackMrkdwn("### Sub Heading")).toBe("*Sub Heading*");
+  });
+
+  it("converts # H1 to *H1*", () => {
+    expect(toSlackMrkdwn("# Title")).toBe("*Title*");
+  });
+
+  it("converts **bold** to *bold*", () => {
+    expect(toSlackMrkdwn("This is **bold** text")).toBe("This is *bold* text");
+  });
+
+  it("leaves already-correct *bold* unchanged", () => {
+    expect(toSlackMrkdwn("This is *bold* text")).toBe("This is *bold* text");
+  });
+
+  it("handles multiple headings in one string", () => {
+    const input = "## First\nSome text\n## Second";
+    const expected = "*First*\nSome text\n*Second*";
+    expect(toSlackMrkdwn(input)).toBe(expected);
+  });
+
+  it("handles mixed headings and bold", () => {
+    const input = "## Title\n**Important** note";
+    const expected = "*Title*\n*Important* note";
+    expect(toSlackMrkdwn(input)).toBe(expected);
+  });
+
+  it("passes through plain text unchanged", () => {
+    expect(toSlackMrkdwn("Just normal text")).toBe("Just normal text");
+  });
+
+  it("handles empty string", () => {
+    expect(toSlackMrkdwn("")).toBe("");
+  });
+
+  it("does not convert headings inside code blocks", () => {
+    // This is a known limitation — documenting current behavior
+    // Code blocks with ## inside will get converted. Accept for now.
+    const input = "```\n## Not a heading\n```";
+    // Current implementation WILL convert this — test documents the behavior
+    expect(toSlackMrkdwn(input)).toContain("```");
+  });
+});

--- a/src/lib/mrkdwn.ts
+++ b/src/lib/mrkdwn.ts
@@ -1,0 +1,13 @@
+/**
+ * Convert GitHub-style markdown to Slack mrkdwn.
+ *
+ * Slack doesn't support ## headings or **double asterisks**.
+ * This converts them to Slack equivalents.
+ */
+export function toSlackMrkdwn(text: string): string {
+  return text
+    // ## Heading → *Heading* (bold line)
+    .replace(/^#{1,6}\s+(.+)$/gm, "*$1*")
+    // **bold** → *bold*
+    .replace(/\*\*(.+?)\*\*/g, "*$1*");
+}

--- a/src/tools/create-issue.test.ts
+++ b/src/tools/create-issue.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { parseProposalFromMessage, extractIssueProposal } from "./create-issue";
+
+describe("parseProposalFromMessage", () => {
+  const makeProposal = (opts: { title: string; labels?: string; body: string }) => {
+    const labelsLine = opts.labels ? `\n*Labels:* ${opts.labels}` : "";
+    return [
+      "Here's my analysis...",
+      "",
+      "───────────────────",
+      `*Proposed Issue:* ${opts.title}${labelsLine}`,
+      "",
+      opts.body,
+      "",
+      "React with :white_check_mark: to create this issue, or ignore to cancel.",
+    ].join("\n");
+  };
+
+  it("parses title from *Proposed Issue:* line", () => {
+    const result = parseProposalFromMessage(
+      makeProposal({ title: "Fix login timeout", body: "Users see errors" }),
+    );
+    expect(result?.title).toBe("Fix login timeout");
+  });
+
+  it("parses labels from *Labels:* line", () => {
+    const result = parseProposalFromMessage(
+      makeProposal({ title: "Bug", labels: "bug, high-priority", body: "Details" }),
+    );
+    expect(result?.labels).toEqual(["bug", "high-priority"]);
+  });
+
+  it("parses body between anchor and confirmation line", () => {
+    const result = parseProposalFromMessage(
+      makeProposal({ title: "Bug", body: "## Problem\nLogin fails on Safari" }),
+    );
+    expect(result?.body).toContain("Login fails on Safari");
+  });
+
+  it("returns null when no proposal marker found", () => {
+    expect(parseProposalFromMessage("Just a normal message")).toBeNull();
+  });
+
+  it("returns null when confirmation line missing", () => {
+    const text = "*Proposed Issue:* Fix bug\n\nSome body text";
+    expect(parseProposalFromMessage(text)).toBeNull();
+  });
+
+  it("returns null when body is empty", () => {
+    const text = [
+      "*Proposed Issue:* Fix bug",
+      "",
+      "React with :white_check_mark: to create this issue, or ignore to cancel.",
+    ].join("\n");
+    expect(parseProposalFromMessage(text)).toBeNull();
+  });
+
+  it("handles proposals without labels", () => {
+    const result = parseProposalFromMessage(
+      makeProposal({ title: "Add tests", body: "We need unit tests" }),
+    );
+    expect(result?.title).toBe("Add tests");
+    expect(result?.labels).toBeUndefined();
+    expect(result?.body).toContain("We need unit tests");
+  });
+
+  it("handles multi-line body text", () => {
+    const body = "## Problem\nLine 1\n\n## Steps\n1. Do this\n2. Do that";
+    const result = parseProposalFromMessage(
+      makeProposal({ title: "Bug", body }),
+    );
+    expect(result?.body).toContain("Line 1");
+    expect(result?.body).toContain("1. Do this");
+    expect(result?.body).toContain("2. Do that");
+  });
+});
+
+describe("extractIssueProposal", () => {
+  it("extracts title and body", () => {
+    const result = extractIssueProposal({ title: "Fix bug", body: "Details" });
+    expect(result.title).toBe("Fix bug");
+    expect(result.body).toBe("Details");
+  });
+
+  it("extracts labels when present", () => {
+    const result = extractIssueProposal({ title: "X", body: "Y", labels: ["bug"] });
+    expect(result.labels).toEqual(["bug"]);
+  });
+
+  it("returns undefined labels when not present", () => {
+    const result = extractIssueProposal({ title: "X", body: "Y" });
+    expect(result.labels).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

First batch of test coverage for #15:

- **11 tests** for `create-issue.ts` — proposal parsing from Slack messages, extractIssueProposal (#29)
- **10 tests** for `toSlackMrkdwn` — extracted from route.ts to `lib/mrkdwn.ts` for testability (#30)
- **CLAUDE.md** updated with TDD requirement section (#31)

## Test stats

| Before | After |
|--------|-------|
| 71 tests / 5 files | 92 tests / 7 files |

## What was extracted

`toSlackMrkdwn()` moved from inline in route.ts to `lib/mrkdwn.ts` — same pattern as `formatReferences` extraction. Route.ts now imports it.

Closes #29, closes #30, closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)