### PR TITLE
fix: Recency bias, brevity rules, and date-aware issue sorting

### DIFF
--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -165,6 +165,34 @@ describe("assembleSystemPrompt", () => {
     });
   });
 
+  describe("recency and brevity", () => {
+    it("includes today's date in the prompt", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      // Must contain a date in YYYY-MM-DD format
+      expect(prompt).toMatch(/\d{4}-\d{2}-\d{2}/);
+    });
+
+    it("instructs to prefer recent activity over historical", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      expect(prompt).toMatch(/recent.*first|most recent|last 30 days|newest first/i);
+    });
+
+    it("instructs to avoid archived/historical docs unless asked", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      expect(prompt).toMatch(/archive.*avoid|archive.*skip|archive.*only.*if.*asked|archive.*historical/i);
+    });
+
+    it("instructs to be concise and direct", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      expect(prompt).toMatch(/concise|brief|direct|short|15 lines|don.t editorialize/i);
+    });
+
+    it("instructs not to write marketing copy or brochure-style", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      expect(prompt).toMatch(/no.*brochure|no.*marketing|no.*editorial|skip.*what makes.*special/i);
+    });
+  });
+
   describe("hierarchy labels match context sections", () => {
     it("knowledge section warns it can become stale", () => {
       const prompt = assembleSystemPrompt({

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -66,7 +66,27 @@ export function assembleSystemPrompt(inputs: PromptInputs): string {
     ? `\n## Repository Map (auto-generated index)\n\nThis map shows the key areas of the repo. Use it to jump directly to relevant files with \`read_file\` instead of searching blind. The map is rebuilt automatically when the repo changes.\n\n${repoIndex}\n`
     : "";
 
+  const today = new Date().toISOString().split("T")[0];
+
   return `You are Battle Mage (@bm), an AI assistant embedded in Slack with read access to the ${owner}/${repo} GitHub repository.
+
+Today's date: ${today}
+
+## Recency and Brevity — CRITICAL
+
+*Recency:*
+- Always prefer the most recent activity first. When asked about "recent developments", "status", or "what's new", focus on the last 30 days from today (${today}).
+- Use \`list_issues\` sorted by recently updated — newest first. Do NOT treat high issue numbers as "recent" — check the dates.
+- Files under \`docs/archive/\` or similar archive paths are historical records. Skip them unless the user explicitly asks about history or past decisions.
+- If all the information you found is older than 30 days, say so — don't present stale data as current.
+
+*Brevity:*
+- Lead with the direct answer in 2-3 sentences.
+- Use bullet points for supporting details, not prose paragraphs.
+- Target ~15 lines or fewer for a typical answer. Only go longer if the question genuinely requires depth.
+- Do NOT editorialize. No brochure-style copy ("What Makes This Special"), no marketing language, no "comprehensive overview" essays. Just answer the question.
+- Skip sections like "Development Maturity Indicators" or "Why This Is Impressive" — the user didn't ask for a pitch.
+- If the user wants more detail, they'll ask a follow-up.
 
 ## Source-of-Truth Hierarchy
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -53,12 +53,16 @@ export async function listIssues(
     owner: string;
     repo: string;
     state: "open" | "closed" | "all";
+    sort: "updated";
+    direction: "desc";
     per_page: number;
     labels?: string;
   } = {
     owner: owner(),
     repo: repo(),
     state,
+    sort: "updated",
+    direction: "desc",
     per_page: 20,
   };
   if (labels) params.labels = labels;
@@ -71,6 +75,7 @@ export async function listIssues(
     labels: issue.labels.map((l) => (typeof l === "string" ? l : l.name)),
     url: issue.html_url,
     created_at: issue.created_at,
+    updated_at: issue.updated_at,
   }));
 }
 

--- a/src/tools/list-issues.ts
+++ b/src/tools/list-issues.ts
@@ -4,7 +4,7 @@ import { listIssues, getIssue } from "@/lib/github";
 export const listIssuesTool: Tool = {
   name: "list_issues",
   description:
-    "List GitHub issues for the repository. Can filter by state and labels. Use this to understand current bugs, feature requests, and project status.",
+    "List GitHub issues sorted by most recently updated. Can filter by state and labels. Results include dates so you can assess recency.",
   input_schema: {
     type: "object" as const,
     properties: {
@@ -52,9 +52,10 @@ export async function executeListIssues(
   }
 
   return issues
-    .map(
-      (i) =>
-        `- **#${i.number}**: ${i.title} (${i.state}) ${i.labels.length ? `[${i.labels.join(", ")}]` : ""}`,
-    )
+    .map((i) => {
+      const updated = i.updated_at ? ` (updated: ${i.updated_at.split("T")[0]})` : "";
+      const labels = i.labels.length ? ` [${i.labels.join(", ")}]` : "";
+      return `- **#${i.number}**: ${i.title} (${i.state})${updated}${labels}`;
+    })
     .join("\n");
 }


### PR DESCRIPTION
## Problem

The agent was giving long-winded brochure-style answers citing year-old issues and archived docs. When asked "what are recent developments?", it returned content from June 2025.

## Root causes

1. **No date awareness** — the agent didn't know today's date, so it couldn't tell "June 2025" is old
2. **Issues sorted by creation, not activity** — `listIssues` used default GitHub sort (created desc), not recently updated
3. **No brevity constraints** — the prompt had no rules about answer length or editorial style
4. **No archive avoidance** — `docs/archive/` treated the same as current docs

## Fixes

| Change | File |
|--------|------|
| Today's date injected into prompt | `claude.ts` |
| Recency rules: prefer last 30 days, skip archives | `claude.ts` |
| Brevity rules: ~15 lines max, no brochure copy, no editorializing | `claude.ts` |
| `listIssues` sorts by `updated` desc, returns `updated_at` | `github.ts` |
| Issue list output includes update dates | `list-issues.ts` |

## Test plan

- [x] 5 new tests (97 total):
  - Prompt includes YYYY-MM-DD date
  - Prompt instructs recent-first
  - Prompt instructs archive avoidance
  - Prompt instructs conciseness
  - Prompt forbids brochure-style copy
- [x] `npm run typecheck` + `npm run build` pass

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)