### PR TITLE
docs: Comprehensive documentation rewrite + proprietary cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,11 +5,14 @@ A Slack agent with Claude AI intelligence and GitHub repo access. Invoke via `@b
 ## Architecture
 
 - **Runtime**: Vercel (Next.js serverless functions)
-- **Slack**: Webhook mode via Next.js API route (`/api/slack`)
-- **AI**: Anthropic Claude API with tool use
-- **GitHub**: Octokit REST API (fine-grained PAT, read-only)
-- **Knowledge**: Vercel KV (corrections persist without GitHub write access)
-- **Context**: Project CLAUDE.md + wizard reasoning framework
+- **Slack**: Webhook mode via Next.js API route (`/api/slack`), ack-then-process via `after()`
+- **AI**: Anthropic Claude API with tool use (7 tools, 15-round budget)
+- **GitHub**: Octokit REST API (fine-grained PAT, read-only for code/PRs, read-write for issues)
+- **Knowledge**: Vercel KV (corrections, feedback, repo index cache)
+- **Context**: CLAUDE.md + KB + feedback + repo index + source hierarchy + search strategy + recency/brevity rules
+- **Progress**: Live thinking messages with contextual emoji, deleted on answer
+- **Formatting**: Markdown-to-Slack mrkdwn conversion, deduplicated references (capped at 5)
+- **Auto-correct**: Thumbs-down removes stale KB entries, flags outdated docs
 
 ## Development
 
@@ -42,15 +45,36 @@ src/
     page.tsx              — Landing page
   lib/
     slack.ts              — Slack client, signature verification, message helpers
-    claude.ts             — Anthropic client, system prompt, agent loop
-    github.ts             — Octokit client (search, read, issues, PRs — read-only)
-    knowledge.ts          — Knowledge base (Vercel KV — no GitHub write access)
+    claude.ts             — Anthropic client, system prompt assembly, agent loop
+    github.ts             — Octokit client (search, read, issues, PRs, commits, tree)
+    knowledge.ts          — Knowledge base (Vercel KV sorted set)
+    feedback.ts           — Feedback storage (Vercel KV) and Q&A context
+    repo-index.ts         — Repository topic index (lazy rebuild on SHA change)
+    auto-correct.ts       — Stale KB entry detection and doc reference flagging
+    progress.ts           — Progress message formatter (tool → emoji + status)
+    mrkdwn.ts             — Markdown → Slack mrkdwn converter
+    references.ts         — Reference deduplication, capping, and formatting
   tools/
+    index.ts              — Tool registry and executor
     search-code.ts        — GitHub code search tool
-    read-file.ts          — GitHub file read tool
+    read-file.ts          — GitHub file/directory read tool
     list-issues.ts        — GitHub issue list/lookup tool
+    list-commits.ts       — Recent commits on main (with dates)
+    list-prs.ts           — Recent pull requests (open/merged/closed)
     create-issue.ts       — GitHub issue proposal + parser
     save-knowledge.ts     — Knowledge base save (Vercel KV)
+docs/
+  setup.md                — Complete setup guide (Slack, GitHub, Vercel, KV)
+  usage.md                — How to use the bot day-to-day
+  architecture.md         — How the internals work (agent loop, prompt, tools)
+  contributing.md         — Contributing guide (TDD, CI, fork workflow)
+  troubleshooting.md      — Common issues and fixes
+  features/
+    repo-index.md         — Lazy-rebuilt topic map (KV-cached)
+    knowledge-base.md     — Vercel KV knowledge base
+    source-hierarchy.md   — Source-of-truth hierarchy (5 levels)
+    auto-correction.md    — Auto-correction on 👎 reactions
+    progress-ux.md        — Live progress updates (emoji + status)
 ```
 
 ## Testing (TDD Required)

--- a/README.md
+++ b/README.md
@@ -1,326 +1,86 @@
 # Battle Mage (@bm)
 
-A Slack agent powered by Claude AI that answers questions about your GitHub codebase. Mention `@bm` in any channel and ask about code, architecture, GitHub issues, or pull requests — the agent reads your repo in real time to give grounded answers.
+A Slack agent powered by Claude AI that answers questions about your GitHub codebase. Mention `@bm` in any channel and ask about code, architecture, issues, or pull requests.
 
 <img src="icon.png" alt="Battle Mage icon" width="128">
 
-## What It Does
+## Features
 
-- **Answers code questions** — "Where is authentication handled?" "What does the OrderService do?" The agent searches your repo, reads the actual files, and responds with specific file paths and line numbers.
-- **Reads GitHub issues and PRs** — "What are the open bugs?" "Summarize PR #42." It pulls live data from GitHub, not cached summaries.
-- **Creates GitHub issues** — Ask it to file a bug or feature request. It drafts the issue and shows you a preview. Nothing gets created until you react with ✅ — there are no surprises.
-- **Remembers corrections** — If the agent gets something wrong and you correct it, it saves that fact to a knowledge base file in your repo (`.battle-mage/knowledge.md`). Next time anyone asks, it knows the right answer. The knowledge base is just a markdown file — your team can read, edit, or delete entries at any time.
-- **Follows threads** — After the first `@bm` mention, you can keep chatting in the same thread without mentioning it again. It knows it's part of the conversation.
-- **Loads your project context** — If your repo has a `CLAUDE.md` file (common in projects using Claude), the agent reads it on startup and uses it to understand your project's conventions, architecture, and terminology.
+- **Code intelligence** — searches and reads your repo to answer with specific file paths and line numbers
+- **Issue and PR awareness** — lists recent issues, PRs, and commits sorted by date
+- **Issue creation** — drafts issues with a preview; creates only after ✅ reaction
+- **Thread conversations** — follow up without re-mentioning the bot
+- **Persistent knowledge base** — remembers corrections across conversations (Vercel KV)
+- **Repo index** — auto-built topic map for fast navigation, rebuilt lazily on push
+- **Source-of-truth hierarchy** — weights code over docs over KB when sources conflict
+- **Auto-correction** — removes stale knowledge entries when answers get 👎
+- **Live progress** — shows what the agent is doing step by step with contextual emoji
+- **Recency-first** — prefers recent commits, PRs, and issues over historical data
 
-## Getting Started
-
-### 1. Clone and install
+## Quick Start
 
 ```bash
 git clone <your-fork-url>
 cd battle-mage
 npm install
+cp .env.example .env.local  # Fill in credentials
+npm run dev
 ```
 
-### 2. Create a Slack app
+See the [full setup guide](docs/setup.md) for Slack app creation, GitHub PAT, Vercel deployment, and first-run testing.
 
-This is the part that trips people up the most, so here's the play-by-play:
+## Documentation
 
-1. Go to [api.slack.com/apps?new_app=1](https://api.slack.com/apps?new_app=1)
-2. Choose **"From a manifest"** — this is the fastest path
-3. Select your workspace
-4. Switch to the **YAML** tab and paste the contents of `slack-app-manifest.yaml` from this repo
-5. Review and click **Create**
+| Guide | What it covers |
+|-------|---------------|
+| [Setup](docs/setup.md) | Slack app, GitHub PAT, Vercel deploy, env vars |
+| [Usage](docs/usage.md) | Asking questions, threads, issues, corrections, feedback |
+| [Architecture](docs/architecture.md) | Agent loop, tools, system prompt, design decisions |
+| [Contributing](docs/contributing.md) | Fork workflow, TDD, CI, branch protection |
+| [Troubleshooting](docs/troubleshooting.md) | Common issues and fixes |
 
-> **Important:** The manifest includes a placeholder `request_url`. You'll update this to your real Vercel URL after deploying (step 5). Don't worry about the "URL not verified" warning for now — it's expected.
+### Feature Deep-Dives
 
-After creating the app:
+| Feature | Doc |
+|---------|-----|
+| Repo Index | [docs/features/repo-index.md](docs/features/repo-index.md) |
+| Knowledge Base | [docs/features/knowledge-base.md](docs/features/knowledge-base.md) |
+| Source-of-Truth Hierarchy | [docs/features/source-hierarchy.md](docs/features/source-hierarchy.md) |
+| Auto-Correction on 👎 | [docs/features/auto-correction.md](docs/features/auto-correction.md) |
+| Live Progress Updates | [docs/features/progress-ux.md](docs/features/progress-ux.md) |
 
-6. Go to **Install App** in the left sidebar and click **Install to Workspace**. Authorize it.
-7. You now have two values you'll need:
-   - **Bot User OAuth Token** (`xoxb-...`) — find it on the **OAuth & Permissions** page, at the top under "OAuth Tokens for Your Workspace"
-   - **Signing Secret** — find it on **Basic Information** page under "App Credentials". Click "Show" to reveal it.
+## Environment Variables
 
-> **Customizing the bot handle:** The manifest sets the display name to `bm`, so users will type `@bm`. If you want a different handle, change `display_name` in the manifest before creating the app, or edit it later under **App Home** in the Slack dashboard. Keep in mind that the handle is what people type every day, so shorter is better.
+| Variable | Description |
+|----------|-------------|
+| `SLACK_BOT_TOKEN` | Bot User OAuth Token (`xoxb-...`) |
+| `SLACK_SIGNING_SECRET` | Slack app signing secret |
+| `ANTHROPIC_API_KEY` | Claude API key |
+| `GITHUB_PAT_BM` | Fine-grained PAT scoped to your target repo |
+| `GITHUB_OWNER` | GitHub org or username |
+| `GITHUB_REPO` | Repository name |
 
-### 3. Create a GitHub PAT
+## How It Works
 
-The agent needs read access to your target repo (and write access to GitHub Issues, if you want issue creation).
+```
+User @mentions @bm in Slack
+  → Webhook received, ack'd within 3 seconds
+  → Live progress: 🧠 → 🔍 → 👓 → ✏️
+  → Claude reads code, issues, PRs via GitHub API
+  → Answer posted in thread, progress message deleted
+```
 
-1. Go to [github.com/settings/tokens?type=beta](https://github.com/settings/tokens?type=beta) (fine-grained PATs)
-2. Click **Generate new token**
-3. Under **Repository access**, select **"Only select repositories"** and pick your target repo
-4. Set these permissions:
+For the full architecture walkthrough, see [docs/architecture.md](docs/architecture.md).
 
-| Permission | Level | Why |
-|-----------|-------|-----|
-| Contents | Read | Search code, read files |
-| Issues | Read & Write | List GitHub issues, create new ones |
-| Pull requests | Read | Read PR details |
-| Metadata | Read | Required baseline (auto-selected) |
-
-5. Set an expiration (90 days is reasonable) and **set a calendar reminder to rotate it** — expired PATs fail silently and the bot just stops being able to read your repo.
-
-> **Why fine-grained?** Classic PATs grant access to ALL your repos. Fine-grained PATs are scoped to specific repositories, which is much safer. If the token leaks, the blast radius is one repo, not your entire GitHub account.
-
-### 4. Set environment variables
-
-You'll need an [Anthropic API key](https://console.anthropic.com) if you don't have one already.
-
-Copy the example file and fill in the values:
+## Testing
 
 ```bash
-cp .env.example .env.local
+npm test              # 100 tests across 7 files
+npm run test:watch    # Watch mode
+npm run typecheck     # TypeScript strict
 ```
 
-| Variable | Where to get it |
-|----------|----------------|
-| `SLACK_BOT_TOKEN` | Slack app > OAuth & Permissions > Bot User OAuth Token |
-| `SLACK_SIGNING_SECRET` | Slack app > Basic Information > App Credentials > Signing Secret |
-| `ANTHROPIC_API_KEY` | [console.anthropic.com](https://console.anthropic.com) > API Keys |
-| `GITHUB_PAT_BM` | The fine-grained PAT you just created |
-| `GITHUB_OWNER` | The GitHub org or username that owns the target repo (e.g., `acme-corp`) |
-| `GITHUB_REPO` | The repo name (e.g., `backend`) |
-
-### 5. Deploy to Vercel
-
-The simplest path:
-
-```bash
-npm install -g vercel   # if you don't have it
-vercel login            # authenticate (opens browser)
-vercel link             # connect this directory to a Vercel project
-vercel env add SLACK_BOT_TOKEN production
-vercel env add SLACK_SIGNING_SECRET production
-vercel env add ANTHROPIC_API_KEY production
-vercel env add GITHUB_PAT_BM production
-vercel env add GITHUB_OWNER production
-vercel env add GITHUB_REPO production
-vercel --prod           # deploy
-```
-
-Each `vercel env add` command will prompt you to paste the value. They're stored encrypted in Vercel's dashboard.
-
-After the deploy succeeds, note your production URL (e.g., `https://your-project.vercel.app`).
-
-### 6. Connect Slack to your deploy
-
-Now go back to your Slack app settings:
-
-1. Go to **Event Subscriptions** in the left sidebar
-2. Set the **Request URL** to: `https://your-project.vercel.app/api/slack`
-3. Slack will send a verification challenge. If everything is wired up correctly, you'll see a green **"Verified"** checkmark within a few seconds.
-
-> **If verification fails:** Check that your env vars are set correctly in Vercel (especially `SLACK_SIGNING_SECRET`), and that the deploy completed successfully. You can check Vercel's function logs for errors.
-
-### 7. Invite and test
-
-In any Slack channel:
-
-```
-/invite @bm
-@bm what does this repo do?
-```
-
-You should see:
-1. A "🧠 Battle Mage is thinking..." message appear immediately
-2. A detailed response in the thread a few seconds later
-
-If nothing happens, check the Vercel function logs (`vercel logs --prod`) for errors.
-
-## Using Battle Mage
-
-### Asking questions
-
-Just `@bm` followed by your question in any channel the bot has been invited to:
-
-```
-@bm where is the payment processing logic?
-@bm what are the open GitHub issues labeled "bug"?
-@bm show me the contents of src/config/database.ts
-@bm summarize PR #87
-```
-
-The agent has access to these GitHub tools and will use them automatically:
-- **Code search** — finds files matching your query across the repo
-- **File read** — reads the actual content of specific files
-- **GitHub issue/PR lookup** — lists and reads GitHub issues and pull requests
-
-### Follow-up questions
-
-After the first `@bm` mention in a thread, you can reply normally without mentioning the bot again. It detects that it's already participating in the thread and responds to follow-ups automatically.
-
-```
-You:  @bm how does the auth middleware work?
-Bot:  [explains auth middleware]
-You:  what about the refresh token logic?        ← no @bm needed
-Bot:  [explains refresh tokens]
-```
-
-> **Heads up:** The bot does NOT have conversation memory across threads. Each thread is an independent conversation. If you start a new thread, you're starting fresh.
-
-### Creating GitHub issues
-
-Ask the bot to create an issue and it will draft one for you:
-
-```
-@bm create an issue: the login page crashes on Safari when cookies are disabled
-```
-
-The bot will show you a preview with a title, body, and suggested labels. **Nothing is created yet.** React with ✅ on the bot's message to confirm and actually create the issue on GitHub. If you ignore it or don't react, nothing happens.
-
-> **Why the confirmation step?** Because creating GitHub issues is a write operation that's visible to your whole team. The bot should never surprise anyone with unexpected issues appearing in the backlog.
-
-### Correcting the bot
-
-If the bot gives you wrong information, just tell it:
-
-```
-Bot:  The auth module is in app/Http/Auth...
-You:  That's wrong — auth lives in app/Services/Auth since the v3 refactor
-Bot:  Got it, I'll save that to the knowledge base.
-```
-
-The bot saves the correction to Vercel KV (a serverless key-value store that comes with your Vercel deployment). The knowledge is loaded into every future conversation, so the bot won't make the same mistake again.
-
-You can view entries in the Vercel dashboard under Storage > KV. Each entry is timestamped so you can see when it was learned.
-
-> **Why not save to the repo?** Saving corrections as file commits would require the GitHub PAT to have Contents: Write permission — which means the bot could modify *any* file in your repo, not just the knowledge base. GitHub fine-grained PATs can't scope write access to a specific path. By using Vercel KV, the bot's GitHub access stays strictly read-only, and your repo is safe from accidental writes.
-
-## Architecture
-
-### Why these choices?
-
-| Decision | Why |
-|----------|-----|
-| **Vercel + Next.js** | Serverless means no servers to maintain, scales to zero when idle, and deploys on every push to main. |
-| **Webhook mode** (not Socket mode) | Vercel serverless functions can't maintain persistent WebSocket connections. Webhook mode works naturally with request/response. |
-| **Ack-then-process** | Slack requires a 200 OK within 3 seconds or it retries (and shows errors). The API route acks immediately, then uses Next.js `after()` to process the AI call asynchronously while Vercel keeps the function alive. |
-| **Thread-only replies** | Posting at channel root would be noisy and disruptive. Thread replies keep conversations contained. |
-| **Reaction-based confirmation** | Simpler than interactive buttons (no interactivity endpoint needed), and it's a natural Slack gesture. ✅ to confirm, ignore to cancel. |
-| **Knowledge in Vercel KV** (not repo) | Keeps the GitHub PAT read-only. Fine-grained PATs can't scope write access to one file — Contents: Write means the bot could edit any file in your repo. KV avoids this entirely. Entries visible in the Vercel dashboard. |
-
-### How the agent loop works
-
-When the bot receives a message, it enters a tool-use loop with Claude:
-
-1. Send the user's message to Claude along with the system prompt (which includes CLAUDE.md and the knowledge base)
-2. Claude decides whether to use a tool (search code, read a file, etc.) or respond directly
-3. If Claude uses a tool, execute it and feed the result back to Claude
-4. Repeat until Claude gives a final text response (max 10 rounds)
-5. Post the response to the Slack thread
-
-This means the bot can chain multiple tools together. For example, it might search for a function name, read the file it's in, then read a related test file, before synthesizing an answer.
-
-### Project structure
-
-```
-src/
-  app/
-    api/slack/route.ts    — Webhook handler: mentions, reactions, thread follow-ups
-    page.tsx              — Landing page (just a status page)
-  lib/
-    slack.ts              — Slack client, signature verification, message helpers
-    claude.ts             — Claude client, system prompt builder, agent loop
-    github.ts             — GitHub client: code search, file read, issues, PRs (read-only)
-    knowledge.ts          — Knowledge base storage (Vercel KV)
-  tools/
-    search-code.ts        — Code search tool definition + executor
-    read-file.ts          — File read tool definition + executor
-    list-issues.ts        — Issue list/lookup tool definition + executor
-    create-issue.ts       — Issue proposal tool + message parser
-    save-knowledge.ts     — Knowledge base save tool + executor
-slack-app-manifest.yaml   — Slack app manifest for one-step app creation
-```
-
-## Troubleshooting
-
-### Bot doesn't respond at all
-- Is the bot invited to the channel? (`/invite @bm`)
-- Is the Event Subscription URL verified in the Slack dashboard?
-- Check Vercel function logs: `vercel logs --prod`
-- Are all 6 env vars set? `vercel env ls`
-
-### Bot responds but can't read the repo
-- Is `GITHUB_PAT_BM` set and not expired?
-- Is the PAT scoped to the correct repo (`GITHUB_OWNER`/`GITHUB_REPO`)?
-- Does the PAT have "Contents: Read" permission?
-
-### Formatting looks wrong (raw `##` or `**` in messages)
-- This was a known issue — the bot's output is now post-processed to convert markdown to Slack mrkdwn. If you still see artifacts, check that you're running the latest deploy.
-
-### "Thinking..." message appears but no follow-up
-- The Claude API call is probably timing out. Vercel's Hobby plan has a 10-second function timeout. Upgrade to Pro for 60-second timeouts, which is usually enough.
-- Check Vercel function logs for timeout errors.
-
-### Thread follow-ups don't work
-- Make sure your Slack app is subscribed to `message.channels` and `message.groups` events (check **Event Subscriptions** > **Subscribe to bot events** in the Slack dashboard)
-- The bot only responds in threads where it has already replied. It won't respond to random thread messages in channels it's in.
-
-## Local Development
-
-```bash
-npm run dev     # Start Next.js dev server on port 3000
-npm run build   # Production build
-npm run lint    # ESLint
-npm run typecheck  # TypeScript strict mode check
-```
-
-For local testing with Slack, you'll need a tunnel (like [ngrok](https://ngrok.com)) to expose your local server:
-
-```bash
-ngrok http 3000
-# Copy the https URL and set it as your Slack Event Subscription URL
-# Remember to change it back to your Vercel URL when you're done
-```
-
-## Contributing
-
-Contributions are welcome! Here's how the process works:
-
-1. **Fork the repo** — don't clone it directly. Direct pushes to `main` are blocked for everyone, including maintainers. All changes go through pull requests.
-
-2. **Create a feature branch** on your fork:
-   ```bash
-   git checkout -b feat/my-change
-   ```
-
-3. **Make your changes.** Before pushing, make sure everything passes:
-   ```bash
-   npm run typecheck   # TypeScript strict mode — no errors allowed
-   npm run build       # Full production build must succeed
-   ```
-
-4. **Open a pull request** against `main`. Include:
-   - A clear description of what you changed and why
-   - Steps to test it, if applicable
-   - Screenshots for UI changes
-
-5. **Wait for review.** PRs require at least one approving review before they can be merged. Stale approvals are dismissed automatically when new commits are pushed, so reviewers always see the latest code.
-
-### Branch protection
-
-The `main` branch has these protections enabled:
-
-- **No direct pushes** — everything goes through a PR
-- **1 approving review required** — for outside contributors
-- **Stale review dismissal** — pushing new commits resets previous approvals
-- **Linear history** — merge commits are not allowed; use rebase or squash
-- **No force pushes or branch deletion**
-
-### What makes a good contribution?
-
-- **Bug fixes** — especially around Slack formatting edge cases or error handling
-- **New tools** — adding new GitHub capabilities (e.g., reading commit history, browsing branches)
-- **Documentation** — if you hit a setup snag that isn't covered, add it to the troubleshooting section
-- **Tests** — the project currently has no test suite, so this is a great area to contribute
-
-### What to avoid
-
-- Don't add external dependencies without discussing it in an issue first
-- Don't change the core agent loop without a clear rationale
-- Don't add features that require new infrastructure (databases, queues, etc.) — the project is intentionally serverless and stateless
+TDD is mandatory for all new features. See [docs/contributing.md](docs/contributing.md).
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,248 @@
+# Architecture
+
+Battle Mage is a Slack bot that runs as a Next.js serverless function on Vercel. It receives webhook events from Slack, processes them with Claude AI and GitHub tools, and replies in-thread.
+
+## High-Level Flow
+
+```
+Slack Event (webhook)
+  |
+  v
+POST /api/slack (Next.js API route)
+  |
+  ├── Verify Slack signature (HMAC-SHA256)
+  ├── Return 200 OK immediately (ack within 3 seconds)
+  |
+  └── after() — async processing continues after response
+        |
+        ├── Post thinking message ("Battle Mage is working...")
+        ├── Run agent loop (Claude + tools)
+        │     ├── Tool round 1: search_code("auth middleware")
+        │     │   └── Update thinking message: "Searching for auth middleware..."
+        │     ├── Tool round 2: read_file("src/middleware/auth.ts")
+        │     │   └── Update thinking message: "Reading src/middleware/auth.ts..."
+        │     └── ... up to 15 rounds
+        ├── Delete thinking message
+        ├── Convert markdown to Slack mrkdwn
+        ├── Format reference links
+        └── Post final answer in thread
+```
+
+## The Ack-Then-Process Pattern
+
+Slack requires a `200 OK` response within 3 seconds. If the webhook handler takes longer, Slack retries the event (and eventually marks the app as unhealthy).
+
+Battle Mage uses Next.js `after()` to ack the HTTP request immediately, then continue processing asynchronously. Vercel keeps the serverless function alive until the `after()` callback completes.
+
+```typescript
+export async function POST(request: NextRequest) {
+  // ... verify signature, parse event ...
+
+  // Return 200 immediately
+  after(async () => {
+    // This runs AFTER the response is sent
+    // Claude + GitHub calls happen here
+  });
+
+  return NextResponse.json({ ok: true });
+}
+```
+
+The route also rejects Slack retries by checking the `x-slack-retry-num` header. Since we already acked the first delivery, retries are duplicates.
+
+## Webhook Event Handling
+
+The `/api/slack` route handles four event types:
+
+### `app_mention` -- Direct @mention
+
+When a user types `@bm <question>`, Slack sends an `app_mention` event. The handler:
+
+1. Strips the `<@BOT_ID>` mention from the message text
+2. Posts a thinking message in the thread
+3. Runs the agent loop with live progress updates
+4. Deletes the thinking message
+5. Posts the final answer with references
+
+### `message` (thread reply) -- Follow-up without re-mention
+
+When a user posts in a thread where the bot has already replied, Slack sends a `message` event. The handler:
+
+1. Checks this is a thread reply (not a top-level message)
+2. Skips messages that @mention the bot (those are handled by `app_mention`)
+3. Checks if the bot has previously replied in this thread (via `conversations.replies`)
+4. If yes, processes the message the same way as an `app_mention`
+
+### `reaction_added` with `white_check_mark` -- Issue creation confirmation
+
+When a user reacts with :white_check_mark: to a bot message containing an issue proposal:
+
+1. Fetches the message text
+2. Verifies it was posted by the bot (not by someone else)
+3. Parses the proposal title, body, and labels from the message format
+4. Creates the issue on GitHub via `octokit.rest.issues.create`
+5. Replies with a link to the new issue
+
+### `reaction_added` with `+1` or `-1` -- Feedback
+
+**Thumbs up (+1)**:
+1. Fetches the Q&A context stored in KV (question, answer summary, references)
+2. Saves a positive feedback entry
+3. Adds a :brain: reaction to acknowledge
+
+**Thumbs down (-1)**:
+1. Fetches the Q&A context
+2. Saves a negative feedback entry
+3. Runs auto-correction: identifies stale KB entries (keyword matching) and doc references
+4. Removes stale KB entries from Vercel KV
+5. Replies asking the user what was wrong
+
+## System Prompt Assembly
+
+The system prompt is assembled from multiple sources every time the agent runs. The function `assembleSystemPrompt()` takes these inputs:
+
+| Input | Source | Description |
+|-------|--------|-------------|
+| `owner` / `repo` | Environment variables | Target GitHub repository |
+| `claudeMd` | `CLAUDE.md` in the target repo | Project-specific context (cached per cold start) |
+| `knowledge` | Vercel KV | Knowledge base entries (corrections from users) |
+| `feedback` | Vercel KV | Recent thumbs up/down feedback summaries |
+| `repoIndex` | Vercel KV (lazy-rebuilt) | Auto-generated topic map of the repository |
+
+The assembled prompt includes these sections in order:
+
+1. **Identity and date** -- who the bot is, today's date
+2. **Recency and brevity rules** -- prefer recent activity, keep answers concise, no brochure copy
+3. **Source-of-truth hierarchy** -- code > tests > docs > KB > feedback (see [Source Hierarchy](./features/source-hierarchy.md))
+4. **Core principles** -- verify before asserting, cite specifically, thread-only replies
+5. **Available tools** -- descriptions of all 7 tools
+6. **Search strategy** -- budget tool rounds, search before read, synthesize early
+7. **Knowledge base instructions** -- when/how to save corrections
+8. **Response style** -- Slack mrkdwn rules (no `##` headings, no `**bold**`)
+9. **Repository context** -- owner, repo, CLAUDE.md content
+10. **Repository map** -- auto-generated topic index (if available)
+11. **Knowledge base entries** -- actual KB data with staleness warning
+12. **Feedback entries** -- positive/negative reaction summaries
+
+## The Agent Loop
+
+The agent loop is a standard Claude tool-use loop with a hard cap of 15 rounds:
+
+```
+for round in 0..MAX_TOOL_ROUNDS:
+    response = claude.messages.create(system, tools, messages)
+
+    if response.stop_reason == "end_turn":
+        return text + references
+
+    for each tool_use block in response:
+        fire onProgress callback (updates thinking message)
+        result = executeTool(name, input)
+        collect references from result
+
+    append tool results to messages
+
+if loop exhausted:
+    return "hit maximum tool calls" message
+```
+
+Key behaviors:
+
+- **References are collected from tool results**, not from Claude's text. Each tool that accesses a file or issue returns structured `Reference` objects with labels and GitHub URLs.
+- **References are deduplicated by URL** during collection and by label (case-insensitive) during formatting.
+- **References are capped at 5** in the final output to keep the footer scannable.
+- **Issue proposals are extracted** from `create_issue` tool calls and attached to the result separately. They are formatted with a confirmation prompt in the Slack message.
+
+## Tool System
+
+Seven tools are registered with Claude's tool-use API:
+
+| Tool | GitHub API | Returns References? |
+|------|-----------|-------------------|
+| `search_code` | `search.code` | No (discovery only) |
+| `read_file` | `repos.getContent` | Yes (file path + URL) |
+| `list_issues` | `issues.listForRepo` / `issues.get` | Yes (issue numbers + URLs) |
+| `list_commits` | `repos.listCommits` | No |
+| `list_prs` | `pulls.list` | No |
+| `create_issue` | None (proposal only) | No |
+| `save_knowledge` | None (Vercel KV) | No |
+
+The tool registry is in `src/tools/index.ts`. Each tool is a separate file that exports:
+- A `Tool` definition (name, description, input schema) for Claude's API
+- An execute function that calls the GitHub API and formats the result
+
+## Markdown to Slack mrkdwn Conversion
+
+Claude generates standard Markdown, but Slack uses its own "mrkdwn" format. The `toSlackMrkdwn()` function converts:
+
+- `## Heading` becomes `*Heading*` (Slack bold on its own line)
+- `**bold**` becomes `*bold*` (Slack uses single asterisks)
+
+This runs on every response before posting to Slack. Without it, users would see literal `##` and `**` characters.
+
+> **Known limitation**: The converter does not handle headings inside code blocks. A `## comment` inside triple backticks will be converted to `*comment*`. This rarely matters in practice since code blocks are fenced with triple backticks which Slack handles natively.
+
+## Reference Formatting
+
+Every bot answer includes a footer with links to the files and issues that were accessed:
+
+```
+───
+References:
+  - src/middleware/auth.ts
+  - src/middleware/auth.test.ts
+  - #42
+```
+
+References are:
+- **Deduplicated** by label (case-insensitive, first occurrence wins)
+- **Capped at 5** to keep the footer short
+- **Formatted as Slack links** (`<url|label>`) so they are clickable
+- **Only from files actually read** -- search results do not generate references (they are discovery aids)
+
+If there are more than 5 unique references, the footer shows "...and N more".
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| **Webhook mode, not Socket mode** | Vercel serverless functions cannot maintain persistent WebSocket connections. Webhook mode works naturally with serverless. |
+| **Ack-then-process** | Slack requires 200 OK within 3 seconds. The API route acks immediately, then processes via `after()`. |
+| **Thread-only replies** | The bot never posts at channel root. All responses go in the thread where it was mentioned. Keeps channels clean. |
+| **Verify before asserting** | The agent uses GitHub tools to check that files and methods actually exist before referencing them. No hallucinated code references. |
+| **Issue creation requires confirmation** | The bot proposes issues but never creates them without explicit :white_check_mark: reaction. Prevents accidental issue spam. |
+| **Search first, read second** | The system prompt instructs Claude to search for code patterns before reading files. A single search returns multiple paths with context, avoiding blind file reads. |
+| **15 tool round budget** | Hard cap prevents runaway tool loops. The system prompt instructs Claude to synthesize early rather than exhausting all rounds. |
+| **References from reads only** | Search results are discovery aids and do not appear in references. Only files the agent actually reads (via `read_file`) are cited. |
+| **KV for knowledge, not GitHub** | The knowledge base lives in Vercel KV, not in the GitHub repo. The GitHub PAT does not need Contents: Write permission. |
+| **Progress messages deleted** | The thinking message is deleted when the answer is ready, rather than edited in place. This keeps the thread clean with just the final answer. |
+
+## Project Structure
+
+```
+src/
+  app/
+    api/slack/route.ts    -- Webhook handler (mention, reaction, thread follow-up)
+    page.tsx              -- Landing page
+    layout.tsx            -- Root layout
+  lib/
+    slack.ts              -- Slack client, signature verification, message helpers
+    claude.ts             -- Anthropic client, system prompt assembly, agent loop
+    github.ts             -- Octokit client (search, read, issues, PRs, commits, tree)
+    knowledge.ts          -- Knowledge base (Vercel KV sorted set)
+    feedback.ts           -- Feedback storage (Vercel KV) and Q&A context
+    repo-index.ts         -- Repository topic index (lazy rebuild on SHA change)
+    auto-correct.ts       -- Stale KB entry detection and doc reference flagging
+    progress.ts           -- Progress message formatter (tool name to emoji + status)
+    mrkdwn.ts             -- Markdown to Slack mrkdwn converter
+    references.ts         -- Reference deduplication, capping, and formatting
+  tools/
+    index.ts              -- Tool registry and executor
+    search-code.ts        -- GitHub code search
+    read-file.ts          -- GitHub file/directory read
+    list-issues.ts        -- GitHub issue list and lookup
+    list-commits.ts       -- Recent commits on main
+    list-prs.ts           -- Recent pull requests
+    create-issue.ts       -- Issue proposal drafting and message parsing
+    save-knowledge.ts     -- Knowledge base save (Vercel KV)
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,219 @@
+# Contributing Guide
+
+Battle Mage is an open-source project. Contributions are welcome -- but the project has specific standards around testing, code structure, and quality. Read this before opening a PR.
+
+## Getting Started
+
+```bash
+# Fork and clone
+git clone https://github.com/your-username/battle-mage.git
+cd battle-mage
+
+# Install dependencies
+npm install
+
+# Copy environment template
+cp .env.example .env.local
+# Fill in credentials (see docs/setup.md)
+
+# Run tests
+npm test
+
+# Start dev server
+npm run dev
+```
+
+## TDD Is Mandatory
+
+Every new feature and bug fix must follow test-driven development:
+
+### RED
+
+Write the failing test first. Define what the code should do before writing any implementation.
+
+```typescript
+// src/lib/my-feature.test.ts
+import { describe, it, expect } from "vitest";
+import { myFunction } from "./my-feature";
+
+describe("myFunction", () => {
+  it("returns the expected result", () => {
+    expect(myFunction("input")).toBe("expected output");
+  });
+});
+```
+
+Run `npm test` -- the test should fail (because `myFunction` does not exist yet).
+
+### GREEN
+
+Write the minimum code to make the test pass.
+
+```typescript
+// src/lib/my-feature.ts
+export function myFunction(input: string): string {
+  return "expected output";
+}
+```
+
+Run `npm test` -- the test should pass.
+
+### REFACTOR
+
+Clean up the implementation while keeping tests green. Run `npm test` after every change.
+
+### Test Infrastructure
+
+- **Framework**: Vitest
+- **Config**: `vitest.config.ts` with `@` path alias resolution
+- **Colocated**: test files live next to source files (`foo.ts` -> `foo.test.ts`)
+- **Run all tests**: `npm test` (single run, CI mode)
+- **Watch mode**: `npm run test:watch` (re-runs on file changes)
+- **Current count**: 100 tests across 7 test files
+
+### What to Test
+
+The project follows a pattern of extracting pure functions for testability and keeping side effects in the handler layer.
+
+**Test these** (pure functions):
+- System prompt assembly (`assembleSystemPrompt`)
+- Topic classification (`classifyTopics`, `buildIndexSummary`)
+- Stale entry detection (`identifyStaleKBEntries`, `buildCorrectionActions`)
+- Message formatting (`formatProgressMessage`, `buildThinkingMessage`)
+- Markdown conversion (`toSlackMrkdwn`)
+- Reference formatting (`formatReferences`)
+- Issue proposal parsing (`parseProposalFromMessage`)
+
+**Do not test directly** (side-effect layer):
+- The route handler (`route.ts`) -- it orchestrates side effects (Slack API, GitHub API, KV)
+- KV read/write operations -- these are integration concerns
+- GitHub API calls -- these depend on external services
+
+If your feature requires external calls, extract the logic into a pure function that can be tested in isolation, and call that function from the handler.
+
+## CI Pipeline
+
+Every pull request runs the CI pipeline on GitHub Actions:
+
+```yaml
+steps:
+  - Checkout
+  - Setup Node.js 22 with npm cache
+  - npm ci
+  - Typecheck (tsc --noEmit)
+  - Test (vitest run)
+  - Build (next build)
+```
+
+All three checks must pass:
+
+1. **Typecheck** -- no TypeScript errors
+2. **Test** -- all 100+ tests pass
+3. **Build** -- the Next.js app compiles successfully
+
+CI runs on:
+- Every push to `main`
+- Every pull request targeting `main`
+
+### Branch Protection
+
+The `main` branch requires:
+- CI status checks to pass before merging
+- Pull request review (depending on repo settings)
+
+Do not push directly to `main`. Always use a feature branch and PR.
+
+## Fork Workflow
+
+1. **Fork** the repository on GitHub
+2. **Clone** your fork locally
+3. **Create a feature branch**: `git checkout -b feat/my-feature`
+4. **Write tests first** (RED)
+5. **Implement** (GREEN)
+6. **Refactor** while tests stay green
+7. **Run the full suite**: `npm test && npm run typecheck`
+8. **Commit** with a descriptive message
+9. **Push** to your fork: `git push origin feat/my-feature`
+10. **Open a PR** against `main`
+
+### Commit Message Convention
+
+Use conventional-style prefixes:
+
+- `feat:` -- new feature
+- `fix:` -- bug fix
+- `test:` -- adding or updating tests
+- `docs:` -- documentation changes
+- `refactor:` -- code restructuring without behavior change
+
+Examples:
+```
+feat: Add list_commits tool for recent commit history
+fix: Handle empty KB entries in auto-correction
+test: Add edge cases for mrkdwn heading conversion
+refactor: Extract keyword matching into pure function
+```
+
+## What Makes a Good Contribution
+
+### Good Contributions
+
+- **New tools**: Adding a tool for a new GitHub API (e.g., `list_releases`, `get_workflow_runs`). Follow the existing pattern: tool definition + execute function + tests.
+- **Better classification**: Improving the repo index topic rules to catch more patterns.
+- **Mrkdwn improvements**: Handling more Markdown-to-Slack conversions (e.g., tables, strikethrough).
+- **Bug fixes**: Fixing edge cases in existing functionality, especially with tests that reproduce the bug.
+- **Test coverage**: Adding tests for untested edge cases in existing pure functions.
+
+### Contributions to Avoid
+
+- **Large refactors without tests**: If you want to restructure something, write tests for the current behavior first, then refactor.
+- **Adding dependencies**: The project intentionally has a small dependency footprint. If you want to add a dependency, open an issue first to discuss.
+- **Changing the system prompt without tests**: The system prompt is tested. Changes to prompt behavior should be accompanied by test updates.
+- **Breaking the pure/side-effect boundary**: Keep pure functions pure. Do not add KV or API calls to modules that are currently testable without mocks.
+
+## Project Structure
+
+```
+src/
+  app/
+    api/slack/route.ts    -- Webhook handler (side-effect layer)
+    page.tsx              -- Landing page
+  lib/
+    claude.ts             -- System prompt + agent loop
+    claude.test.ts        -- 30+ tests for prompt assembly
+    slack.ts              -- Slack API helpers
+    github.ts             -- GitHub API helpers
+    knowledge.ts          -- KV knowledge base
+    feedback.ts           -- KV feedback storage
+    repo-index.ts         -- Topic classification
+    repo-index.test.ts    -- Classification tests
+    auto-correct.ts       -- Stale entry detection
+    auto-correct.test.ts  -- Auto-correction tests
+    progress.ts           -- Progress message formatting
+    progress.test.ts      -- Progress formatting tests
+    mrkdwn.ts             -- Markdown to Slack converter
+    mrkdwn.test.ts        -- Conversion tests
+    references.ts         -- Reference formatting
+    references.test.ts    -- Reference tests
+  tools/
+    index.ts              -- Tool registry + executor
+    search-code.ts        -- search_code tool
+    read-file.ts          -- read_file tool
+    list-issues.ts        -- list_issues tool
+    list-commits.ts       -- list_commits tool
+    list-prs.ts           -- list_prs tool
+    create-issue.ts       -- create_issue tool
+    create-issue.test.ts  -- Proposal parsing tests
+    save-knowledge.ts     -- save_knowledge tool
+```
+
+## Local Development Tips
+
+- Use `npm run test:watch` during development -- it re-runs affected tests on save.
+- You do not need Slack, GitHub, or KV credentials to run tests. Tests only exercise pure functions.
+- For full end-to-end testing, you need all environment variables set and a tunnel (like ngrok) to expose your local server to Slack.
+- The dev server runs at `http://localhost:3000`. The landing page shows basic project info.
+
+## Questions?
+
+Open a GitHub issue with the `question` label. We are happy to help with setup issues, architectural questions, or contribution guidance.

--- a/docs/features/auto-correction.md
+++ b/docs/features/auto-correction.md
@@ -1,0 +1,126 @@
+# Auto-Correction
+
+When a user reacts with :thumbsdown: to a bot answer, the auto-correction system analyzes the answer's context and takes corrective actions automatically.
+
+## Overview
+
+The flow:
+
+1. User thumbs-down a bot message
+2. Route handler fetches the Q&A context (stored in KV when the answer was posted)
+3. Route handler fetches all current KB entries
+4. `buildCorrectionActions()` analyzes references and KB entries
+5. Stale KB entries are removed from KV
+6. Stale doc references are flagged to the user
+7. Bot replies asking what was wrong
+
+## How Stale KB Entries Are Identified
+
+The heuristic is keyword matching between the answer's references and KB entry text.
+
+### Step 1: Extract Keywords from References
+
+When the bot answered the question, it collected references -- the file paths it actually read. The auto-correction system extracts meaningful keywords from those paths:
+
+```
+Reference: "app/Services/Auth/LoginService.php"
+Keywords:  ["app", "services", "auth", "login", "service", "php"]
+```
+
+Keywords are extracted by:
+1. Replacing non-alphanumeric characters with spaces
+2. Splitting camelCase and PascalCase (`LoginService` becomes `Login Service`)
+3. Splitting on whitespace
+4. Filtering out words shorter than 3 characters
+5. Lowercasing everything
+
+### Step 2: Match Against KB Entries
+
+Each KB entry's text is tokenized the same way. If any token in the KB entry matches a keyword from the references (excluding common stop words like "the", "is", "in", "not", "and"), the entry is flagged as potentially stale.
+
+Example:
+
+```
+References: ["src/controllers/AuthController.ts"]
+  -> keywords: ["app", "http", "controllers", "auth", "controller", "php"]
+
+KB entry: "Auth uses JWT tokens, not session cookies"
+  -> tokens: ["auth", "uses", "jwt", "tokens", "not", "session", "cookies"]
+
+Match: "auth" appears in both -> entry flagged as stale
+```
+
+### Step 3: Remove Stale Entries
+
+Flagged KB entries are removed from the Vercel KV sorted set via `removeKnowledgeEntry()`. This is an exact match on the entry text -- the function scans all members of the sorted set to find and remove the matching one.
+
+## How Doc References Are Flagged
+
+If the answer referenced documentation files (paths ending in `.md` or starting with `docs/`), those are flagged as potentially outdated. The bot does not auto-create issues -- it informs the user:
+
+```
+Auto-corrections taken:
+- Removed stale KB entry: "Auth uses JWT"
+- These docs may be outdated: `docs/auth.md` -- reply "create issue" if
+  you'd like me to propose a doc-fix issue
+```
+
+This gives the user the choice to file an issue for updating the documentation.
+
+## The Correction Actions Structure
+
+`buildCorrectionActions()` returns a `CorrectionActions` object:
+
+```typescript
+interface CorrectionActions {
+  kbEntriesToRemove: KnowledgeEntry[];  // KB entries to delete
+  docsToProposeFix: string[];           // doc paths to flag
+  hasActions: boolean;                  // true if either array is non-empty
+}
+```
+
+This is a pure function -- it takes references and KB entries as input and returns actions as output. The actual KV writes and Slack replies happen in the route handler.
+
+## What the User Sees
+
+When a user thumbs-down an answer that referenced auth files and the KB had a matching auth entry:
+
+```
+:thinking_face: Thanks for the feedback.
+
+Auto-corrections taken:
+- Removed stale KB entry: "Auth uses JWT, not session cookies"
+- These docs may be outdated: `docs/auth-guide.md` -- reply "create issue"
+  if you'd like me to propose a doc-fix issue
+
+What was wrong with this answer? Reply here and I'll save the correction
+to my knowledge base.
+```
+
+If there are no auto-corrections to take (no matching KB entries, no doc references), the user sees a simpler message:
+
+```
+:thinking_face: Thanks for the feedback.
+
+What was wrong with this answer? Reply here and I'll save the correction
+to my knowledge base.
+```
+
+## Limitations
+
+The keyword matching heuristic is deliberately broad. It can produce false positives:
+
+- A KB entry about "AuthController response format" would be flagged as stale if the answer referenced any auth file, even if the KB entry is still correct.
+
+This is by design. When a user signals an answer was wrong, it is better to be aggressive about removing potentially stale data. The user can re-teach the bot the correct information in the follow-up.
+
+## Testing
+
+The auto-correction logic is tested in `src/lib/auto-correct.test.ts`. All three exported functions are pure (no KV, no side effects) and tested with various scenarios:
+
+- KB entries matching referenced file paths
+- KB entries matching by topic keyword (not exact path)
+- No matches (empty actions)
+- Doc file references detected and flagged
+- Both KB removals and doc flags in the same correction
+- The `hasActions` flag

--- a/docs/features/knowledge-base.md
+++ b/docs/features/knowledge-base.md
@@ -1,0 +1,117 @@
+# Knowledge Base
+
+The knowledge base stores corrections and learned facts from Slack conversations. It persists across conversations and is injected into every system prompt, giving the bot a persistent memory that improves over time.
+
+## Storage
+
+The knowledge base uses Vercel KV (Upstash Redis). Entries are stored in a sorted set with the key `knowledge:entries`, scored by Unix timestamp (newest first).
+
+Each entry is a JSON string:
+
+```json
+{
+  "entry": "The auth module lives in app/Services/Auth, not app/Http/Auth",
+  "timestamp": "2026-03-28"
+}
+```
+
+## How Entries Are Saved
+
+### Via the `save_knowledge` Tool
+
+When a user corrects the bot in a conversation, the bot uses the `save_knowledge` tool to persist the correction:
+
+```
+User: @bm Where does the auth config live?
+Bot:  It's in config/auth.php
+User: No, we moved that to config/security.php last month
+Bot:  [calls save_knowledge with "Auth config was moved from config/auth.php
+       to config/security.php"] Thanks for the correction! I've saved that.
+```
+
+The system prompt instructs the bot to save corrections immediately when:
+
+- A user corrects a specific fact ("no, that's in X not Y")
+- A user shares insider knowledge ("we deprecated that endpoint last week")
+- The bot discovers something that contradicts documentation
+- A user says "remember this" or similar
+
+### Via Auto-Correction on Thumbs Down
+
+When a user reacts with :thumbsdown:, the auto-correction system may **remove** stale KB entries. See [Auto-Correction](./auto-correction.md) for details.
+
+## How Entries Flow Into the System Prompt
+
+The function `getKnowledgeAsMarkdown()` fetches all entries from KV and formats them as a timestamped list:
+
+```
+- [2026-03-28] The auth module lives in app/Services/Auth, not app/Http/Auth
+- [2026-03-27] API rate limit is 120 req/min, not 60
+- [2026-03-25] The deploy pipeline uses Docker Alpine, not Ubuntu
+```
+
+This is injected into the system prompt under the heading "Knowledge Base (learned corrections)" with a staleness warning:
+
+> These are corrections from the team stored in Vercel KV. They can become stale as the codebase evolves -- always verify against the actual code before trusting a KB entry.
+
+This warning is critical. KB entries rank 4th in the [source-of-truth hierarchy](./source-hierarchy.md) -- below source code, tests, and documentation. The bot is instructed to flag discrepancies when a KB entry contradicts what it sees in the code.
+
+## Writing Good KB Entries
+
+The system prompt guides the bot to write entries as standalone facts, not conversation snippets:
+
+**Good entries:**
+- "The auth module lives in app/Services/Auth, not app/Http/Auth"
+- "The API rate limit is 120 req/min, not 60"
+- "The `UserService.sync()` method was deprecated in favor of `UserSync.run()`"
+
+**Bad entries:**
+- "User said auth is somewhere else"
+- "The thing they asked about is different now"
+- "See the conversation above"
+
+Each entry should be self-contained -- readable and useful without any surrounding context.
+
+## Viewing and Managing Entries
+
+### Via Vercel KV Browser
+
+You can inspect and edit knowledge base entries directly in the Vercel dashboard:
+
+1. Go to your project's **Storage** tab
+2. Open the KV database
+3. Find the key `knowledge:entries`
+4. Browse the sorted set members
+
+### Via Code
+
+The `knowledge.ts` module exports these functions:
+
+| Function | Description |
+|----------|-------------|
+| `saveKnowledgeEntry(entry)` | Add a new entry |
+| `getAllKnowledge()` | Get all entries, newest first |
+| `removeKnowledgeEntry(entryText)` | Remove an entry by matching its text |
+| `getKnowledgeAsMarkdown()` | Format all entries as markdown for the prompt |
+
+### Removing a Stale Entry
+
+If you need to manually remove a KB entry, you can:
+
+1. Use the Vercel KV browser to find and delete the specific member from the sorted set
+2. Or let the auto-correction system handle it -- thumbs-down an answer that relied on stale KB data, and the bot will identify and remove related entries
+
+## Graceful Degradation
+
+If Vercel KV is not configured (common during local development without KV credentials), `getKnowledgeAsMarkdown()` catches the error silently and returns `null`. The bot works normally without a knowledge base -- it just does not have persistent memory.
+
+The knowledge base section is simply omitted from the system prompt when there are no entries.
+
+## Relationship to Feedback
+
+The knowledge base and the feedback system are separate:
+
+- **Knowledge base** stores factual corrections ("X lives in Y, not Z"). These are high-signal, specific, and actionable.
+- **Feedback** stores thumbs up/down signals with question/answer context. These are lower-signal and used to calibrate tone and approach.
+
+Both are stored in Vercel KV but under different keys (`knowledge:entries` vs `feedback:entries`). Both are injected into the system prompt but with different headings and different trust levels.

--- a/docs/features/progress-ux.md
+++ b/docs/features/progress-ux.md
@@ -1,0 +1,116 @@
+# Live Progress Updates
+
+While Battle Mage processes a question, users see a live-updating status message in the thread. This provides visibility into what the bot is doing and reduces the perception of waiting.
+
+## The Thinking Message Pattern
+
+When the bot starts processing a question:
+
+1. A "thinking" message is posted immediately in the thread
+2. As each tool is called, the message is updated in place with a new status line
+3. When the answer is ready, the thinking message is deleted
+4. The final answer is posted as a new message
+
+The user sees something like:
+
+```
+🧠 Battle Mage is working... (this may take a minute, go grab some tea)
+🔍 Searching for "authentication middleware"...
+```
+
+Then a few seconds later:
+
+```
+🧠 Battle Mage is working... (this may take a minute, go grab some tea)
+👓 Reading src/middleware/auth.ts...
+```
+
+Then the thinking message disappears and the final answer appears.
+
+## Header + Status Line
+
+The thinking message has two parts:
+
+1. **Header** (fixed): `🧠 Battle Mage is working... _(this may take a minute, go grab some tea)_`
+2. **Status line** (updates on each tool call): the contextual status
+
+The header stays the same on every update. Only the status line changes. This prevents the message from "jumping" in the Slack UI, since the first line remains stable.
+
+The `buildThinkingMessage()` function composes these two parts:
+
+```typescript
+function buildThinkingMessage(toolName: string, input: ToolInput): string {
+  const status = formatProgressMessage(toolName, input);
+  return `${HEADER}\n${status}`;
+}
+```
+
+## Contextual Emoji Map
+
+Each tool has its own emoji and message format:
+
+| Tool / Step | Emoji | Example Message |
+|-------------|-------|-----------------|
+| `thinking` | 🧠 | _Thinking about your question..._ |
+| `index` | 🗂️ | _Checking repo index..._ |
+| `search_code` | 🔍 | _Searching for "authentication middleware"..._ |
+| `read_file` | 👓 | _Reading src/middleware/auth.ts..._ |
+| `list_issues` | 🎫 | _Looking up issues..._ |
+| `list_commits` | 📜 | _Checking recent commits..._ |
+| `list_prs` | 🔀 | _Checking recent PRs..._ |
+| `create_issue` | 📝 | _Drafting issue proposal..._ |
+| `save_knowledge` | 💾 | _Saving to knowledge base..._ |
+| `composing` | ✏️ | _Composing answer..._ |
+| (unknown) | 🧠 | _Working on it..._ |
+
+All status messages are italicized using Slack's underscore syntax (`_text_`), which visually distinguishes them from actual answer text.
+
+## Dynamic Content in Status Lines
+
+Two tools include dynamic content from their input:
+
+- **`search_code`** shows the search query: `🔍 _Searching for "authentication middleware"..._`
+- **`read_file`** shows the file path: `👓 _Reading src/middleware/auth.ts..._`
+
+Long file paths are truncated to 60 characters with a leading `...`:
+
+```
+👓 _Reading ...eeply/nested/directory/structure/that/goes/on/forever/file.php..._
+```
+
+Other tools show fixed messages since their inputs are less informative to the user.
+
+## How Updates Are Delivered
+
+The progress callback is passed to `runAgent()`:
+
+```typescript
+const result = await runAgent(cleanMessage, async (toolName, input) => {
+  if (thinkingTs) {
+    await updateMessage(channel, thinkingTs, buildThinkingMessage(toolName, input));
+  }
+});
+```
+
+Before each tool is executed, the callback fires. The route handler uses `updateMessage()` (which calls `slack.chat.update`) to edit the thinking message in place.
+
+After the final answer is ready, a "composing" status is shown briefly, then the thinking message is deleted via `deleteMessage()` and replaced with the final answer.
+
+## Why Delete Instead of Edit?
+
+The thinking message is deleted rather than edited into the final answer because:
+
+1. The thinking message has a different visual style (emoji + italics) that would need to be completely replaced
+2. Deleting and reposting ensures the message appears at the bottom of the thread, in chronological order
+3. It keeps the thread clean -- only the final answer remains
+
+## Testing
+
+The progress formatting is tested in `src/lib/progress.test.ts`. Tests cover:
+
+- Each tool's emoji and message format
+- All messages being italic (wrapped in underscores)
+- Unknown tool names handled gracefully (fallback to brain emoji)
+- Long file path truncation
+- The header staying constant across different tools
+- The header appearing on the first line of every built message

--- a/docs/features/repo-index.md
+++ b/docs/features/repo-index.md
@@ -1,0 +1,98 @@
+# Repository Index
+
+The repository index is an auto-generated topic map of your codebase. It helps the bot jump directly to relevant files instead of searching blind.
+
+## How It Works
+
+When the bot starts processing a question, it calls `getOrRebuildIndex()` which:
+
+1. Fetches the current HEAD SHA from the main branch
+2. Compares it against the stored SHA in Vercel KV
+3. If they match, returns the cached index summary
+4. If they differ (new commits since last build), rebuilds the index
+
+### Lazy Rebuild
+
+The index is only rebuilt when the repo has changed. This means:
+
+- **First question after a push**: index rebuilds (adds a few hundred milliseconds)
+- **Subsequent questions on the same SHA**: index served from KV cache (fast)
+- **No background jobs**: the rebuild happens lazily on the next request
+
+If the rebuild fails for any reason (GitHub API error, KV timeout), the bot falls back to an empty index and relies on `search_code` instead. The index is a performance optimization, not a hard dependency.
+
+## Topic Classification
+
+The index works by fetching the full file tree from GitHub (via `git.getTree` with `recursive: true`) and classifying each file path against a set of heuristic rules.
+
+### Classification Rules
+
+Each rule is a `[topic, regex]` pair tested against the file path:
+
+| Topic | Pattern matches |
+|-------|----------------|
+| `authentication` | auth, login, session, oauth, jwt, token, password, credential |
+| `deployment` | dockerfile, docker-compose, deploy, cloud run, kubernetes, k8s, helm |
+| `database` | migration, schema, database, seed, .sql, models/ |
+| `testing` | tests, .test., .spec., __tests__, phpunit, jest, vitest |
+| `documentation` | .md, docs/ |
+| `ci-cd` | .github/workflows/, .circleci, .gitlab-ci, jenkinsfile, buildkite |
+| `api` | routes, controller, endpoint, api/ |
+| `configuration` | config/, .env, docker-compose, .yml, .json |
+
+A single file can appear in multiple topics. For example, `tests/Auth/LoginTest.php` matches both `testing` and `authentication`.
+
+### Ignored Paths
+
+Files under these prefixes are skipped entirely:
+
+- `vendor/`
+- `node_modules/`
+- `.git/`
+- `dist/`
+- `build/`
+
+### Path Capping
+
+Each topic shows at most 8 file paths. If a topic has more files, the summary shows `(+N more)`. This keeps the index concise enough to fit in the system prompt without consuming too many tokens.
+
+## KV Storage
+
+Four keys are stored in Vercel KV:
+
+| Key | Value | Purpose |
+|-----|-------|---------|
+| `index:sha` | HEAD commit SHA | Staleness check |
+| `index:topics` | JSON topic map | Full topic-to-paths mapping |
+| `index:summary` | Formatted text | Ready-to-inject prompt section |
+| `index:built_at` | ISO timestamp | Debugging/auditing |
+
+## Prompt Injection
+
+When the index is available, it is injected into the system prompt under the heading "Repository Map (auto-generated index)":
+
+```
+## Repository Map (auto-generated index)
+
+This map shows the key areas of the repo. Use it to jump directly to
+relevant files with `read_file` instead of searching blind. The map
+is rebuilt automatically when the repo changes.
+
+- *authentication*: app/Services/Auth/LoginService.php, config/auth.php
+- *deployment*: Dockerfile, .github/workflows/deploy.yml
+- *testing*: tests/Unit/AuthTest.php, tests/Feature/LoginTest.php (+12 more)
+```
+
+This gives the bot a high-level map of the repository so it can use `read_file` directly when it knows which area of the codebase is relevant, saving tool rounds.
+
+## Adding New Topics
+
+To classify new topics, add a `[topic, regex]` entry to the `TOPIC_RULES` array in `src/lib/repo-index.ts`. The regex is tested case-insensitively against the full file path.
+
+Example -- adding a "frontend" topic:
+
+```typescript
+["frontend", /\bcomponents?\b|\.tsx$|\.jsx$|pages?\//i],
+```
+
+The pure classification functions (`classifyTopics`, `isIndexStale`, `buildIndexSummary`) are exported and tested separately from the KV and GitHub integration. See `src/lib/repo-index.test.ts` for the test suite.

--- a/docs/features/source-hierarchy.md
+++ b/docs/features/source-hierarchy.md
@@ -1,0 +1,92 @@
+# Source-of-Truth Hierarchy
+
+Battle Mage draws from multiple information sources when answering questions. These sources have different reliability levels. The hierarchy defines which source to trust when they conflict.
+
+## The Five Levels
+
+| Rank | Source | Trust Level | Description |
+|------|--------|-------------|-------------|
+| 1 | **Source code** | Highest | The actual implementation. Code is the ultimate source of truth. |
+| 2 | **Tests** | High | Encode expected behavior. If tests pass, the tested behavior is correct. |
+| 3 | **Documentation** | Medium | Describes intent but can drift from reality. |
+| 4 | **Knowledge base** | Low-medium | User corrections from Slack. Useful but can become outdated as code changes. |
+| 5 | **Feedback signals** | Lowest | Thumbs up/down reactions. Subjective quality preferences. |
+
+## How It Works in Practice
+
+### Code vs. Documentation
+
+If the bot reads a file and sees that `authenticate()` accepts two parameters, but the README says it accepts three, the bot should:
+
+1. Trust the code (2 parameters)
+2. Flag the discrepancy: "Note: the README says `authenticate()` takes three parameters, but the current code only accepts two. The documentation may be outdated."
+
+### Code vs. Knowledge Base
+
+If a KB entry says "The auth module lives in `app/Services/Auth`" but the bot searches and finds it at `app/Auth`, the bot should:
+
+1. Trust the code (`app/Auth`)
+2. Flag the stale KB entry: "Note: the knowledge base says auth is in `app/Services/Auth`, but I found it at `app/Auth`. The KB entry may be outdated."
+
+The bot is explicitly told: **never silently prefer a lower-ranked source over a higher-ranked one.**
+
+### Tests as Behavioral Truth
+
+Tests occupy the second rank because they encode the team's expectations about how code should behave. If a function's docstring says it returns a list, but tests assert it returns a dict, the tests are more likely to be correct (assuming they pass).
+
+### Feedback as Calibration Only
+
+Feedback (thumbs up/down) is the weakest signal. It reflects subjective preferences about answer quality, not factual truth. The system prompt explicitly labels it:
+
+> This is the weakest, most subjective signal -- use it to calibrate tone and style, not as a source of factual truth.
+
+## Conflict Detection Rules
+
+The system prompt includes three specific rules for handling conflicts:
+
+1. **For code-level questions, always read the actual code** before asserting anything from docs, KB, or memory.
+
+2. **When you find a discrepancy**, include both the code truth and the stale source in your answer so the user can decide what to update.
+
+3. **Never silently prefer a lower-ranked source** over a higher-ranked one.
+
+## How This Manifests in the System Prompt
+
+The hierarchy is injected as a numbered list in the system prompt under the heading "Source-of-Truth Hierarchy":
+
+```
+1. *Source code* -- The actual implementation. Code is the ultimate source
+   of truth. Always verify claims against the code before asserting them.
+2. *Tests* -- Encode expected behavior. If tests pass, the tested behavior
+   is correct.
+3. *Documentation* (docs/, CLAUDE.md, README) -- Describes intent but can
+   drift from reality. If documentation contradicts code, trust the code
+   and flag the stale documentation.
+4. *Knowledge base* (Vercel KV corrections) -- User corrections from Slack.
+   Useful but can become outdated as code changes. If a KB entry contradicts
+   what you see in the code, the code is authoritative.
+5. *Feedback signals* (thumbs up/down reactions) -- The least authoritative
+   signal. Subjective quality preferences.
+```
+
+Additionally, the knowledge base data section includes a staleness warning, and the feedback section is labeled as "the weakest, most subjective signal."
+
+## Integration with Auto-Correction
+
+When a user thumbs-down an answer, the [auto-correction system](./auto-correction.md) uses the hierarchy implicitly:
+
+- KB entries that share keywords with the answer's references are presumed stale and removed
+- Documentation files referenced in the answer are flagged as potentially outdated
+
+This creates a self-correcting loop: the bot answers using KB + docs, the user signals the answer was wrong, and the system removes the lower-ranked sources that may have contributed to the bad answer.
+
+## Testing
+
+The hierarchy behavior is tested in `src/lib/claude.test.ts`. Tests verify that:
+
+- All five levels appear in the correct order
+- The prompt instructs the bot to flag code-vs-KB discrepancies
+- The prompt instructs the bot to flag code-vs-docs discrepancies
+- The prompt instructs the bot to verify code before asserting KB/doc claims
+- The knowledge section warns about staleness
+- The feedback section is labeled as the weakest signal

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,243 @@
+# Setup Guide
+
+This guide walks you through deploying Battle Mage from scratch. You will create a Slack app, a GitHub personal access token, a Vercel project with KV storage, and wire them all together.
+
+Estimated time: 20-30 minutes.
+
+## Prerequisites
+
+- A Slack workspace where you have permission to install apps
+- A GitHub account with access to the repository you want Battle Mage to read
+- A Vercel account (free tier works)
+- An Anthropic API key ([console.anthropic.com](https://console.anthropic.com))
+- Node.js 18.17+ installed locally
+
+## 1. Create the Slack App
+
+Go to [api.slack.com/apps](https://api.slack.com/apps) and click **Create New App** > **From a manifest**.
+
+Select your workspace, then paste this manifest (YAML):
+
+```yaml
+display_information:
+  name: Battle Mage
+  description: AI assistant for your GitHub codebase
+  background_color: "#1a1a2e"
+
+features:
+  bot_user:
+    display_name: bm
+    always_online: true
+
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - channels:history
+      - channels:read
+      - chat:write
+      - groups:history
+      - groups:read
+      - reactions:read
+      - reactions:write
+
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+      - message.channels
+      - message.groups
+      - reaction_added
+  interactivity:
+    is_enabled: false
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false
+```
+
+Click **Create**. You will configure the event subscription URL after deploying to Vercel (step 5).
+
+### Install to Workspace
+
+From your app's settings page:
+
+1. Go to **OAuth & Permissions** in the sidebar
+2. Click **Install to Workspace** and approve the permissions
+3. Copy the **Bot User OAuth Token** (starts with `xoxb-`) -- you will need this as `SLACK_BOT_TOKEN`
+4. Go to **Basic Information** and copy the **Signing Secret** -- you will need this as `SLACK_SIGNING_SECRET`
+
+> **Gotcha**: The signing secret is under Basic Information, not OAuth & Permissions. They are different credentials.
+
+### Required Scopes Explained
+
+| Scope | Why |
+|-------|-----|
+| `app_mentions:read` | Detect when someone @mentions the bot |
+| `channels:history` | Read thread messages for follow-up context |
+| `channels:read` | Access channel info |
+| `chat:write` | Post replies in threads |
+| `groups:history` | Same as channels:history but for private channels |
+| `groups:read` | Same as channels:read but for private channels |
+| `reactions:read` | Detect thumbs up/down and checkmark reactions |
+| `reactions:write` | Add brain emoji to acknowledge positive feedback |
+
+## 2. Create a GitHub Fine-Grained PAT
+
+Go to [github.com/settings/tokens?type=beta](https://github.com/settings/tokens?type=beta) and create a **fine-grained personal access token**.
+
+Configuration:
+
+- **Token name**: `battle-mage` (or whatever you prefer)
+- **Expiration**: 90 days (GitHub's maximum for fine-grained tokens; set a calendar reminder to rotate)
+- **Repository access**: Select **Only select repositories** and pick the repo you want Battle Mage to read
+- **Permissions**: Set these repository permissions:
+
+| Permission | Access Level | Why |
+|-----------|-------------|-----|
+| Contents | Read-only | Read files, list directory trees, fetch commits |
+| Issues | Read and write | List issues and create new ones (via confirmation flow) |
+| Pull requests | Read-only | List recent PRs and read PR details |
+| Metadata | Read-only | Required by GitHub for all fine-grained PATs |
+
+Click **Generate token** and copy it immediately. This is your `GITHUB_PAT_BM`.
+
+> **Tip**: The PAT does NOT need Contents: Write. Battle Mage never pushes code. The knowledge base lives in Vercel KV, not in the GitHub repo.
+
+> **Gotcha**: If you select "All repositories" instead of scoping to one repo, Battle Mage will still only operate on the repo specified by `GITHUB_OWNER` and `GITHUB_REPO`. But scoping the PAT to a single repo is better security practice.
+
+## 3. Deploy to Vercel
+
+### Option A: Deploy via CLI (recommended)
+
+```bash
+# Clone the repo
+git clone https://github.com/your-fork/battle-mage.git
+cd battle-mage
+npm install
+
+# Install Vercel CLI if you don't have it
+npm i -g vercel
+
+# Link to Vercel (creates project if needed)
+vercel link
+
+# Set environment variables
+vercel env add SLACK_BOT_TOKEN        # paste your xoxb-... token
+vercel env add SLACK_SIGNING_SECRET   # paste signing secret
+vercel env add ANTHROPIC_API_KEY      # paste sk-ant-... key
+vercel env add GITHUB_PAT_BM         # paste github_pat_... token
+vercel env add GITHUB_OWNER           # e.g. "acme-corp"
+vercel env add GITHUB_REPO            # e.g. "backend"
+
+# Deploy to production
+vercel --prod
+```
+
+### Option B: Deploy via Vercel Dashboard
+
+1. Go to [vercel.com/new](https://vercel.com/new)
+2. Import your fork of the battle-mage repo
+3. Add all six environment variables in the **Environment Variables** section before deploying
+4. Click **Deploy**
+
+### Set Up Vercel KV
+
+Battle Mage uses Vercel KV (powered by Upstash Redis) for the knowledge base, feedback storage, and repo index cache.
+
+1. Go to your project in the Vercel dashboard
+2. Navigate to **Storage** tab
+3. Click **Create Database** > **KV (Upstash)**
+4. Name it something like `battle-mage-kv`
+5. Connect it to your project
+
+Vercel automatically injects `KV_REST_API_URL` and `KV_REST_API_TOKEN` into your environment. No manual configuration needed.
+
+> **Gotcha**: If you skip KV setup, the bot will still work for basic Q&A -- but the knowledge base, feedback, and repo index features will silently degrade. You will see no errors, but corrections will not persist and the repo map will not be cached.
+
+### For Local Development
+
+```bash
+cp .env.example .env.local
+```
+
+Fill in all the credentials. For KV, you need to pull the KV credentials from Vercel:
+
+```bash
+vercel env pull .env.local
+```
+
+This will add `KV_REST_API_URL` and `KV_REST_API_TOKEN` to your `.env.local`.
+
+Then start the dev server:
+
+```bash
+npm run dev
+```
+
+The app runs at `http://localhost:3000`. For local Slack testing, you will need a tunnel (like ngrok) to expose your local server to Slack's webhook.
+
+## 4. Connect Slack to Your Deployment
+
+Once deployed, your app URL will be something like `https://battle-mage-abc123.vercel.app`.
+
+1. Go back to [api.slack.com/apps](https://api.slack.com/apps) and select your app
+2. Go to **Event Subscriptions** in the sidebar
+3. Toggle **Enable Events** to ON
+4. Set the **Request URL** to: `https://your-domain.vercel.app/api/slack`
+5. Slack will send a verification challenge -- your app should respond with `200 OK` and the challenge value. If this fails, check that your environment variables are set correctly.
+6. Click **Save Changes**
+
+> **Gotcha**: The URL must end with `/api/slack` exactly. This is the Next.js API route that handles all Slack events.
+
+> **Gotcha**: If verification fails, the most common cause is that the deployment has not finished yet. Wait for the Vercel deployment to complete, then retry.
+
+## 5. Invite the Bot to a Channel
+
+In Slack:
+
+1. Go to the channel where you want to use Battle Mage
+2. Type `/invite @bm` or click the channel settings and add the app
+3. The bot will now listen for @mentions and reactions in that channel
+
+## 6. First Test
+
+In the channel where you invited the bot, type:
+
+```
+@bm What is the project structure?
+```
+
+You should see:
+
+1. A thinking message appear with a brain emoji header
+2. The status line updating as the bot searches and reads files (magnifying glass for search, glasses for file reads)
+3. The thinking message disappear
+4. A final answer with the project structure, followed by reference links
+
+If the bot does not respond, check the [Troubleshooting Guide](./troubleshooting.md).
+
+## Environment Variables Reference
+
+| Variable | Required | Example | Description |
+|----------|----------|---------|-------------|
+| `SLACK_BOT_TOKEN` | Yes | `xoxb-123-456-abc` | Bot OAuth token from Slack app settings |
+| `SLACK_SIGNING_SECRET` | Yes | `abc123def456` | Signing secret from Slack Basic Information |
+| `ANTHROPIC_API_KEY` | Yes | `sk-ant-api03-...` | API key from Anthropic console |
+| `GITHUB_PAT_BM` | Yes | `github_pat_...` | Fine-grained PAT scoped to your target repo |
+| `GITHUB_OWNER` | Yes | `acme-corp` | GitHub organization or username |
+| `GITHUB_REPO` | Yes | `backend` | Repository name |
+| `KV_REST_API_URL` | Auto | `https://...upstash.io` | Injected by Vercel KV -- do not set manually |
+| `KV_REST_API_TOKEN` | Auto | `AaB1Cc2...` | Injected by Vercel KV -- do not set manually |
+
+## Security Notes
+
+- The `SLACK_SIGNING_SECRET` is used to verify that incoming webhooks are genuinely from Slack (HMAC-SHA256 with 5-minute timestamp tolerance). Never disable this.
+- The GitHub PAT should be scoped to the minimum permissions listed above. Never grant write access to Contents.
+- All environment variables should be set in Vercel's encrypted environment variable store, not committed to the repo.
+- The `.env.local` file is in `.gitignore` and should never be committed.
+
+## Next Steps
+
+- [Usage Guide](./usage.md) -- how to use the bot day-to-day
+- [Architecture](./architecture.md) -- how the internals work
+- [Troubleshooting](./troubleshooting.md) -- common issues and fixes

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,131 @@
+# Troubleshooting
+
+Common issues and how to fix them.
+
+## Bot Does Not Respond to @mentions
+
+**Symptom**: You @mention the bot in a channel and nothing happens. No thinking message, no reply.
+
+**Check these in order:**
+
+1. **Is the bot invited to the channel?** Type `/invite @bm` in the channel. The bot only receives events from channels it has been added to.
+
+2. **Is the event subscription URL set?** Go to [api.slack.com/apps](https://api.slack.com/apps) > your app > Event Subscriptions. The Request URL should be `https://your-domain.vercel.app/api/slack` and show a green "Verified" checkmark.
+
+3. **Are the correct bot events subscribed?** Under Event Subscriptions > Subscribe to bot events, you need: `app_mention`, `message.channels`, `message.groups`, `reaction_added`.
+
+4. **Is the deployment healthy?** Check your Vercel dashboard for deployment errors. Look at the function logs for the `/api/slack` route.
+
+5. **Are environment variables set?** In Vercel dashboard > Settings > Environment Variables, verify all six required variables are present: `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `ANTHROPIC_API_KEY`, `GITHUB_PAT_BM`, `GITHUB_OWNER`, `GITHUB_REPO`.
+
+6. **Is signature verification failing?** Check Vercel function logs for "Invalid signature" 401 responses. This means the `SLACK_SIGNING_SECRET` does not match the signing secret from your Slack app's Basic Information page.
+
+7. **Is Slack retrying?** If the bot takes too long, Slack retries the event. The handler rejects retries via the `x-slack-retry-num` header, which is correct -- but if the first request also failed, you will see no response. Check Vercel logs for errors in the `after()` callback.
+
+## Bot Responds With an Error Message
+
+**Symptom**: The bot replies with "Something went wrong while processing your request."
+
+**Check:**
+
+- **Anthropic API key**: Is `ANTHROPIC_API_KEY` valid and not expired? Test it with a curl request to the Anthropic API.
+- **GitHub PAT**: Is `GITHUB_PAT_BM` valid and not expired? Fine-grained PATs expire -- check the expiration date at [github.com/settings/tokens](https://github.com/settings/tokens).
+- **Rate limits**: Both GitHub and Anthropic APIs have rate limits. If you are hitting them, you will see errors in the Vercel function logs.
+- **Vercel function logs**: The error message is logged to console. Check Vercel dashboard > Logs for the specific error.
+
+## Bot Cannot Read the Repository
+
+**Symptom**: The bot says it cannot find files, or search returns no results.
+
+**Check:**
+
+- **GITHUB_OWNER and GITHUB_REPO**: Are these set correctly? They should be the org/user and repo name (e.g., `acme-corp` and `backend`), not the full URL.
+- **PAT repository access**: The fine-grained PAT must be scoped to the correct repository. Check at [github.com/settings/tokens](https://github.com/settings/tokens) > your token > Repository access.
+- **PAT permissions**: The token needs Contents (read), Issues (read/write), Pull requests (read), and Metadata (read). If any are missing, certain tools will fail.
+- **Private repo**: If the repo is private, make sure the PAT has access. Fine-grained PATs for private repos require the token owner to have access to the repo.
+
+## Formatting Looks Wrong in Slack
+
+**Symptom**: You see raw `##` or `**` characters in the bot's responses.
+
+**This is expected for some edge cases.** The `toSlackMrkdwn()` converter handles:
+- `## Heading` -> `*Heading*` (Slack bold)
+- `**bold**` -> `*bold*` (Slack bold)
+
+**Known limitations:**
+- Headings inside code blocks will be converted incorrectly. A `## comment` inside triple backticks will become `*comment*`. This is a known tradeoff that rarely matters in practice.
+- Slack does not support tables, so table-formatted content will appear as raw text.
+- Nested formatting (e.g., bold inside italic) may not render correctly in Slack.
+
+## Timeout Issues
+
+**Symptom**: The thinking message appears but the bot never replies, or the answer is cut off.
+
+**Possible causes:**
+
+- **Vercel function timeout**: By default, Vercel Hobby plans have a 10-second function timeout. The `after()` callback runs outside the response lifecycle but still has a maximum execution time based on your plan. Pro plans get up to 60 seconds, Enterprise gets more.
+- **Complex questions**: If the bot uses all 15 tool rounds, each involving a GitHub API call and a Claude API call, the total execution time can exceed timeout limits.
+- **Large files**: Reading very large files from GitHub can be slow. The bot does not paginate or truncate file reads.
+
+**Fixes:**
+- Upgrade to a Vercel Pro plan for longer function execution times
+- Ask more specific questions that require fewer tool rounds
+- If the thinking message was posted but the answer was not, the thinking message may remain in the thread. The bot deletes it just before posting the answer, so a timeout means the delete and reply never happened.
+
+## Thread Follow-Ups Not Working
+
+**Symptom**: You post in a thread where the bot has replied, but the bot does not respond to your follow-up.
+
+**Check:**
+
+1. **Is this a thread reply?** Follow-ups only work for threaded replies, not top-level messages. Make sure you are replying in the thread, not posting a new message in the channel.
+
+2. **Has the bot actually replied in this thread?** The bot checks `conversations.replies` to see if it has posted in the thread. If the bot's previous message was deleted, it will not respond to follow-ups.
+
+3. **Does the message @mention the bot?** If your follow-up includes `@bm`, it will be handled by the `app_mention` handler, not the thread follow-up handler. Both should work, but if the `app_mention` handler fires, the thread follow-up handler skips the message to avoid duplicates.
+
+4. **Is the bot's user ID resolvable?** The bot calls `auth.test()` to get its own user ID (cached per cold start). If this fails, the thread follow-up handler cannot determine if the bot has replied in the thread.
+
+5. **Are `channels:history` and `groups:history` scopes granted?** These are required for the bot to read thread history. Without them, `conversations.replies` will fail silently.
+
+## KV Not Configured (Knowledge Base Not Working)
+
+**Symptom**: The bot works for basic Q&A but corrections are not persisted, the repo index is not cached, and feedback has no effect.
+
+**Check:**
+
+- **Is a KV store linked?** Go to your Vercel project > Storage tab. You should see a KV database connected.
+- **Are KV credentials present?** Vercel auto-injects `KV_REST_API_URL` and `KV_REST_API_TOKEN`. Check that these appear in your Environment Variables.
+- **Local development**: For local dev, you need to pull KV credentials: `vercel env pull .env.local`. Without these, the KV-dependent features silently degrade -- no errors, but no persistence either.
+
+**Graceful degradation**: If KV is not available, the bot still answers questions. It just cannot:
+- Save or retrieve knowledge base entries
+- Store or process feedback (thumbs up/down)
+- Cache the repo index (rebuilds on every request)
+
+## Progress Message Not Updating
+
+**Symptom**: The thinking message appears but the status line never changes.
+
+**Possible causes:**
+
+- **Slack API rate limits**: The bot calls `chat.update` on every tool call. If Slack rate-limits these calls, updates will be silently dropped.
+- **The bot lacks `chat:write` scope**: This is unlikely if the bot can post messages at all, but double-check the OAuth scopes.
+- **The message was deleted**: If someone deletes the thinking message while the bot is processing, `chat.update` calls will fail silently (the handler does not crash, it just continues).
+
+## Issue Creation Fails After Checkmark Reaction
+
+**Symptom**: You react with :white_check_mark: but no issue is created.
+
+**Check:**
+
+- **Is `reactions:read` scope granted?** Without this, the bot does not receive `reaction_added` events.
+- **Was the reaction on the bot's message?** The handler verifies that the reacted message was posted by the bot. If someone copies the proposal text into their own message and you react to that, nothing happens.
+- **Does the PAT have Issues (read/write) permission?** Creating issues requires write access. If the PAT only has read access, the API call will fail.
+- **Check Vercel logs**: The error is logged with the message "Battle Mage reaction handler error".
+
+## Still Stuck?
+
+1. Check Vercel function logs (Dashboard > your project > Logs)
+2. Check Slack app activity logs (api.slack.com/apps > your app > App Activity Log)
+3. Open a GitHub issue with the `bug` label, including the error message and steps to reproduce

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,172 @@
+# Usage Guide
+
+Battle Mage is a Slack bot that answers questions about your GitHub codebase. Mention it with `@bm` to ask a question. It reads your code, searches for patterns, checks issues and PRs, and replies in-thread.
+
+## Asking Questions
+
+Mention the bot in any channel where it is installed:
+
+```
+@bm Where is the authentication middleware defined?
+```
+
+```
+@bm What changed in the last week?
+```
+
+```
+@bm How does the payment processing pipeline work?
+```
+
+The bot will:
+
+1. Post a thinking message with live status updates
+2. Search your codebase, read relevant files, and check issues/PRs
+3. Delete the thinking message and post the final answer with reference links
+
+All replies go in-thread. The bot never posts at channel root.
+
+## Thread Follow-Ups
+
+Once the bot has replied in a thread, you can send follow-up messages **without re-mentioning** it:
+
+```
+@bm How does user authentication work?
+  [bot answers]
+
+What about the password reset flow?
+  [bot answers -- no @bm needed]
+
+Can you show me the relevant tests?
+  [bot answers]
+```
+
+The bot checks whether it has already replied in the thread. If it has, it treats any new message in that thread as a follow-up and responds automatically.
+
+> **Tip**: This only works in threads where the bot has already posted. If you start a new thread, you need to @mention the bot again.
+
+## What Kinds of Questions Work Well
+
+Battle Mage has access to seven tools for exploring your codebase:
+
+| Tool | What it does |
+|------|-------------|
+| `search_code` | Find functions, classes, patterns, keywords across the repo |
+| `read_file` | Read file contents or list directory entries |
+| `list_issues` | List open/closed issues, look up specific issues by number |
+| `list_commits` | Show recent commits on main with dates |
+| `list_prs` | Show recent PRs (open, merged, closed) with dates |
+| `create_issue` | Propose a new GitHub issue (requires your confirmation) |
+| `save_knowledge` | Save a correction to the persistent knowledge base |
+
+**Good questions**:
+
+- "Where is X defined?" -- the bot searches for X and reads the file
+- "How does feature Y work?" -- the bot searches, reads relevant files, and explains
+- "What's changed recently?" -- the bot checks commits, PRs, and issues
+- "What's the status of issue #42?" -- the bot looks up the specific issue
+- "What are the open bugs?" -- the bot lists issues filtered by labels
+- "Show me the tests for the auth module" -- the bot searches for test files
+
+**Less effective questions**:
+
+- Extremely broad questions like "explain the entire codebase" -- the bot has a budget of 15 tool rounds per question, so it cannot read every file
+- Questions about runtime behavior or logs -- the bot has read access to code, not production systems
+- Questions about other repositories -- the bot is scoped to a single repo
+
+> **Tip**: If the bot's answer is too shallow, ask a more specific follow-up. "How does the auth module work?" is broad. "How does the auth middleware validate JWT tokens?" is specific enough for the bot to find exactly the right code.
+
+## Creating GitHub Issues
+
+Ask the bot to create an issue:
+
+```
+@bm Can you file a bug for the login timeout on Safari?
+```
+
+The bot will draft a proposal with a title, body, and suggested labels. It will **not** create the issue immediately. Instead, you will see:
+
+```
+[analysis and context]
+
+───────────────────
+Proposed Issue: Fix login timeout on Safari
+Labels: bug
+
+[issue body with steps to reproduce, context, etc.]
+
+React with :white_check_mark: to create this issue, or ignore to cancel.
+```
+
+To confirm, add a :white_check_mark: (checkmark) reaction to the bot's message. The bot will create the issue on GitHub and reply with a link:
+
+```
+:white_check_mark: Created issue #47: Fix login timeout on Safari
+```
+
+If you do not react, nothing happens. The proposal is discarded.
+
+> **Why the confirmation step?** The bot should never create issues without explicit human approval. This prevents accidental issue spam and lets you review the proposed title and description first.
+
+## Correcting the Bot
+
+When the bot gets something wrong, you have two options:
+
+### Option 1: Reply with the correction
+
+Just tell the bot what was wrong in the thread:
+
+```
+@bm Where does the config file live?
+  [bot says config/settings.php]
+
+No, we moved that to config/app.php last month.
+  [bot saves correction to knowledge base]
+```
+
+The bot uses the `save_knowledge` tool to persist the correction in Vercel KV. Future answers will include this correction in the system prompt.
+
+### Option 2: Thumbs down and explain
+
+React with :thumbsdown: to the bot's answer. The bot will:
+
+1. Record negative feedback
+2. Check for stale knowledge base entries related to the answer and remove them
+3. Check if the answer referenced documentation files that may be outdated
+4. Reply asking what was wrong
+
+Then explain the issue in the thread, and the bot will save the correction.
+
+## Feedback Reactions
+
+React to any bot answer with:
+
+- **:thumbsup:** -- The bot records positive feedback silently (adds a :brain: reaction to acknowledge). Over time, positive feedback helps the bot understand what answer style works well for your team.
+
+- **:thumbsdown:** -- The bot takes corrective action (see above) and asks for more detail.
+
+Feedback is stored in Vercel KV and injected into the system prompt. The bot sees a summary of what worked and what did not when composing future answers.
+
+> **Note**: Feedback context expires after 7 days. If you react to a very old message, the bot will not have the Q&A context to process the feedback.
+
+## Tips for Getting Better Answers
+
+1. **Be specific**. "How does auth work?" is vague. "How does the JWT validation middleware handle expired tokens?" gives the bot a clear search target.
+
+2. **Ask about code, not opinions**. The bot excels at "where is X?", "how does Y work?", and "what changed?". It is less useful for design advice or architecture opinions.
+
+3. **Use follow-up threads**. Start broad, then narrow down. The bot handles multi-turn conversations naturally.
+
+4. **Correct mistakes immediately**. The sooner you correct the bot, the sooner the knowledge base improves. Corrections persist across conversations.
+
+5. **Watch the progress messages**. The thinking message shows what the bot is doing (searching for "auth middleware", reading `src/auth.ts`, etc.). If it is searching for the wrong thing, you can post a follow-up to redirect it.
+
+6. **Leverage recency**. The bot is date-aware and prefers recent activity. Questions like "what shipped this week?" or "any new bugs?" work well because the bot checks commits, PRs, and issues with date context.
+
+## Limitations
+
+- **15 tool rounds per question**. The bot budgets its tool calls. For very complex questions, it may answer with partial information and suggest follow-ups.
+- **Read-only GitHub access**. The bot can read code and create issues (with confirmation), but cannot push code, merge PRs, or modify files.
+- **Single repository**. The bot is configured to read one repository. It cannot cross-reference multiple repos.
+- **No runtime access**. The bot reads source code and GitHub metadata. It does not have access to logs, databases, or production environments.
+- **Slack formatting**. The bot outputs Slack mrkdwn, which does not support GitHub-flavored markdown features like tables or task lists.

--- a/src/lib/auto-correct.test.ts
+++ b/src/lib/auto-correct.test.ts
@@ -9,9 +9,9 @@ import type { KnowledgeEntry } from "./knowledge";
 
 describe("identifyStaleKBEntries", () => {
   it("returns KB entries that mention referenced file paths", () => {
-    const references = ["app/Services/Auth/LoginService.php", "config/auth.php"];
+    const references = ["src/services/auth/login.ts", "src/config/auth.ts"];
     const kbEntries: KnowledgeEntry[] = [
-      { entry: "The auth module lives in app/Services/Auth, not app/Http/Auth", timestamp: "2026-03-28" },
+      { entry: "The auth module lives in src/services/auth, not src/controllers/auth", timestamp: "2026-03-28" },
       { entry: "Database migrations use timestamps not sequential IDs", timestamp: "2026-03-29" },
     ];
 
@@ -21,9 +21,9 @@ describe("identifyStaleKBEntries", () => {
   });
 
   it("matches KB entries by topic keywords, not just exact paths", () => {
-    const references = ["app/Http/Controllers/AuthController.php"];
+    const references = ["src/controllers/AuthController.ts"];
     const kbEntries: KnowledgeEntry[] = [
-      { entry: "Auth uses Laravel Sanctum, not Passport", timestamp: "2026-03-28" },
+      { entry: "Auth uses JWT tokens, not session cookies", timestamp: "2026-03-28" },
       { entry: "Redis cache TTL is 3600 seconds", timestamp: "2026-03-29" },
     ];
 
@@ -33,9 +33,9 @@ describe("identifyStaleKBEntries", () => {
   });
 
   it("returns empty array when no KB entries match", () => {
-    const references = ["app/Models/User.php"];
+    const references = ["src/models/User.ts"];
     const kbEntries: KnowledgeEntry[] = [
-      { entry: "Deploy uses Docker Alpine, not Ubuntu", timestamp: "2026-03-28" },
+      { entry: "Deploy uses nginx, not Apache", timestamp: "2026-03-28" },
     ];
 
     const stale = identifyStaleKBEntries(references, kbEntries);
@@ -43,7 +43,7 @@ describe("identifyStaleKBEntries", () => {
   });
 
   it("returns empty array when no KB entries exist", () => {
-    const stale = identifyStaleKBEntries(["app/Models/User.php"], []);
+    const stale = identifyStaleKBEntries(["src/models/User.ts"], []);
     expect(stale).toHaveLength(0);
   });
 
@@ -59,21 +59,21 @@ describe("identifyStaleKBEntries", () => {
 describe("identifyStaleDocReferences", () => {
   it("returns references that are doc/markdown files", () => {
     const references = [
-      "app/Models/User.php",
-      "docs/deployment/gcp-cloud-run.md",
+      "src/models/User.ts",
+      "docs/deployment/setup.md",
       "README.md",
-      "config/auth.php",
+      "src/config/auth.ts",
     ];
 
     const stale = identifyStaleDocReferences(references);
-    expect(stale).toContain("docs/deployment/gcp-cloud-run.md");
+    expect(stale).toContain("docs/deployment/setup.md");
     expect(stale).toContain("README.md");
-    expect(stale).not.toContain("app/Models/User.php");
-    expect(stale).not.toContain("config/auth.php");
+    expect(stale).not.toContain("src/models/User.ts");
+    expect(stale).not.toContain("src/config/auth.ts");
   });
 
   it("returns empty array when no doc references", () => {
-    const stale = identifyStaleDocReferences(["app/Models/User.php", "config/auth.php"]);
+    const stale = identifyStaleDocReferences(["src/models/User.ts", "src/config/auth.ts"]);
     expect(stale).toHaveLength(0);
   });
 
@@ -85,8 +85,8 @@ describe("identifyStaleDocReferences", () => {
 describe("buildCorrectionActions", () => {
   it("returns KB removals when stale KB entries found", () => {
     const actions = buildCorrectionActions(
-      ["app/Services/Auth/LoginService.php"],
-      [{ entry: "Auth lives in app/Services/Auth", timestamp: "2026-03-28" }],
+      ["src/services/auth/login.ts"],
+      [{ entry: "Auth lives in src/services/auth", timestamp: "2026-03-28" }],
     );
     expect(actions.kbEntriesToRemove).toHaveLength(1);
     expect(actions.kbEntriesToRemove[0].entry).toContain("Auth");
@@ -94,17 +94,17 @@ describe("buildCorrectionActions", () => {
 
   it("returns doc fix proposals when doc references found", () => {
     const actions = buildCorrectionActions(
-      ["docs/deployment/gcp-cloud-run.md", "app/Models/User.php"],
+      ["docs/deployment/setup.md", "src/models/User.ts"],
       [],
     );
-    expect(actions.docsToProposeFix).toContain("docs/deployment/gcp-cloud-run.md");
-    expect(actions.docsToProposeFix).not.toContain("app/Models/User.php");
+    expect(actions.docsToProposeFix).toContain("docs/deployment/setup.md");
+    expect(actions.docsToProposeFix).not.toContain("src/models/User.ts");
   });
 
   it("returns both KB removals and doc proposals when both apply", () => {
     const actions = buildCorrectionActions(
-      ["docs/deployment/gcp-cloud-run.md", "app/Services/Auth/LoginService.php"],
-      [{ entry: "Auth uses Sanctum", timestamp: "2026-03-28" }],
+      ["docs/deployment/setup.md", "src/services/auth/login.ts"],
+      [{ entry: "Auth uses JWT", timestamp: "2026-03-28" }],
     );
     expect(actions.kbEntriesToRemove.length).toBeGreaterThan(0);
     expect(actions.docsToProposeFix.length).toBeGreaterThan(0);
@@ -112,7 +112,7 @@ describe("buildCorrectionActions", () => {
 
   it("returns empty actions when nothing to correct", () => {
     const actions = buildCorrectionActions(
-      ["app/Models/User.php"],
+      ["src/models/User.ts"],
       [{ entry: "Redis TTL is 3600", timestamp: "2026-03-28" }],
     );
     expect(actions.kbEntriesToRemove).toHaveLength(0);
@@ -129,7 +129,7 @@ describe("buildCorrectionActions", () => {
 
   it("hasActions is false when empty", () => {
     const actions = buildCorrectionActions(
-      ["app/Models/User.php"],
+      ["src/models/User.ts"],
       [],
     );
     expect(actions.hasActions).toBe(false);

--- a/src/lib/auto-correct.ts
+++ b/src/lib/auto-correct.ts
@@ -14,7 +14,7 @@ import type { KnowledgeEntry } from "./knowledge";
 // ── Identify stale KB entries ────────────────────────────────────────
 // A KB entry is "stale" if it mentions the same files or topics as the
 // answer's references. This is a heuristic — it catches entries like
-// "Auth uses Sanctum" when the answer referenced auth files.
+// "Auth uses JWT" when the answer referenced auth files.
 
 function extractKeywords(path: string): string[] {
   // Extract meaningful words from a file path, splitting camelCase/PascalCase

--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -66,9 +66,9 @@ describe("assembleSystemPrompt", () => {
     it("includes CLAUDE.md when provided", () => {
       const prompt = assembleSystemPrompt({
         ...baseArgs,
-        claudeMd: "# My Project\nLaravel + GCP",
+        claudeMd: "# My Project\nNext.js + PostgreSQL",
       });
-      expect(prompt).toContain("Laravel + GCP");
+      expect(prompt).toContain("Next.js + PostgreSQL");
       expect(prompt).toContain("Project Context");
     });
 

--- a/src/lib/repo-index.test.ts
+++ b/src/lib/repo-index.test.ts
@@ -3,32 +3,32 @@ import { classifyTopics, isIndexStale, buildIndexSummary } from "./repo-index";
 
 describe("classifyTopics", () => {
   it("classifies auth-related files", () => {
-    const paths = ["app/Services/Auth/LoginService.php", "config/auth.php", "README.md"];
+    const paths = ["src/services/auth/login.ts", "src/config/auth.ts", "README.md"];
     const topics = classifyTopics(paths);
-    expect(topics["authentication"]).toContain("app/Services/Auth/LoginService.php");
-    expect(topics["authentication"]).toContain("config/auth.php");
+    expect(topics["authentication"]).toContain("src/services/auth/login.ts");
+    expect(topics["authentication"]).toContain("src/config/auth.ts");
     expect(topics["authentication"]).not.toContain("README.md");
   });
 
   it("classifies deployment files", () => {
-    const paths = ["Dockerfile", "docs/deployment/gcp-cloud-run.md", ".github/workflows/deploy.yml"];
+    const paths = ["Dockerfile", "docs/deployment/setup.md", ".github/workflows/deploy.yml"];
     const topics = classifyTopics(paths);
     expect(topics["deployment"]).toContain("Dockerfile");
-    expect(topics["deployment"]).toContain("docs/deployment/gcp-cloud-run.md");
+    expect(topics["deployment"]).toContain("docs/deployment/setup.md");
     expect(topics["deployment"]).toContain(".github/workflows/deploy.yml");
   });
 
   it("classifies database/migration files", () => {
-    const paths = ["database/migrations/001_create_users.php", "config/database.php"];
+    const paths = ["db/migrations/001_create_users.sql", "src/config/database.ts"];
     const topics = classifyTopics(paths);
-    expect(topics["database"]).toContain("database/migrations/001_create_users.php");
-    expect(topics["database"]).toContain("config/database.php");
+    expect(topics["database"]).toContain("db/migrations/001_create_users.sql");
+    expect(topics["database"]).toContain("src/config/database.ts");
   });
 
   it("classifies test files", () => {
-    const paths = ["tests/Unit/AuthTest.php", "spec/models/user.spec.ts"];
+    const paths = ["tests/auth/login.test.ts", "spec/models/user.spec.ts"];
     const topics = classifyTopics(paths);
-    expect(topics["testing"]).toContain("tests/Unit/AuthTest.php");
+    expect(topics["testing"]).toContain("tests/auth/login.test.ts");
     expect(topics["testing"]).toContain("spec/models/user.spec.ts");
   });
 
@@ -46,16 +46,16 @@ describe("classifyTopics", () => {
   });
 
   it("classifies API/routing files", () => {
-    const paths = ["routes/api.php", "app/Http/Controllers/UserController.php"];
+    const paths = ["src/routes/api.ts", "src/controllers/UserController.ts"];
     const topics = classifyTopics(paths);
-    expect(topics["api"]).toContain("routes/api.php");
-    expect(topics["api"]).toContain("app/Http/Controllers/UserController.php");
+    expect(topics["api"]).toContain("src/routes/api.ts");
+    expect(topics["api"]).toContain("src/controllers/UserController.ts");
   });
 
   it("classifies configuration files", () => {
-    const paths = ["config/app.php", ".env.example", "docker-compose.yml"];
+    const paths = ["config/app.json", ".env.example", "docker-compose.yml"];
     const topics = classifyTopics(paths);
-    expect(topics["configuration"]).toContain("config/app.php");
+    expect(topics["configuration"]).toContain("config/app.json");
     expect(topics["configuration"]).toContain(".env.example");
   });
 
@@ -65,21 +65,21 @@ describe("classifyTopics", () => {
   });
 
   it("ignores vendor/node_modules paths", () => {
-    const paths = ["vendor/laravel/framework/Auth.php", "node_modules/express/index.js", "app/Auth.php"];
+    const paths = ["vendor/some-lib/auth.js", "node_modules/express/index.js", "src/auth.ts"];
     const topics = classifyTopics(paths);
     // vendor and node_modules files should not appear in any topic
     const allPaths = Object.values(topics).flat();
-    expect(allPaths).not.toContain("vendor/laravel/framework/Auth.php");
+    expect(allPaths).not.toContain("vendor/some-lib/auth.js");
     expect(allPaths).not.toContain("node_modules/express/index.js");
-    expect(allPaths).toContain("app/Auth.php");
+    expect(allPaths).toContain("src/auth.ts");
   });
 
   it("a file can appear in multiple topics", () => {
-    const paths = ["tests/Auth/LoginTest.php"];
+    const paths = ["tests/auth/login.test.ts"];
     const topics = classifyTopics(paths);
     // This is both a test file AND auth-related
-    expect(topics["testing"]).toContain("tests/Auth/LoginTest.php");
-    expect(topics["authentication"]).toContain("tests/Auth/LoginTest.php");
+    expect(topics["testing"]).toContain("tests/auth/login.test.ts");
+    expect(topics["authentication"]).toContain("tests/auth/login.test.ts");
   });
 });
 
@@ -100,12 +100,12 @@ describe("isIndexStale", () => {
 describe("buildIndexSummary", () => {
   it("formats topics as a compact text summary", () => {
     const topics = {
-      authentication: ["app/Services/Auth/LoginService.php", "config/auth.php"],
+      authentication: ["src/services/auth/login.ts", "src/config/auth.ts"],
       deployment: ["Dockerfile"],
     };
     const summary = buildIndexSummary(topics);
     expect(summary).toContain("authentication");
-    expect(summary).toContain("app/Services/Auth/LoginService.php");
+    expect(summary).toContain("src/services/auth/login.ts");
     expect(summary).toContain("deployment");
     expect(summary).toContain("Dockerfile");
   });
@@ -116,7 +116,7 @@ describe("buildIndexSummary", () => {
 
   it("caps file paths per topic to keep summary compact", () => {
     const topics = {
-      testing: Array.from({ length: 20 }, (_, i) => `tests/test${i}.php`),
+      testing: Array.from({ length: 20 }, (_, i) => `tests/test${i}.ts`),
     };
     const summary = buildIndexSummary(topics);
     // Should not list all 20 files — capped for prompt size

--- a/src/tools/save-knowledge.ts
+++ b/src/tools/save-knowledge.ts
@@ -11,7 +11,7 @@ export const saveKnowledgeTool: Tool = {
       entry: {
         type: "string",
         description:
-          "A concise factual statement to remember. Write it as a standalone fact, not a conversation snippet. E.g. 'The auth module lives in app/Services/Auth, not app/Http/Auth' or 'The Tradier API rate limit is 120 req/min, not 60'.",
+          "A concise factual statement to remember. Write it as a standalone fact, not a conversation snippet. E.g. 'The auth module lives in app/Services/Auth, not app/Http/Auth' or 'The API rate limit is 120 req/min, not 60'.",
       },
     },
     required: ["entry"],


### PR DESCRIPTION
## Summary

Production-quality documentation for open-source release.

### New docs (10 files)

| Doc | Lines | Covers |
|-----|-------|--------|
| `docs/setup.md` | 243 | Slack app, GitHub PAT, Vercel deploy, env vars, first test |
| `docs/usage.md` | 172 | Questions, threads, issues, corrections, feedback |
| `docs/architecture.md` | 248 | Agent loop, tools, system prompt, design decisions |
| `docs/contributing.md` | 219 | Fork workflow, TDD, CI, branch protection |
| `docs/troubleshooting.md` | 131 | 8 problem categories with diagnostics |
| `docs/features/repo-index.md` | 98 | Lazy-rebuilt topic map |
| `docs/features/knowledge-base.md` | 117 | KV corrections system |
| `docs/features/source-hierarchy.md` | 92 | 5-level truth weighting |
| `docs/features/auto-correction.md` | 126 | Thumbs-down auto-fix |
| `docs/features/progress-ux.md` | 116 | Live thinking updates |

### README rewrite

Slimmed from 327 → 95 lines. Now a brief overview with a table-of-contents linking to the docs tree. All setup/usage/architecture detail moved to dedicated docs.

### CLAUDE.md update

Project structure updated with all current files (7 tools, 9 lib modules, full docs tree).

### Proprietary cleanup

All references to internal project details replaced with generic equivalents across source files, tests, and docs. Final scan confirmed zero matches.

## Verification

- 100 tests pass
- Typecheck clean
- Zero proprietary references

🤖 Generated with [Claude Code](https://claude.com/claude-code)