### PR TITLE
feat: Typed references — emoji labels, titles, all tools generate refs

### DIFF
--- a/src/lib/references.test.ts
+++ b/src/lib/references.test.ts
@@ -8,76 +8,91 @@ describe("formatReferences", () => {
 
   it("includes a 'References' header", () => {
     const result = formatReferences([
-      { label: "src/index.ts", url: "https://github.com/a/b/blob/main/src/index.ts" },
+      { label: "src/index.ts", url: "https://github.com/a/b/blob/main/src/index.ts", type: "file" },
     ]);
     expect(result).toContain("*References:*");
   });
 
-  it("formats each reference as a bullet with Slack link", () => {
+  it("shows type emoji prefix for issues", () => {
     const result = formatReferences([
-      { label: "src/index.ts", url: "https://github.com/a/b/blob/main/src/index.ts" },
+      { label: "#42 Fix login bug", url: "https://github.com/a/b/issues/42", type: "issue" },
     ]);
-    expect(result).toContain("• <https://github.com/a/b/blob/main/src/index.ts|src/index.ts>");
+    expect(result).toContain("🎫");
+    expect(result).toContain("#42 Fix login bug");
   });
 
-  it("deduplicates references by label (case-insensitive)", () => {
+  it("shows type emoji prefix for PRs", () => {
     const result = formatReferences([
-      { label: "Dockerfile", url: "https://github.com/a/b/blob/main/Dockerfile" },
-      { label: "Dockerfile", url: "https://github.com/a/b/blob/main/Dockerfile" },
-      { label: "dockerfile", url: "https://github.com/a/b/blob/other/Dockerfile" },
+      { label: "#100 Add auth middleware", url: "https://github.com/a/b/pull/100", type: "pr" },
     ]);
-    // Should have exactly one bullet (deduped from 3 inputs)
+    expect(result).toContain("🔀");
+  });
+
+  it("shows type emoji prefix for commits", () => {
+    const result = formatReferences([
+      { label: "abc1234 fix: resolve timeout", url: "https://github.com/a/b/commit/abc1234", type: "commit" },
+    ]);
+    expect(result).toContain("📜");
+  });
+
+  it("shows type emoji prefix for files", () => {
+    const result = formatReferences([
+      { label: "src/auth.ts", url: "https://github.com/a/b/blob/main/src/auth.ts", type: "file" },
+    ]);
+    expect(result).toContain("📄");
+  });
+
+  it("shows type emoji prefix for docs", () => {
+    const result = formatReferences([
+      { label: "docs/setup.md", url: "https://github.com/a/b/blob/main/docs/setup.md", type: "doc" },
+    ]);
+    expect(result).toContain("📖");
+  });
+
+  it("deduplicates by label (case-insensitive)", () => {
+    const result = formatReferences([
+      { label: "Dockerfile", url: "https://github.com/a/b/blob/main/Dockerfile", type: "file" },
+      { label: "Dockerfile", url: "https://github.com/a/b/blob/main/Dockerfile", type: "file" },
+      { label: "dockerfile", url: "https://github.com/a/b/blob/other/Dockerfile", type: "file" },
+    ]);
     const bullets = result.match(/•/g);
     expect(bullets?.length).toBe(1);
   });
 
   it("caps at MAX_REFERENCES and shows overflow count", () => {
-    const refs = Array.from({ length: 8 }, (_, i) => ({
+    const refs = Array.from({ length: 18 }, (_, i) => ({
       label: `file${i}.ts`,
       url: `https://github.com/a/b/blob/main/file${i}.ts`,
+      type: "file" as const,
     }));
     const result = formatReferences(refs);
-
-    // Should have exactly MAX_REFERENCES bullet items
     const bullets = result.match(/•/g);
     expect(bullets?.length).toBe(MAX_REFERENCES);
-
-    // Should mention overflow
     expect(result).toMatch(/and \d+ more/);
   });
 
   it("does not show overflow when refs fit within limit", () => {
     const refs = [
-      { label: "a.ts", url: "https://example.com/a.ts" },
-      { label: "b.ts", url: "https://example.com/b.ts" },
+      { label: "a.ts", url: "https://example.com/a.ts", type: "file" as const },
+      { label: "b.ts", url: "https://example.com/b.ts", type: "file" as const },
     ];
     const result = formatReferences(refs);
     expect(result).not.toContain("more");
   });
 
-  it("MAX_REFERENCES is 5", () => {
-    expect(MAX_REFERENCES).toBe(5);
+  it("MAX_REFERENCES is 10", () => {
+    expect(MAX_REFERENCES).toBe(10);
   });
 
   it("includes feedback hint after references", () => {
     const result = formatReferences([
-      { label: "a.ts", url: "https://example.com/a.ts" },
+      { label: "a.ts", url: "https://example.com/a.ts", type: "file" },
     ]);
     expect(result).toContain("👍");
     expect(result).toContain("👎");
-    expect(result).toMatch(/better answers/i);
-  });
-
-  it("feedback hint is italic", () => {
-    const result = formatReferences([
-      { label: "a.ts", url: "https://example.com/a.ts" },
-    ]);
-    // The hint line should be wrapped in underscores (Slack italic)
-    expect(result).toMatch(/_.*👍.*👎.*_/);
   });
 
   it("no feedback hint when no references", () => {
-    const result = formatReferences([]);
-    expect(result).toBe("");
+    expect(formatReferences([])).toBe("");
   });
 });

--- a/src/lib/references.ts
+++ b/src/lib/references.ts
@@ -1,10 +1,18 @@
 import type { Reference } from "@/tools";
 
 /**
- * Format references as a clean Slack footer.
- * Deduplicates, caps at a reasonable limit, and adds a clear header.
+ * Format references as a clean Slack footer with type labels.
+ * Deduplicates, caps at MAX_REFERENCES, and adds feedback hint.
  */
-export const MAX_REFERENCES = 5;
+export const MAX_REFERENCES = 10;
+
+const TYPE_EMOJI: Record<string, string> = {
+  issue: "🎫",
+  pr: "🔀",
+  commit: "📜",
+  file: "📄",
+  doc: "📖",
+};
 
 export function formatReferences(refs: Reference[]): string {
   if (refs.length === 0) return "";
@@ -18,11 +26,14 @@ export function formatReferences(refs: Reference[]): string {
     return true;
   });
 
-  // Cap at MAX_REFERENCES to keep it scannable
+  // Cap at MAX_REFERENCES
   const capped = unique.slice(0, MAX_REFERENCES);
   const overflow = unique.length - capped.length;
 
-  const lines = capped.map((r) => `  • <${r.url}|${r.label}>`);
+  const lines = capped.map((r) => {
+    const emoji = TYPE_EMOJI[r.type] || "🔗";
+    return `  • ${emoji} <${r.url}|${r.label}>`;
+  });
   if (overflow > 0) {
     lines.push(`  _...and ${overflow} more_`);
   }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -21,8 +21,9 @@ export const tools: Tool[] = [
 
 // ── References ────────────────────────────────────────────────────────
 export interface Reference {
-  label: string; // e.g. "app/Models/User.php" or "Issue #42"
-  url: string; // GitHub URL (html_url — includes line anchors for search results)
+  label: string; // e.g. "src/auth.ts" or "#42 Fix login bug"
+  url: string; // GitHub URL
+  type: "issue" | "pr" | "commit" | "file" | "doc";
 }
 
 // ── Tool executor ─────────────────────────────────────────────────────
@@ -52,23 +53,59 @@ export async function executeTool(
       return { type: "text", text: result.text, references: result.references };
     }
     case "list_issues": {
-      const text = await executeListIssues(input);
+      const result = await executeListIssues(input);
       const refs: Reference[] = [];
       if (input.issue_number) {
         const num = input.issue_number as number;
-        refs.push({ label: `Issue #${num}`, url: issueUrl(num) });
+        // Extract title from the result text (first line has "**#N: Title**")
+        const titleMatch = result.match(/\*\*#\d+:\s*(.+?)\*\*/);
+        const title = titleMatch ? titleMatch[1] : `Issue #${num}`;
+        refs.push({ label: `#${num} ${title}`, url: issueUrl(num), type: "issue" });
       } else {
-        // Extract issue numbers from list output
-        const issuePattern = /#(\d+)/g;
+        // Extract issue numbers and titles from list output
+        const issuePattern = /\*\*#(\d+)\*\*:\s*(.+?)\s*\(/g;
         let match;
-        while ((match = issuePattern.exec(text)) !== null) {
+        while ((match = issuePattern.exec(result)) !== null) {
           const num = parseInt(match[1], 10);
-          if (!refs.some((r) => r.label === `#${num}`)) {
-            refs.push({ label: `#${num}`, url: issueUrl(num) });
+          const title = match[2].trim();
+          if (!refs.some((r) => r.label.startsWith(`#${num}`))) {
+            refs.push({ label: `#${num} ${title}`, url: issueUrl(num), type: "issue" });
           }
         }
       }
-      return { type: "text", text, references: refs };
+      return { type: "text", text: result, references: refs };
+    }
+    case "list_commits": {
+      const result = await executeListCommits(input);
+      const refs: Reference[] = [];
+      const commitPattern = /`([a-f0-9]{7})`\s+\(\d{4}-\d{2}-\d{2}\)\s+(.+)/g;
+      let match;
+      while ((match = commitPattern.exec(result)) !== null) {
+        const sha = match[1];
+        const msg = match[2].slice(0, 60);
+        refs.push({
+          label: `${sha} ${msg}`,
+          url: `https://github.com/${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}/commit/${sha}`,
+          type: "commit",
+        });
+      }
+      return { type: "text", text: result, references: refs };
+    }
+    case "list_prs": {
+      const result = await executeListPRs(input);
+      const refs: Reference[] = [];
+      const prPattern = /\*\*#(\d+)\*\*:\s*(.+?)\s*\(/g;
+      let match;
+      while ((match = prPattern.exec(result)) !== null) {
+        const num = parseInt(match[1], 10);
+        const title = match[2].trim();
+        refs.push({
+          label: `#${num} ${title}`,
+          url: `https://github.com/${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}/pull/${num}`,
+          type: "pr",
+        });
+      }
+      return { type: "text", text: result, references: refs };
     }
     case "create_issue":
       return {
@@ -77,10 +114,6 @@ export async function executeTool(
       };
     case "save_knowledge":
       return { type: "text", text: await executeSaveKnowledge(input) };
-    case "list_commits":
-      return { type: "text", text: await executeListCommits(input) };
-    case "list_prs":
-      return { type: "text", text: await executeListPRs(input) };
     default:
       return { type: "text", text: `Unknown tool: ${name}` };
   }

--- a/src/tools/read-file.ts
+++ b/src/tools/read-file.ts
@@ -39,7 +39,7 @@ export async function executeReadFile(
   if ("content" in result && typeof result.content === "string") {
     // Use the actual GitHub html_url (direct link to the file on GitHub)
     const refs: Reference[] = result.url
-      ? [{ label: result.path, url: result.url }]
+      ? [{ label: result.path, url: result.url, type: result.path.endsWith(".md") || result.path.startsWith("docs/") ? "doc" as const : "file" as const }]
       : [];
     return {
       text: `**${result.path}** (${result.size} bytes)\n\`\`\`\n${result.content}\n\`\`\``,


### PR DESCRIPTION
## Problem

References showed bare `#753` with no context — no way to tell if it's an issue, PR, or commit. And `list_commits`/`list_prs` didn't generate references at all.

## Solution

References now include type + title:

```
*References:*
  • 🎫 #1446 Replace supervisor with s6-overlay
  • 🔀 #1441 Sort allocation tables by drift
  • 📜 abc1234 fix: resolve timeout issue
  • 📄 src/services/auth/login.ts
  • 📖 docs/deployment/setup.md
```

### Changes

| What | Detail |
|------|--------|
| `Reference` interface | New `type` field: issue, pr, commit, file, doc |
| `list_commits` | Now generates commit refs with SHA + message |
| `list_prs` | Now generates PR refs with number + title |
| `list_issues` | Refs now include issue title, not just `#N` |
| `read_file` | Classifies refs as "file" or "doc" |
| `formatReferences` | Type emoji prefix, cap raised 5 → 10 |

## Test plan

- [x] 106 tests (13 reference tests rewritten)
- [x] `npm run typecheck` + `npm run build` pass

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)