### PR TITLE
feat: Weighted reference ranking aligned with source-of-truth hierarchy

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -13,7 +13,7 @@ import { runAgent } from "@/lib/claude";
 import { createIssue } from "@/lib/github";
 import { parseProposalFromMessage } from "@/tools/create-issue";
 import { storeQAContext, getQAContext, saveFeedback } from "@/lib/feedback";
-import { formatReferences } from "@/lib/references";
+import { formatReferences, rankReferences } from "@/lib/references";
 import { getAllKnowledge } from "@/lib/knowledge";
 import { buildCorrectionActions } from "@/lib/auto-correct";
 import { buildThinkingMessage, THINKING_HEADER } from "@/lib/progress";
@@ -87,7 +87,8 @@ export async function POST(request: NextRequest) {
         }
 
         const text = toSlackMrkdwn(result.text);
-        const refsFooter = formatReferences(result.references);
+        const rankedRefs = rankReferences(result.references, result.text);
+        const refsFooter = formatReferences(rankedRefs);
 
         // Delete thinking message — the answer replaces it
         if (thinkingTs) {
@@ -210,7 +211,8 @@ export async function POST(request: NextRequest) {
         }
 
         const text = toSlackMrkdwn(result.text);
-        const refsFooter = formatReferences(result.references);
+        const rankedRefs = rankReferences(result.references, result.text);
+        const refsFooter = formatReferences(rankedRefs);
 
         if (thinkTs) {
           await deleteMessage(channel, thinkTs);

--- a/src/lib/references.test.ts
+++ b/src/lib/references.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatReferences, MAX_REFERENCES } from "./references";
+import { formatReferences, rankReferences, MAX_REFERENCES } from "./references";
 
 describe("formatReferences", () => {
   it("returns empty string when no refs", () => {
@@ -80,8 +80,8 @@ describe("formatReferences", () => {
     expect(result).not.toContain("more");
   });
 
-  it("MAX_REFERENCES is 10", () => {
-    expect(MAX_REFERENCES).toBe(10);
+  it("MAX_REFERENCES is 7", () => {
+    expect(MAX_REFERENCES).toBe(7);
   });
 
   it("includes feedback hint after references", () => {
@@ -94,5 +94,72 @@ describe("formatReferences", () => {
 
   it("no feedback hint when no references", () => {
     expect(formatReferences([])).toBe("");
+  });
+});
+
+describe("rankReferences", () => {
+  it("ranks source code files above docs", () => {
+    const refs = [
+      { label: "docs/setup.md", url: "https://example.com/docs", type: "doc" as const },
+      { label: "src/auth.ts", url: "https://example.com/auth", type: "file" as const },
+    ];
+    const ranked = rankReferences(refs, "some answer");
+    expect(ranked[0].label).toBe("src/auth.ts");
+    expect(ranked[1].label).toBe("docs/setup.md");
+  });
+
+  it("ranks test files above docs but below source code", () => {
+    const refs = [
+      { label: "docs/setup.md", url: "https://example.com/docs", type: "doc" as const },
+      { label: "tests/auth.test.ts", url: "https://example.com/test", type: "file" as const },
+      { label: "src/auth.ts", url: "https://example.com/auth", type: "file" as const },
+    ];
+    const ranked = rankReferences(refs, "some answer");
+    expect(ranked[0].label).toBe("src/auth.ts");
+    expect(ranked[1].label).toBe("tests/auth.test.ts");
+    expect(ranked[2].label).toBe("docs/setup.md");
+  });
+
+  it("boosts refs cited in the answer text", () => {
+    const refs = [
+      { label: "#100 Uncited issue", url: "https://example.com/100", type: "issue" as const },
+      { label: "#200 Cited issue", url: "https://example.com/200", type: "issue" as const },
+    ];
+    const ranked = rankReferences(refs, "As seen in #200, the fix was applied");
+    expect(ranked[0].label).toContain("#200");
+  });
+
+  it("ranks uncited issues/PRs/commits last", () => {
+    const refs = [
+      { label: "#50 Random issue", url: "https://example.com/50", type: "issue" as const },
+      { label: "src/index.ts", url: "https://example.com/src", type: "file" as const },
+      { label: "#99 Another issue", url: "https://example.com/99", type: "issue" as const },
+    ];
+    const ranked = rankReferences(refs, "some answer about index.ts");
+    expect(ranked[0].type).toBe("file");
+    expect(ranked[ranked.length - 1].type).toBe("issue");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(rankReferences([], "answer")).toEqual([]);
+  });
+
+  it("maintains order within same tier", () => {
+    const refs = [
+      { label: "src/a.ts", url: "https://example.com/a", type: "file" as const },
+      { label: "src/b.ts", url: "https://example.com/b", type: "file" as const },
+      { label: "src/c.ts", url: "https://example.com/c", type: "file" as const },
+    ];
+    const ranked = rankReferences(refs, "answer");
+    expect(ranked.map((r) => r.label)).toEqual(["src/a.ts", "src/b.ts", "src/c.ts"]);
+  });
+
+  it("cited doc ranks above uncited doc", () => {
+    const refs = [
+      { label: "docs/old.md", url: "https://example.com/old", type: "doc" as const },
+      { label: "docs/cited.md", url: "https://example.com/cited", type: "doc" as const },
+    ];
+    const ranked = rankReferences(refs, "as documented in docs/cited.md");
+    expect(ranked[0].label).toBe("docs/cited.md");
   });
 });

--- a/src/lib/references.ts
+++ b/src/lib/references.ts
@@ -1,10 +1,12 @@
 import type { Reference } from "@/tools";
 
 /**
- * Format references as a clean Slack footer with type labels.
- * Deduplicates, caps at MAX_REFERENCES, and adds feedback hint.
+ * Reference ranking and formatting.
+ *
+ * References are ranked to mirror the source-of-truth hierarchy:
+ *   code > tests > cited refs > docs > uncited list results
  */
-export const MAX_REFERENCES = 10;
+export const MAX_REFERENCES = 7;
 
 const TYPE_EMOJI: Record<string, string> = {
   issue: "🎫",
@@ -14,6 +16,70 @@ const TYPE_EMOJI: Record<string, string> = {
   doc: "📖",
 };
 
+// ── Test path detection ──────────────────────────────────────────────
+const TEST_PATTERNS = /\btests?\b|\.test\.|\.spec\.|__tests__/i;
+
+function isTestFile(label: string): boolean {
+  return TEST_PATTERNS.test(label);
+}
+
+// ── Score a reference by source-of-truth hierarchy ───────────────────
+function scoreRef(ref: Reference, answerText: string): number {
+  let score = 0;
+
+  // Tier 1: Source code files (non-doc, non-test) — highest trust
+  if (ref.type === "file" && !isTestFile(ref.label)) {
+    score += 50;
+  }
+
+  // Tier 2: Test files
+  if (ref.type === "file" && isTestFile(ref.label)) {
+    score += 40;
+  }
+
+  // Citation boost: ref mentioned in the answer text
+  // Check for label fragments: #number, file paths, SHA prefixes
+  const labelParts = ref.label.split(/\s+/);
+  for (const part of labelParts) {
+    if (part.length > 2 && answerText.includes(part)) {
+      score += 20;
+      break;
+    }
+  }
+
+  // Tier 4: Documentation
+  if (ref.type === "doc") {
+    score += 10;
+  }
+
+  // Tier 5: Uncited issues/PRs/commits get base score of 0
+
+  return score;
+}
+
+// ── Rank references by relevance ─────────────────────────────────────
+export function rankReferences(
+  refs: Reference[],
+  answerText: string,
+): Reference[] {
+  if (refs.length === 0) return [];
+
+  // Score each ref, then stable-sort descending
+  const scored = refs.map((ref, index) => ({
+    ref,
+    score: scoreRef(ref, answerText),
+    originalIndex: index,
+  }));
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.originalIndex - b.originalIndex; // stable within same score
+  });
+
+  return scored.map((s) => s.ref);
+}
+
+// ── Format references as Slack footer ────────────────────────────────
 export function formatReferences(refs: Reference[]): string {
   if (refs.length === 0) return "";
 


### PR DESCRIPTION
## Summary

References are now ranked by trustworthiness, mirroring the source-of-truth hierarchy that governs how answers are constructed.

### Scoring system

| Tier | Type | Score | Rationale |
|------|------|-------|-----------|
| 1 | Source code files | 50 | Code is truth |
| 2 | Test files | 40 | Encode expected behavior |
| — | Citation boost (any type mentioned in answer) | +20 | Agent explicitly cited it |
| 4 | Documentation | 10 | Can drift from reality |
| 5 | Uncited list results | 0 | Discovery artifacts |

A cited issue (#1446 mentioned in the answer) scores 20, ranking above uncited docs (10). A source code file scores 50 regardless of citation. This ensures the user sees the most trustworthy sources first.

### Before vs After

**Before:** 10 refs in tool-call order — issues dominating because `list_issues` fires first

**After:** 7 refs sorted by trust — code files first, cited items second, uncited noise last

### MAX_REFERENCES: 10 → 7

Fewer but more relevant. With ranking, every ref shown has earned its place.

## Files

| File | Change |
|------|--------|
| `src/lib/references.ts` | `rankReferences()` + scoring logic, cap 10→7 |
| `src/lib/references.test.ts` | 7 new tests for ranking |
| `src/app/api/slack/route.ts` | Call `rankReferences` before `formatReferences` |

## Test plan

- [x] 113 tests (7 new for ranking)
- [x] Code files rank above docs
- [x] Test files rank above docs but below code
- [x] Cited refs get boost regardless of type
- [x] Uncited list results rank last
- [x] Stable sort within same tier
- [x] `npm run typecheck` + `npm run build` pass

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)