### PR TITLE
docs: Sync with typed + ranked references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,8 @@ A Slack agent with Claude AI intelligence and GitHub repo access. Invoke via `@b
 - **Knowledge**: Vercel KV (corrections, feedback, repo index cache)
 - **Context**: CLAUDE.md + KB + feedback + repo index + source hierarchy + search strategy + recency/brevity rules
 - **Progress**: Live thinking messages with contextual emoji, deleted on answer
-- **Formatting**: Markdown-to-Slack mrkdwn conversion, deduplicated references (capped at 5)
-- **Auto-correct**: Thumbs-down removes stale KB entries, flags outdated docs
+- **Formatting**: Markdown-to-Slack mrkdwn conversion, typed references with emoji (📄📖🎫🔀📜), ranked by source-of-truth hierarchy, capped at 7
+- **Auto-correct**: Thumbs-down flags stale KB entries for user confirmation, stores pending correction state
 
 ## Development
 
@@ -53,7 +53,7 @@ src/
     auto-correct.ts       — Stale KB entry detection and doc reference flagging
     progress.ts           — Progress message formatter (tool → emoji + status)
     mrkdwn.ts             — Markdown → Slack mrkdwn converter
-    references.ts         — Reference deduplication, capping, and formatting
+    references.ts         — Typed references: ranking, dedup, emoji formatting
   tools/
     index.ts              — Tool registry and executor
     search-code.ts        — GitHub code search tool

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For the full architecture walkthrough, see [docs/architecture.md](docs/architect
 ## Testing
 
 ```bash
-npm test              # 103 tests across 7 files
+npm test              # 113 tests across 7 files
 npm run test:watch    # Watch mode
 npm run typecheck     # TypeScript strict
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,9 +148,9 @@ if loop exhausted:
 
 Key behaviors:
 
-- **References are collected from tool results**, not from Claude's text. Each tool that accesses a file or issue returns structured `Reference` objects with labels and GitHub URLs.
-- **References are deduplicated by URL** during collection and by label (case-insensitive) during formatting.
-- **References are capped at 5** in the final output to keep the footer scannable.
+- **References are collected from tool results**, not from Claude's text. Each tool that accesses a file or issue returns structured `Reference` objects with labels, URLs, and types (`file`, `doc`, `issue`, `pr`, `commit`).
+- **References are ranked** by the source-of-truth hierarchy before display: code files first, then tests, then cited refs, then docs, then uncited list results. This is done by `rankReferences()` in `references.ts`.
+- **References are deduplicated** by label (case-insensitive) during formatting and **capped at 7**.
 - **Issue proposals are extracted** from `create_issue` tool calls and attached to the result separately. They are formatted with a confirmation prompt in the Slack message.
 
 ## Tool System
@@ -160,10 +160,10 @@ Seven tools are registered with Claude's tool-use API:
 | Tool | GitHub API | Returns References? |
 |------|-----------|-------------------|
 | `search_code` | `search.code` | No (discovery only) |
-| `read_file` | `repos.getContent` | Yes (file path + URL) |
-| `list_issues` | `issues.listForRepo` / `issues.get` | Yes (issue numbers + URLs) |
-| `list_commits` | `repos.listCommits` | No |
-| `list_prs` | `pulls.list` | No |
+| `read_file` | `repos.getContent` | Yes — typed as `file` or `doc` |
+| `list_issues` | `issues.listForRepo` / `issues.get` | Yes — typed as `issue`, includes title |
+| `list_commits` | `repos.listCommits` | Yes — typed as `commit`, includes SHA + message |
+| `list_prs` | `pulls.list` | Yes — typed as `pr`, includes number + title |
 | `create_issue` | None (proposal only) | No |
 | `save_knowledge` | None (Vercel KV) | No |
 
@@ -182,25 +182,52 @@ This runs on every response before posting to Slack. Without it, users would see
 
 > **Known limitation**: The converter does not handle headings inside code blocks. A `## comment` inside triple backticks will be converted to `*comment*`. This rarely matters in practice since code blocks are fenced with triple backticks which Slack handles natively.
 
-## Reference Formatting
+## Reference Formatting and Ranking
 
-Every bot answer includes a footer with links to the files and issues that were accessed:
+Every bot answer includes a footer with links to the sources that were accessed, ranked by trustworthiness:
 
 ```
 ───
-References:
-  - src/middleware/auth.ts
-  - src/middleware/auth.test.ts
-  - #42
+*References:*
+  • 📄 src/middleware/auth.ts
+  • 📄 tests/auth.test.ts
+  • 🎫 #1446 Replace supervisor with s6-overlay
+  • 📖 docs/deployment/setup.md
+_React with 👍 or 👎 to help me give better answers in the future._
 ```
 
-References are:
-- **Deduplicated** by label (case-insensitive, first occurrence wins)
-- **Capped at 5** to keep the footer short
-- **Formatted as Slack links** (`<url|label>`) so they are clickable
-- **Only from files actually read** -- search results do not generate references (they are discovery aids)
+### Type labels
 
-If there are more than 5 unique references, the footer shows "...and N more".
+Each reference has a type with an emoji prefix:
+
+| Emoji | Type | Meaning |
+|-------|------|---------|
+| 📄 | `file` | Source code file the agent read |
+| 📖 | `doc` | Documentation file (.md or docs/) |
+| 🎫 | `issue` | GitHub issue (includes title) |
+| 🔀 | `pr` | Pull request (includes title) |
+| 📜 | `commit` | Commit (includes SHA + message) |
+
+### Ranking
+
+References are sorted by `rankReferences()` to mirror the source-of-truth hierarchy:
+
+| Tier | Score | Type | Rationale |
+|------|-------|------|-----------|
+| 1 | 50 | Source code files | Code is truth |
+| 2 | 40 | Test files | Encode expected behavior |
+| — | +20 | Any ref cited in answer | Agent explicitly mentioned it |
+| 4 | 10 | Documentation | Can drift from reality |
+| 5 | 0 | Uncited list results | Discovery artifacts |
+
+This ensures users see the most authoritative sources first.
+
+### Other behaviors
+
+- **Deduplicated** by label (case-insensitive, first occurrence wins)
+- **Capped at 7** -- fewer but higher-quality links
+- **Search results excluded** -- `search_code` does not generate references (discovery only)
+- **Feedback hint** appended after every answer's references
 
 ## Design Decisions
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,7 +69,7 @@ Clean up the implementation while keeping tests green. Run `npm test` after ever
 - **Colocated**: test files live next to source files (`foo.ts` -> `foo.test.ts`)
 - **Run all tests**: `npm test` (single run, CI mode)
 - **Watch mode**: `npm run test:watch` (re-runs on file changes)
-- **Current count**: 103 tests across 7 test files
+- **Current count**: 113 tests across 7 test files
 
 ### What to Test
 

--- a/docs/features/source-hierarchy.md
+++ b/docs/features/source-hierarchy.md
@@ -80,6 +80,18 @@ When a user thumbs-down an answer, the [auto-correction system](./auto-correctio
 
 This creates a self-correcting loop: the bot answers using KB + docs, the user signals the answer was wrong, and the system removes the lower-ranked sources that may have contributed to the bad answer.
 
+## Alignment with Reference Ranking
+
+The source-of-truth hierarchy is mirrored in how references are displayed to the user. The `rankReferences()` function in `src/lib/references.ts` scores each reference by its type:
+
+- Source code files: 50 points (highest — code is truth)
+- Test files: 40 points
+- Any ref cited in the answer text: +20 bonus
+- Documentation: 10 points
+- Uncited list results: 0 points
+
+This means the user sees source code at the top of the reference list and uncited issues at the bottom — reinforcing which sources the answer is grounded in.
+
 ## Testing
 
 The hierarchy behavior is tested in `src/lib/claude.test.ts`. Tests verify that:


### PR DESCRIPTION
## Summary

Sync docs with PRs #42 (typed references) and #44 (weighted ranking).

| File | Change |
|------|--------|
| `docs/architecture.md` | Rewrote reference section: type emoji table, ranking tiers, tool reference generation updated |
| `docs/features/source-hierarchy.md` | New section on `rankReferences()` alignment |
| `README.md` | Test count 103 → 113 |
| `docs/contributing.md` | Test count 103 → 113 |
| `CLAUDE.md` | Reference description: typed, ranked, capped at 7 |

All other docs verified accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)