### PR TITLE
feat: .battle-mage.json config — path annotations (Phase 1 of #25)

### DIFF
--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseBattleMageConfig,
+  getAnnotation,
+  filterPathsByAnnotation,
+  type BattleMageConfig,
+  type PathAnnotation,
+} from "./config";
+
+describe("parseBattleMageConfig", () => {
+  it("parses valid config JSON", () => {
+    const json = '{"paths":{"src/":"core","vendor/":"vendor"}}';
+    const config = parseBattleMageConfig(json);
+    expect(config.paths["src/"]).toBe("core");
+    expect(config.paths["vendor/"]).toBe("vendor");
+  });
+
+  it("returns empty config for null input", () => {
+    const config = parseBattleMageConfig(null);
+    expect(Object.keys(config.paths)).toHaveLength(0);
+  });
+
+  it("returns empty config for invalid JSON", () => {
+    const config = parseBattleMageConfig("not json {{{");
+    expect(Object.keys(config.paths)).toHaveLength(0);
+  });
+
+  it("returns empty config when paths field missing", () => {
+    const config = parseBattleMageConfig('{"other":"field"}');
+    expect(Object.keys(config.paths)).toHaveLength(0);
+  });
+
+  it("ignores invalid annotation values", () => {
+    const config = parseBattleMageConfig('{"paths":{"src/":"core","bad/":"invalid_type"}}');
+    expect(config.paths["src/"]).toBe("core");
+    expect(config.paths["bad/"]).toBeUndefined();
+  });
+});
+
+describe("getAnnotation", () => {
+  const config: BattleMageConfig = {
+    paths: {
+      "src/": "core",
+      "docs/": "current",
+      "docs/archive/": "historic",
+      "vendor/": "vendor",
+      "node_modules/": "excluded",
+    },
+  };
+
+  it("returns annotation for exact prefix match", () => {
+    expect(getAnnotation("src/auth.ts", config)).toBe("core");
+    expect(getAnnotation("vendor/lib/index.js", config)).toBe("vendor");
+  });
+
+  it("returns most specific (longest) prefix match", () => {
+    // docs/ is "current" but docs/archive/ is "historic"
+    expect(getAnnotation("docs/setup.md", config)).toBe("current");
+    expect(getAnnotation("docs/archive/old.md", config)).toBe("historic");
+  });
+
+  it("returns 'current' for unannotated paths", () => {
+    expect(getAnnotation("README.md", config)).toBe("current");
+    expect(getAnnotation("Dockerfile", config)).toBe("current");
+  });
+
+  it("returns 'current' for empty config", () => {
+    expect(getAnnotation("anything.ts", { paths: {} })).toBe("current");
+  });
+
+  it("handles nested paths correctly", () => {
+    expect(getAnnotation("docs/archive/2025/notes.md", config)).toBe("historic");
+  });
+});
+
+describe("filterPathsByAnnotation", () => {
+  const config: BattleMageConfig = {
+    paths: {
+      "src/": "core",
+      "docs/": "current",
+      "docs/archive/": "historic",
+      "vendor/": "vendor",
+      "node_modules/": "excluded",
+    },
+  };
+
+  const allPaths = [
+    "src/auth.ts",
+    "src/index.ts",
+    "docs/setup.md",
+    "docs/archive/old.md",
+    "vendor/lib/index.js",
+    "node_modules/express/index.js",
+    "README.md",
+  ];
+
+  it("excludes paths annotated as 'excluded'", () => {
+    const filtered = filterPathsByAnnotation(allPaths, config, ["excluded"]);
+    expect(filtered).not.toContain("node_modules/express/index.js");
+    expect(filtered).toContain("src/auth.ts");
+  });
+
+  it("can exclude multiple annotation types", () => {
+    const filtered = filterPathsByAnnotation(allPaths, config, ["excluded", "vendor"]);
+    expect(filtered).not.toContain("node_modules/express/index.js");
+    expect(filtered).not.toContain("vendor/lib/index.js");
+    expect(filtered).toContain("src/auth.ts");
+  });
+
+  it("returns all paths when no exclusions specified", () => {
+    const filtered = filterPathsByAnnotation(allPaths, config, []);
+    expect(filtered).toHaveLength(allPaths.length);
+  });
+
+  it("returns all paths for empty config", () => {
+    const filtered = filterPathsByAnnotation(allPaths, { paths: {} }, ["excluded"]);
+    expect(filtered).toHaveLength(allPaths.length);
+  });
+
+  it("preserves order of remaining paths", () => {
+    const filtered = filterPathsByAnnotation(allPaths, config, ["excluded", "vendor"]);
+    expect(filtered[0]).toBe("src/auth.ts");
+    expect(filtered[filtered.length - 1]).toBe("README.md");
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,78 @@
+/**
+ * Battle Mage Configuration — .battle-mage.json loader
+ *
+ * Path annotations give the agent graduated trust levels:
+ * - core: primary source code, highest trust
+ * - current: up-to-date content, normal trust (default)
+ * - historic: archived/outdated, low trust
+ * - vendor: third-party code, low trust
+ * - excluded: invisible to the agent
+ */
+
+export type PathAnnotation = "core" | "current" | "historic" | "vendor" | "excluded";
+
+const VALID_ANNOTATIONS = new Set<PathAnnotation>(["core", "current", "historic", "vendor", "excluded"]);
+
+export interface BattleMageConfig {
+  paths: Record<string, PathAnnotation>;
+}
+
+// ── Parse config from raw JSON string ────────────────────────────────
+
+export function parseBattleMageConfig(raw: string | null): BattleMageConfig {
+  if (!raw) return { paths: {} };
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed.paths !== "object") {
+      return { paths: {} };
+    }
+
+    // Filter to only valid annotation values
+    const paths: Record<string, PathAnnotation> = {};
+    for (const [key, value] of Object.entries(parsed.paths)) {
+      if (VALID_ANNOTATIONS.has(value as PathAnnotation)) {
+        paths[key] = value as PathAnnotation;
+      }
+    }
+
+    return { paths };
+  } catch {
+    return { paths: {} };
+  }
+}
+
+// ── Get annotation for a file path (longest prefix match) ────────────
+
+export function getAnnotation(
+  filePath: string,
+  config: BattleMageConfig,
+): PathAnnotation {
+  const prefixes = Object.keys(config.paths);
+  if (prefixes.length === 0) return "current";
+
+  // Sort by length descending — longest match wins
+  let bestMatch: PathAnnotation = "current";
+  let bestLength = 0;
+
+  for (const prefix of prefixes) {
+    if (filePath.startsWith(prefix) && prefix.length > bestLength) {
+      bestMatch = config.paths[prefix];
+      bestLength = prefix.length;
+    }
+  }
+
+  return bestMatch;
+}
+
+// ── Filter paths by excluding certain annotations ────────────────────
+
+export function filterPathsByAnnotation(
+  paths: string[],
+  config: BattleMageConfig,
+  excludeAnnotations: PathAnnotation[],
+): string[] {
+  if (excludeAnnotations.length === 0) return paths;
+  const excludeSet = new Set(excludeAnnotations);
+  return paths.filter((p) => !excludeSet.has(getAnnotation(p, config)));
+}

--- a/src/lib/repo-index.test.ts
+++ b/src/lib/repo-index.test.ts
@@ -81,6 +81,51 @@ describe("classifyTopics", () => {
     expect(topics["testing"]).toContain("tests/auth/login.test.ts");
     expect(topics["authentication"]).toContain("tests/auth/login.test.ts");
   });
+
+  describe("with config annotations", () => {
+    const config = {
+      paths: {
+        "src/": "core" as const,
+        "docs/": "current" as const,
+        "docs/archive/": "historic" as const,
+        "vendor/": "vendor" as const,
+        "node_modules/": "excluded" as const,
+      },
+    };
+
+    it("excludes paths annotated as 'excluded'", () => {
+      const paths = ["src/auth.ts", "node_modules/express/index.js"];
+      const topics = classifyTopics(paths, config);
+      const allPaths = Object.values(topics).flat();
+      expect(allPaths).toContain("src/auth.ts");
+      expect(allPaths).not.toContain("node_modules/express/index.js");
+    });
+
+    it("routes historic paths to _historic pseudo-topic", () => {
+      const paths = ["docs/archive/old-notes.md", "docs/setup.md"];
+      const topics = classifyTopics(paths, config);
+      expect(topics["_historic"]).toContain("docs/archive/old-notes.md");
+      // docs/setup.md is "current" so it should go to normal topics
+      expect(topics["_historic"] || []).not.toContain("docs/setup.md");
+    });
+
+    it("routes vendor paths to _vendor pseudo-topic", () => {
+      const paths = ["vendor/lib/util.js", "src/app.ts"];
+      const topics = classifyTopics(paths, config);
+      expect(topics["_vendor"]).toContain("vendor/lib/util.js");
+      const allNonVendor = Object.entries(topics)
+        .filter(([k]) => k !== "_vendor")
+        .flatMap(([, v]) => v);
+      expect(allNonVendor).not.toContain("vendor/lib/util.js");
+    });
+
+    it("classifies core/current paths normally", () => {
+      const paths = ["src/services/auth/login.ts"];
+      const topics = classifyTopics(paths, config);
+      expect(topics["authentication"]).toContain("src/services/auth/login.ts");
+      expect(topics["_historic"] || []).not.toContain("src/services/auth/login.ts");
+    });
+  });
 });
 
 describe("isIndexStale", () => {
@@ -119,9 +164,31 @@ describe("buildIndexSummary", () => {
       testing: Array.from({ length: 20 }, (_, i) => `tests/test${i}.ts`),
     };
     const summary = buildIndexSummary(topics);
-    // Should not list all 20 files — capped for prompt size
     const lines = summary.split("\n");
-    // Total output should be manageable (under 30 lines for a single topic)
     expect(lines.length).toBeLessThan(30);
+  });
+
+  it("shows pseudo-topics with hints", () => {
+    const topics = {
+      authentication: ["src/auth.ts"],
+      _historic: ["docs/archive/old.md"],
+      _vendor: ["vendor/lib.js"],
+    };
+    const summary = buildIndexSummary(topics);
+    expect(summary).toContain("historic");
+    expect(summary).toContain("history questions");
+    expect(summary).toContain("vendor");
+    expect(summary).toContain("dependency questions");
+  });
+
+  it("sorts regular topics before pseudo-topics", () => {
+    const topics = {
+      _historic: ["docs/archive/old.md"],
+      authentication: ["src/auth.ts"],
+    };
+    const summary = buildIndexSummary(topics);
+    const lines = summary.split("\n");
+    expect(lines[0]).toContain("authentication");
+    expect(lines[1]).toContain("historic");
   });
 });

--- a/src/lib/repo-index.ts
+++ b/src/lib/repo-index.ts
@@ -1,4 +1,10 @@
 import { kv } from "@vercel/kv";
+import {
+  type BattleMageConfig,
+  parseBattleMageConfig,
+  getAnnotation,
+  filterPathsByAnnotation,
+} from "./config";
 
 // ── Topic classification rules ───────────────────────────────────────
 // Each rule: [topic, pattern that matches against file path (case-insensitive)]
@@ -14,19 +20,40 @@ const TOPIC_RULES: [string, RegExp][] = [
   ["configuration", /config\/|\.env|docker-compose|\.ya?ml$|\.json$/i],
 ];
 
-const IGNORED_PREFIXES = ["vendor/", "node_modules/", ".git/", "dist/", "build/"];
+// Fallback for repos without .battle-mage.json
+const DEFAULT_EXCLUDED_PREFIXES = ["vendor/", "node_modules/", ".git/", "dist/", "build/"];
 
 // ── Pure functions (exported for testing) ─────────────────────────────
 
 export type TopicMap = Record<string, string[]>;
 
-export function classifyTopics(paths: string[]): TopicMap {
+export function classifyTopics(
+  paths: string[],
+  config?: BattleMageConfig,
+): TopicMap {
   const topics: TopicMap = {};
 
-  for (const path of paths) {
-    // Skip vendored/generated files
-    if (IGNORED_PREFIXES.some((prefix) => path.startsWith(prefix))) continue;
+  // Filter out excluded paths using config or fallback
+  const filteredPaths = config
+    ? filterPathsByAnnotation(paths, config, ["excluded"])
+    : paths.filter((p) => !DEFAULT_EXCLUDED_PREFIXES.some((prefix) => p.startsWith(prefix)));
 
+  for (const path of filteredPaths) {
+    const annotation = config ? getAnnotation(path, config) : "current";
+
+    // Route historic and vendor paths to pseudo-topics
+    if (annotation === "historic") {
+      if (!topics["_historic"]) topics["_historic"] = [];
+      topics["_historic"].push(path);
+      continue;
+    }
+    if (annotation === "vendor") {
+      if (!topics["_vendor"]) topics["_vendor"] = [];
+      topics["_vendor"].push(path);
+      continue;
+    }
+
+    // Normal topic classification
     for (const [topic, pattern] of TOPIC_RULES) {
       if (pattern.test(path)) {
         if (!topics[topic]) topics[topic] = [];
@@ -47,9 +74,21 @@ export function isIndexStale(
 
 const MAX_PATHS_PER_TOPIC = 8;
 
+const PSEUDO_TOPIC_HINTS: Record<string, string> = {
+  _historic: "(use only for history questions)",
+  _vendor: "(use only for dependency questions)",
+};
+
 export function buildIndexSummary(topics: TopicMap): string {
   const entries = Object.entries(topics);
   if (entries.length === 0) return "";
+
+  // Sort: regular topics first, then pseudo-topics (_historic, _vendor) last
+  entries.sort((a, b) => {
+    const aIsPseudo = a[0].startsWith("_") ? 1 : 0;
+    const bIsPseudo = b[0].startsWith("_") ? 1 : 0;
+    return aIsPseudo - bIsPseudo;
+  });
 
   return entries
     .map(([topic, paths]) => {
@@ -57,7 +96,9 @@ export function buildIndexSummary(topics: TopicMap): string {
       const overflow = paths.length - capped.length;
       const pathList = capped.join(", ");
       const suffix = overflow > 0 ? ` (+${overflow} more)` : "";
-      return `- *${topic}*: ${pathList}${suffix}`;
+      const hint = PSEUDO_TOPIC_HINTS[topic] || "";
+      const label = topic.startsWith("_") ? topic.slice(1) : topic;
+      return `- *${label}*${hint ? " " + hint : ""}: ${pathList}${suffix}`;
     })
     .join("\n");
 }
@@ -89,6 +130,22 @@ async function fetchHeadSha(): Promise<string> {
   return getHeadSha();
 }
 
+// ── Config loading ───────────────────────────────────────────────────
+const INDEX_CONFIG_KEY = "index:config";
+
+async function fetchBattleMageConfig(): Promise<BattleMageConfig> {
+  try {
+    const { readFile } = await import("@/lib/github");
+    const result = await readFile(".battle-mage.json");
+    if ("content" in result && typeof result.content === "string") {
+      return parseBattleMageConfig(result.content);
+    }
+    return { paths: {} };
+  } catch {
+    return { paths: {} };
+  }
+}
+
 // ── Public API ───────────────────────────────────────────────────────
 
 export async function getOrRebuildIndex(): Promise<string> {
@@ -102,15 +159,17 @@ export async function getOrRebuildIndex(): Promise<string> {
       return summary ?? "";
     }
 
-    // Rebuild index
+    // Load config and rebuild index
+    const config = await fetchBattleMageConfig();
     const paths = await fetchRepoTree();
-    const topics = classifyTopics(paths);
+    const topics = classifyTopics(paths, config);
     const summary = buildIndexSummary(topics);
 
-    // Write to KV (pipeline for atomicity)
+    // Write to KV
     await kv.set(INDEX_SHA_KEY, currentSha);
     await kv.set(INDEX_TOPICS_KEY, JSON.stringify(topics));
     await kv.set(INDEX_SUMMARY_KEY, summary);
+    await kv.set(INDEX_CONFIG_KEY, JSON.stringify(config));
     await kv.set(INDEX_BUILT_AT_KEY, new Date().toISOString());
 
     return summary;
@@ -118,5 +177,21 @@ export async function getOrRebuildIndex(): Promise<string> {
     // If index build fails, return empty — agent falls back to search
     console.error("Repo index build failed:", err);
     return "";
+  }
+}
+
+/**
+ * Get the cached config from KV (loaded during last index build).
+ * Returns empty config if not yet built.
+ */
+export async function getCachedConfig(): Promise<BattleMageConfig> {
+  try {
+    const raw = await kv.get<string>(INDEX_CONFIG_KEY);
+    if (raw) {
+      return typeof raw === "string" ? JSON.parse(raw) : (raw as BattleMageConfig);
+    }
+    return { paths: {} };
+  } catch {
+    return { paths: {} };
   }
 }


### PR DESCRIPTION
## Summary

Phase 1 of #25: Config loader + repo index integration.

Adds support for a \`.battle-mage.json\` file in the target repo that annotates paths with trust levels:

\`\`\`json
{
  "paths": {
    "src/": "core",
    "docs/": "current",
    "docs/archive/": "historic",
    "vendor/": "vendor",
    "node_modules/": "excluded"
  }
}
\`\`\`

### Annotation types

| Type | Trust | Index behavior |
|------|-------|---------------|
| \`core\` | Highest | Normal topic classification, prioritized |
| \`current\` | Normal | Default — standard behavior |
| \`historic\` | Low | Routed to \`_historic\` pseudo-topic with "use only for history questions" hint |
| \`vendor\` | Low | Routed to \`_vendor\` pseudo-topic with "use only for dependency questions" hint |
| \`excluded\` | None | Filtered out, never indexed |

### What's in this PR

- **Config loader** (\`src/lib/config.ts\`): parse, validate, longest-prefix-match lookup
- **Repo index integration**: \`classifyTopics()\` accepts config, routes annotated paths to pseudo-topics
- **Config cached in KV**: available for PR B (prompt injection, search strategy, reference ranking)

### What's NOT in this PR (Phase 2+)

- System prompt injection of annotations
- Search strategy skip rules for historic/vendor
- Reference ranking score adjustments
- Documentation

## Test plan

- [x] 134 tests total (21 new — 15 config, 6 index)
- [x] Config parsing: valid, null, invalid JSON, missing paths, invalid annotations
- [x] Prefix matching: exact, longest match, unannotated, nested paths
- [x] Filtering: single exclusion, multiple, empty config, order preservation
- [x] Index: excluded filtered, historic→_historic, vendor→_vendor, core/current normal
- [x] Summary: pseudo-topic hints, sorted after regular topics
- [x] \`npm run typecheck\` + \`npm run build\` pass

Part of #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)