### PR TITLE
feat: Wire path annotations into prompt + search strategy + ranking (Phase 2 of #25)

### DIFF
--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -9,6 +9,7 @@ describe("assembleSystemPrompt", () => {
     knowledge: null,
     feedback: null,
     repoIndex: null,
+    pathAnnotations: null,
   };
 
   describe("source-of-truth hierarchy", () => {
@@ -190,6 +191,59 @@ describe("assembleSystemPrompt", () => {
     it("instructs not to write marketing copy or brochure-style", () => {
       const prompt = assembleSystemPrompt(baseArgs);
       expect(prompt).toMatch(/no.*brochure|no.*marketing|no.*editorial|skip.*what makes.*special/i);
+    });
+  });
+
+  describe("path annotations", () => {
+    it("injects annotation guidance when config provided", () => {
+      const prompt = assembleSystemPrompt({
+        ...baseArgs,
+        pathAnnotations: {
+          paths: {
+            "src/": "core",
+            "docs/archive/": "historic",
+            "vendor/": "vendor",
+          },
+        },
+      });
+      expect(prompt).toContain("Path Annotations");
+      expect(prompt).toContain("core");
+      expect(prompt).toContain("historic");
+      expect(prompt).toContain("vendor");
+    });
+
+    it("instructs to qualify historic content", () => {
+      const prompt = assembleSystemPrompt({
+        ...baseArgs,
+        pathAnnotations: {
+          paths: { "docs/archive/": "historic" },
+        },
+      });
+      expect(prompt).toMatch(/historic.*qualify|historic.*historically/i);
+    });
+
+    it("instructs to skip historic/vendor by default", () => {
+      const prompt = assembleSystemPrompt({
+        ...baseArgs,
+        pathAnnotations: {
+          paths: { "docs/archive/": "historic", "vendor/": "vendor" },
+        },
+      });
+      expect(prompt).toMatch(/skip.*historic|avoid.*historic|historic.*only.*when/i);
+      expect(prompt).toMatch(/skip.*vendor|avoid.*vendor|vendor.*only.*when/i);
+    });
+
+    it("omits annotation section when config is null", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      expect(prompt).not.toContain("Path Annotations");
+    });
+
+    it("omits annotation section when config has empty paths", () => {
+      const prompt = assembleSystemPrompt({
+        ...baseArgs,
+        pathAnnotations: { paths: {} },
+      });
+      expect(prompt).not.toContain("Path Annotations");
     });
   });
 

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -4,7 +4,8 @@ import type { IssueProposal } from "@/tools/create-issue";
 import { readFile } from "@/lib/github";
 import { getKnowledgeAsMarkdown } from "@/lib/knowledge";
 import { getFeedbackAsMarkdown } from "@/lib/feedback";
-import { getOrRebuildIndex } from "@/lib/repo-index";
+import { getOrRebuildIndex, getCachedConfig } from "@/lib/repo-index";
+import type { BattleMageConfig } from "@/lib/config";
 
 // ── Anthropic client ──────────────────────────────────────────────────
 const anthropic = new Anthropic(); // reads ANTHROPIC_API_KEY from env
@@ -48,10 +49,43 @@ export interface PromptInputs {
   knowledge: string | null;
   feedback: string | null;
   repoIndex: string | null;
+  pathAnnotations: BattleMageConfig | null;
+}
+
+function buildAnnotationsSection(config: BattleMageConfig | null): string {
+  if (!config || Object.keys(config.paths).length === 0) return "";
+
+  const entries = Object.entries(config.paths);
+  const grouped: Record<string, string[]> = {};
+  for (const [path, annotation] of entries) {
+    if (annotation === "excluded") continue; // Don't tell agent about excluded paths
+    if (!grouped[annotation]) grouped[annotation] = [];
+    grouped[annotation].push(path);
+  }
+
+  if (Object.keys(grouped).length === 0) return "";
+
+  const lines = ["\n## Path Annotations (from .battle-mage.json)\n"];
+  lines.push("The team has annotated paths in this repo with trust levels:\n");
+
+  for (const [annotation, paths] of Object.entries(grouped)) {
+    lines.push(`- *${annotation}*: ${paths.join(", ")}`);
+  }
+
+  lines.push("");
+  lines.push("*Rules:*");
+  lines.push("- Prefer *core* paths as primary evidence — read these first");
+  lines.push("- *current* paths have normal trust — standard behavior");
+  lines.push("- Skip *historic* paths unless the question is about history or past decisions. When citing historic content, always qualify as \"historically...\" or \"in the archived docs...\"");
+  lines.push("- Skip *vendor* paths unless the question is about dependencies or third-party libraries. When citing vendor code, qualify as third-party");
+  lines.push("- Never read or reference excluded paths (they are not shown here)");
+  lines.push("");
+
+  return lines.join("\n");
 }
 
 export function assembleSystemPrompt(inputs: PromptInputs): string {
-  const { owner, repo, claudeMd, knowledge, feedback, repoIndex } = inputs;
+  const { owner, repo, claudeMd, knowledge, feedback, repoIndex, pathAnnotations } = inputs;
 
   const contextSection = claudeMd
     ? `\n## Project Context (from CLAUDE.md)\n\n${claudeMd}\n`
@@ -65,6 +99,7 @@ export function assembleSystemPrompt(inputs: PromptInputs): string {
   const repoIndexSection = repoIndex
     ? `\n## Repository Map (auto-generated index)\n\nThis map shows the key areas of the repo. Use it to jump directly to relevant files with \`read_file\` instead of searching blind. The map is rebuilt automatically when the repo changes.\n\n${repoIndex}\n`
     : "";
+  const annotationsSection = buildAnnotationsSection(pathAnnotations);
 
   const today = new Date().toISOString().split("T")[0];
 
@@ -187,18 +222,21 @@ You are writing for Slack mrkdwn, NOT standard Markdown. Slack will show raw cha
 
 Owner: ${owner}
 Repository: ${repo}
-${contextSection}${repoIndexSection}${knowledgeSection}${feedbackSection}`;
+${contextSection}${repoIndexSection}${annotationsSection}${knowledgeSection}${feedbackSection}`;
 }
 
 // ── Async wrapper that fetches data then assembles ────────────────────
 async function buildSystemPrompt(): Promise<string> {
+  const repoIndex = await getOrRebuildIndex();
+  const config = await getCachedConfig();
   return assembleSystemPrompt({
     owner: process.env.GITHUB_OWNER,
     repo: process.env.GITHUB_REPO,
     claudeMd: await getClaudeMd(),
     knowledge: await getKnowledge(),
     feedback: await getFeedbackAsMarkdown(),
-    repoIndex: await getOrRebuildIndex(),
+    repoIndex,
+    pathAnnotations: Object.keys(config.paths).length > 0 ? config : null,
   });
 }
 

--- a/src/lib/references.test.ts
+++ b/src/lib/references.test.ts
@@ -162,4 +162,32 @@ describe("rankReferences", () => {
     const ranked = rankReferences(refs, "as documented in docs/cited.md");
     expect(ranked[0].label).toBe("docs/cited.md");
   });
+
+  it("boosts core-annotated files when config provided", () => {
+    const config = { paths: { "src/": "core" as const, "lib/": "current" as const } };
+    const refs = [
+      { label: "lib/util.ts", url: "https://example.com/lib", type: "file" as const },
+      { label: "src/auth.ts", url: "https://example.com/src", type: "file" as const },
+    ];
+    const ranked = rankReferences(refs, "answer", config);
+    expect(ranked[0].label).toBe("src/auth.ts");
+  });
+
+  it("penalizes historic-annotated files when config provided", () => {
+    const config = { paths: { "docs/": "current" as const, "docs/archive/": "historic" as const } };
+    const refs = [
+      { label: "docs/archive/old.md", url: "https://example.com/old", type: "doc" as const },
+      { label: "docs/setup.md", url: "https://example.com/setup", type: "doc" as const },
+    ];
+    const ranked = rankReferences(refs, "answer", config);
+    expect(ranked[0].label).toBe("docs/setup.md");
+  });
+
+  it("works without config (backwards compatible)", () => {
+    const refs = [
+      { label: "src/auth.ts", url: "https://example.com/auth", type: "file" as const },
+    ];
+    const ranked = rankReferences(refs, "answer");
+    expect(ranked).toHaveLength(1);
+  });
 });

--- a/src/lib/references.ts
+++ b/src/lib/references.ts
@@ -1,10 +1,12 @@
 import type { Reference } from "@/tools";
+import { type BattleMageConfig, getAnnotation } from "./config";
 
 /**
  * Reference ranking and formatting.
  *
  * References are ranked to mirror the source-of-truth hierarchy:
  *   code > tests > cited refs > docs > uncited list results
+ * Path annotations from .battle-mage.json adjust scores further.
  */
 export const MAX_REFERENCES = 7;
 
@@ -24,7 +26,11 @@ function isTestFile(label: string): boolean {
 }
 
 // ── Score a reference by source-of-truth hierarchy ───────────────────
-function scoreRef(ref: Reference, answerText: string): number {
+function scoreRef(
+  ref: Reference,
+  answerText: string,
+  config?: BattleMageConfig,
+): number {
   let score = 0;
 
   // Tier 1: Source code files (non-doc, non-test) — highest trust
@@ -38,7 +44,6 @@ function scoreRef(ref: Reference, answerText: string): number {
   }
 
   // Citation boost: ref mentioned in the answer text
-  // Check for label fragments: #number, file paths, SHA prefixes
   const labelParts = ref.label.split(/\s+/);
   for (const part of labelParts) {
     if (part.length > 2 && answerText.includes(part)) {
@@ -54,6 +59,14 @@ function scoreRef(ref: Reference, answerText: string): number {
 
   // Tier 5: Uncited issues/PRs/commits get base score of 0
 
+  // Annotation adjustments from .battle-mage.json
+  if (config) {
+    const annotation = getAnnotation(ref.label, config);
+    if (annotation === "core") score += 10;
+    if (annotation === "historic") score -= 20;
+    if (annotation === "vendor") score -= 20;
+  }
+
   return score;
 }
 
@@ -61,13 +74,14 @@ function scoreRef(ref: Reference, answerText: string): number {
 export function rankReferences(
   refs: Reference[],
   answerText: string,
+  config?: BattleMageConfig,
 ): Reference[] {
   if (refs.length === 0) return [];
 
   // Score each ref, then stable-sort descending
   const scored = refs.map((ref, index) => ({
     ref,
-    score: scoreRef(ref, answerText),
+    score: scoreRef(ref, answerText, config),
     originalIndex: index,
   }));
 


### PR DESCRIPTION
## Summary

Phase 2 of #25: Annotations from \`.battle-mage.json\` now affect how the agent builds answers.

### System Prompt

When config exists, a "Path Annotations" section is injected listing annotated paths with rules:
- Prefer *core* paths as primary evidence
- Skip *historic* unless question is about history — qualify as "historically..."
- Skip *vendor* unless question is about dependencies — qualify as third-party
- Never read excluded paths

### Reference Ranking

\`rankReferences()\` now accepts an optional config:
- \`core\` paths: +10 bonus (total: 60 for a core source file)
- \`historic\` paths: -20 penalty
- \`vendor\` paths: -20 penalty
- \`current\` paths: no change

This means a historic doc (10 - 20 = -10) ranks below even uncited issues (0), ensuring stale content sinks to the bottom.

## Files

| File | Change |
|------|--------|
| \`src/lib/claude.ts\` | PromptInputs + pathAnnotations, buildAnnotationsSection(), buildSystemPrompt loads config |
| \`src/lib/claude.test.ts\` | 5 new tests for annotation injection |
| \`src/lib/references.ts\` | rankReferences + scoreRef accept optional config |
| \`src/lib/references.test.ts\` | 3 new tests for annotation scoring |

## Test plan

- [x] 142 tests total (8 new)
- [x] \`npm run typecheck\` + \`npm run build\` pass

Part of #25. Phase 3 (documentation) remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)