### PR TITLE
feat: Add security topic to repo index classifier

### DIFF
--- a/src/lib/repo-index.test.ts
+++ b/src/lib/repo-index.test.ts
@@ -52,6 +52,37 @@ describe("classifyTopics", () => {
     expect(topics["api"]).toContain("src/controllers/UserController.ts");
   });
 
+  it("classifies security scanning files", () => {
+    const paths = [
+      ".github/workflows/security-scan.yml",
+      "app/Security/IpBlocker.ts",
+      "infra/scc-sync.tf",
+    ];
+    const topics = classifyTopics(paths);
+    expect(topics["security"]).toContain(".github/workflows/security-scan.yml");
+    expect(topics["security"]).toContain("app/Security/IpBlocker.ts");
+    expect(topics["security"]).toContain("infra/scc-sync.tf");
+  });
+
+  it("classifies CI security tools by name", () => {
+    const paths = [
+      ".github/workflows/gitguardian.yml",
+      ".github/workflows/checkov-scan.yml",
+      ".github/workflows/trivy.yml",
+    ];
+    const topics = classifyTopics(paths);
+    expect(topics["security"]).toContain(".github/workflows/gitguardian.yml");
+    expect(topics["security"]).toContain(".github/workflows/checkov-scan.yml");
+    expect(topics["security"]).toContain(".github/workflows/trivy.yml");
+  });
+
+  it("security files can also appear in ci-cd topic", () => {
+    const paths = [".github/workflows/security-scan.yml"];
+    const topics = classifyTopics(paths);
+    expect(topics["security"]).toContain(".github/workflows/security-scan.yml");
+    expect(topics["ci-cd"]).toContain(".github/workflows/security-scan.yml");
+  });
+
   it("classifies configuration files", () => {
     const paths = ["config/app.json", ".env.example", "docker-compose.yml"];
     const topics = classifyTopics(paths);

--- a/src/lib/repo-index.ts
+++ b/src/lib/repo-index.ts
@@ -18,6 +18,7 @@ const TOPIC_RULES: [string, RegExp][] = [
   ["documentation", /\.md$|docs?\//i],
   ["ci-cd", /\.github\/workflows\/|\.circleci|\.gitlab-ci|jenkinsfile|buildkite/i],
   ["api", /routes?\b|controller|endpoint|api\//i],
+  ["security", /security|firewall|waf|ip.?block|rate.?limit|encrypt|cipher|tls|ssl|audit|compliance|soc2|gitguardian|ggshield|checkov|bridgecrew|snyk|trivy|grype|codeql|semgrep|scc|vulnerability|pentest/i],
   ["configuration", /config\/|\.env|docker-compose|\.ya?ml$|\.json$/i],
 ];
 


### PR DESCRIPTION
## Summary

Security questions now surface CI/CD scanning config alongside app-level security code.

### Before
Asking about "security posture" found IP blocking, auth, and logging — but missed GitGuardian, Checkov, and GCP SCC because they live in workflow files classified only under \`ci-cd\`.

### After
New \`security\` topic matches:
- **CI tools**: gitguardian, ggshield, checkov, bridgecrew, snyk, trivy, grype, codeql, semgrep
- **Infrastructure**: scc, vulnerability, pentest
- **App security**: firewall, waf, ip blocking, rate limiting, encryption, audit, compliance, soc2

Files can appear in both \`security\` and \`ci-cd\` (existing multi-topic behavior).

### No config changes needed
This is a classifier change in Battle Mage itself. Target repos don't need to update \`.battle-mage.json\`.

## Test plan

- [x] 151 tests (3 new for security topic)
- [x] \`npm run typecheck\` + \`npm run build\` pass

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)