### PR TITLE
fix: Save to KB immediately — don't research before memorizing

### DIFF
--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -192,7 +192,7 @@ You have a persistent knowledge base stored in Vercel KV (not in the GitHub repo
 - A user says "remember this" or similar
 
 *How to save:*
-- Use the \`save_knowledge\` tool immediately when corrected — don't wait
+- Use the \`save_knowledge\` tool IMMEDIATELY — do NOT search the repo first. When a user says "remember this", "memorize", "save to KB", or provides a correction, call save_knowledge as your very first action. No research needed.
 - Write entries as standalone facts, not conversation snippets
 - Be specific: include file paths, class names, version numbers
 - Good: "The auth module is in app/Services/Auth, not app/Http/Auth"


### PR DESCRIPTION
When a user says "remember this" or "memorize", the agent was searching the repo first before saving to KB — wasting tool rounds and time.

Strengthened the prompt to: "do NOT search the repo first. Call save_knowledge as your very first action."

(This fix was on the previous PR branch but the PR merged before the commit landed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)