### PR TITLE
feat: 5-minute time budget with graceful degradation

### DIFF
--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -6,6 +6,7 @@ import { getKnowledgeAsMarkdown } from "@/lib/knowledge";
 import { getFeedbackAsMarkdown } from "@/lib/feedback";
 import { getOrRebuildIndex, getCachedConfig } from "@/lib/repo-index";
 import { log } from "@/lib/logger";
+import { shouldWarnBudget, shouldForceStop } from "@/lib/time-budget";
 import type { BattleMageConfig } from "@/lib/config";
 
 // ── Anthropic client ──────────────────────────────────────────────────
@@ -265,7 +266,25 @@ export async function runAgent(
   const systemPrompt = await buildSystemPrompt();
   log("agent_start", { promptLength: systemPrompt.length, question: userMessage.slice(0, 100) });
 
+  let warned = false;
+
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+    // Time budget check — force-stop if over 5 minutes
+    if (shouldForceStop(startTime)) {
+      log("agent_timeout", { rounds: round, duration_ms: Date.now() - startTime });
+      const seen = new Set<string>();
+      const finalRefs = allReferences.filter((r) => {
+        if (seen.has(r.url)) return false;
+        seen.add(r.url);
+        return true;
+      });
+      return {
+        text: "I've been working on this for a while and want to give you what I have so far rather than keep you waiting. Here's my answer based on what I've found:\n\n_I ran out of time before completing a thorough analysis. Ask a follow-up question if you need more detail on a specific area._",
+        issueProposal,
+        references: finalRefs,
+      };
+    }
+
     const response = await anthropic.messages.create({
       model: MODEL,
       max_tokens: 4096,
@@ -362,6 +381,17 @@ export async function runAgent(
           is_error: true,
         });
       }
+    }
+
+    // Inject time budget warning at 80% — tell Claude to wrap up
+    if (!warned && shouldWarnBudget(startTime)) {
+      warned = true;
+      log("agent_budget_warning", { round, elapsed_ms: Date.now() - startTime });
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: toolResults[toolResults.length - 1]?.tool_use_id || "system",
+        content: "[SYSTEM] You are running low on time. Synthesize your answer NOW with what you have. Do not make more tool calls unless absolutely critical.",
+      } as Anthropic.ToolResultBlockParam);
     }
 
     messages.push({ role: "user", content: toolResults });

--- a/src/lib/time-budget.test.ts
+++ b/src/lib/time-budget.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldWarnBudget,
+  shouldForceStop,
+  AGENT_BUDGET_MS,
+  AGENT_WARN_THRESHOLD,
+} from "./time-budget";
+
+describe("time-budget", () => {
+  it("AGENT_BUDGET_MS is 5 minutes", () => {
+    expect(AGENT_BUDGET_MS).toBe(5 * 60 * 1000);
+  });
+
+  it("AGENT_WARN_THRESHOLD is 0.8 (80%)", () => {
+    expect(AGENT_WARN_THRESHOLD).toBe(0.8);
+  });
+
+  describe("shouldWarnBudget", () => {
+    it("returns false when under 80% of budget", () => {
+      const start = Date.now() - 60_000; // 1 minute elapsed
+      expect(shouldWarnBudget(start)).toBe(false);
+    });
+
+    it("returns true when over 80% of budget", () => {
+      const start = Date.now() - 250_000; // 4m10s elapsed (> 80% of 5m)
+      expect(shouldWarnBudget(start)).toBe(true);
+    });
+
+    it("returns true at exactly 80%", () => {
+      const start = Date.now() - (AGENT_BUDGET_MS * AGENT_WARN_THRESHOLD);
+      expect(shouldWarnBudget(start)).toBe(true);
+    });
+  });
+
+  describe("shouldForceStop", () => {
+    it("returns false when under budget", () => {
+      const start = Date.now() - 60_000; // 1 minute elapsed
+      expect(shouldForceStop(start)).toBe(false);
+    });
+
+    it("returns true when over budget", () => {
+      const start = Date.now() - 310_000; // 5m10s elapsed
+      expect(shouldForceStop(start)).toBe(true);
+    });
+
+    it("returns true at exactly budget", () => {
+      const start = Date.now() - AGENT_BUDGET_MS;
+      expect(shouldForceStop(start)).toBe(true);
+    });
+  });
+});

--- a/src/lib/time-budget.ts
+++ b/src/lib/time-budget.ts
@@ -1,0 +1,20 @@
+/**
+ * Time Budget — prevents the agent from running indefinitely.
+ *
+ * Default: 5 minutes (300 seconds).
+ * At 80%: warn the agent to synthesize with what it has.
+ * At 100%: force-stop the loop and return partial answer.
+ */
+
+export const AGENT_BUDGET_MS = 5 * 60 * 1000; // 5 minutes
+export const AGENT_WARN_THRESHOLD = 0.8; // 80%
+
+export function shouldWarnBudget(startTime: number): boolean {
+  const elapsed = Date.now() - startTime;
+  return elapsed >= AGENT_BUDGET_MS * AGENT_WARN_THRESHOLD;
+}
+
+export function shouldForceStop(startTime: number): boolean {
+  const elapsed = Date.now() - startTime;
+  return elapsed >= AGENT_BUDGET_MS;
+}


### PR DESCRIPTION
## Problem

No wall-clock timeout on the agent loop. Complex questions could run for 5+ minutes, burning tokens and Vercel function time while the user waits.

## Solution

Two-phase time budget:

### Phase 1: Warning at 80% (4 minutes)
A system hint is injected into the tool results:
> [SYSTEM] You are running low on time. Synthesize your answer NOW with what you have.

Claude sees this and wraps up instead of making more tool calls.

### Phase 2: Force-stop at 100% (5 minutes)
The loop exits and returns whatever partial information was gathered:
> I've been working on this for a while and want to give you what I have so far rather than keep you waiting...

### Logging
- \`agent_budget_warning\` — logged at 80% with round and elapsed time
- \`agent_timeout\` — logged at 100% with rounds completed and duration

## Files

| File | Change |
|------|--------|
| \`src/lib/time-budget.ts\` | New — pure functions: shouldWarnBudget, shouldForceStop |
| \`src/lib/time-budget.test.ts\` | New — 8 tests |
| \`src/lib/claude.ts\` | Budget checks in agent loop |

## Test plan

- [x] 159 tests (8 new)
- [x] \`npm run typecheck\` + \`npm run build\` pass

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)