### PR TITLE
fix: README auto-correction description — flags, not removes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Slack agent powered by Claude AI that reads your GitHub repo in real time — 
 - **Persistent knowledge base** — remembers corrections across conversations (Vercel KV)
 - **Repo index** — auto-built topic map for fast navigation, rebuilt lazily on push
 - **Source-of-truth hierarchy** — weights code over docs over KB when sources conflict
-- **Auto-correction** — removes stale knowledge entries when answers get 👎
+- **Auto-correction** — flags possibly stale knowledge entries on 👎, saves corrections directly to KB
 - **Live progress** — shows what the agent is doing step by step with contextual emoji
 - **Recency-first** — prefers recent commits, PRs, and issues over historical data
 - **Configurable trust** — `.battle-mage.json` in your repo lets you annotate paths as core, historic, vendor, or excluded


### PR DESCRIPTION
README line 16 still said "removes stale knowledge entries" from the pre-PR #39 behavior. Changed to "flags possibly stale knowledge entries on 👎, saves corrections directly to KB."

The knowledge base description on line 13 was already correct (says Vercel KV). No other stale references found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)