### PR TITLE
feat: Pre-match topic index — inject file hints into user message

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -19,6 +19,8 @@ import { buildCorrectionActions } from "@/lib/auto-correct";
 import { buildThinkingMessage, THINKING_HEADER } from "@/lib/progress";
 import { toSlackMrkdwn } from "@/lib/mrkdwn";
 import { createRequestLogger } from "@/lib/logger";
+import { getCachedTopics } from "@/lib/repo-index";
+import { matchTopicsToQuestion, buildQuestionHints } from "@/lib/topic-match";
 
 /**
  * Slack Events API webhook handler.
@@ -80,7 +82,16 @@ export async function POST(request: NextRequest) {
         );
 
         const cleanMessage = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
-        const result = await runAgent(cleanMessage, async (toolName, input) => {
+
+        // Pre-match question against topic index for concrete file hints
+        const topics = await getCachedTopics();
+        const topicMatches = matchTopicsToQuestion(cleanMessage, topics);
+        const augmentedMessage = buildQuestionHints(cleanMessage, topicMatches);
+        if (topicMatches.length > 0) {
+          rlog("topic_hints_injected", { topics: topicMatches.map((m) => m.topic), fileCount: topicMatches.reduce((s, m) => s + m.paths.length, 0) });
+        }
+
+        const result = await runAgent(augmentedMessage, async (toolName, input) => {
           if (thinkingTs) {
             await updateMessage(channel, thinkingTs, buildThinkingMessage(toolName, input));
           }
@@ -211,7 +222,13 @@ export async function POST(request: NextRequest) {
         );
 
         const cleanMessage = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
-        const result = await runAgent(cleanMessage, async (toolName, input) => {
+
+        // Pre-match for thread follow-ups too
+        const followupTopics = await getCachedTopics();
+        const followupMatches = matchTopicsToQuestion(cleanMessage, followupTopics);
+        const followupMessage = buildQuestionHints(cleanMessage, followupMatches);
+
+        const result = await runAgent(followupMessage, async (toolName, input) => {
           if (thinkTs) {
             await updateMessage(channel, thinkTs, buildThinkingMessage(toolName, input));
           }

--- a/src/lib/repo-index.ts
+++ b/src/lib/repo-index.ts
@@ -188,6 +188,18 @@ export async function getOrRebuildIndex(): Promise<string> {
  * Get the cached config from KV (loaded during last index build).
  * Returns empty config if not yet built.
  */
+export async function getCachedTopics(): Promise<TopicMap> {
+  try {
+    const raw = await kv.get<string>(INDEX_TOPICS_KEY);
+    if (raw) {
+      return typeof raw === "string" ? JSON.parse(raw) : (raw as TopicMap);
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
 export async function getCachedConfig(): Promise<BattleMageConfig> {
   try {
     const raw = await kv.get<string>(INDEX_CONFIG_KEY);

--- a/src/lib/topic-match.test.ts
+++ b/src/lib/topic-match.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { matchTopicsToQuestion, buildQuestionHints } from "./topic-match";
+import type { TopicMap } from "./repo-index";
+
+const sampleTopics: TopicMap = {
+  authentication: ["src/services/auth/login.ts", "src/config/auth.ts", "tests/auth/login.test.ts"],
+  deployment: ["Dockerfile", "docs/deployment/setup.md", ".github/workflows/deploy.yml"],
+  database: ["db/migrations/001_create_users.sql", "src/config/database.ts"],
+  security: [".github/workflows/security-scan.yml", "src/Security/IpBlocker.ts"],
+  configuration: ["docs/development/local-setup.md", "docs/setup/development.md", "config/app.json"],
+};
+
+describe("matchTopicsToQuestion", () => {
+  it("matches 'authentication' topic for auth questions", () => {
+    const matches = matchTopicsToQuestion("how does authentication work?", sampleTopics);
+    expect(matches.length).toBeGreaterThan(0);
+    expect(matches[0].topic).toBe("authentication");
+  });
+
+  it("matches 'deployment' topic for deploy questions", () => {
+    const matches = matchTopicsToQuestion("how do we deploy to production?", sampleTopics);
+    expect(matches.length).toBeGreaterThan(0);
+    expect(matches.some((m) => m.topic === "deployment")).toBe(true);
+  });
+
+  it("matches 'security' topic for security questions", () => {
+    const matches = matchTopicsToQuestion("what is our security posture?", sampleTopics);
+    expect(matches.length).toBeGreaterThan(0);
+    expect(matches.some((m) => m.topic === "security")).toBe(true);
+  });
+
+  it("matches by file path keywords too", () => {
+    const matches = matchTopicsToQuestion("tell me about the local setup process", sampleTopics);
+    expect(matches.length).toBeGreaterThan(0);
+    // "setup" appears in configuration topic file paths
+    expect(matches.some((m) => m.topic === "configuration")).toBe(true);
+  });
+
+  it("returns empty array for unrelated questions", () => {
+    const matches = matchTopicsToQuestion("what is the meaning of life?", sampleTopics);
+    expect(matches).toHaveLength(0);
+  });
+
+  it("returns top file paths per matched topic (capped)", () => {
+    const matches = matchTopicsToQuestion("how does auth work?", sampleTopics);
+    if (matches.length > 0) {
+      expect(matches[0].paths.length).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it("handles empty topics gracefully", () => {
+    expect(matchTopicsToQuestion("anything", {})).toHaveLength(0);
+  });
+
+  it("handles empty question gracefully", () => {
+    expect(matchTopicsToQuestion("", sampleTopics)).toHaveLength(0);
+  });
+});
+
+describe("buildQuestionHints", () => {
+  it("returns augmented message with file paths", () => {
+    const matches = [
+      { topic: "authentication", paths: ["src/services/auth/login.ts", "src/config/auth.ts"] },
+    ];
+    const result = buildQuestionHints("how does auth work?", matches);
+    expect(result).toContain("how does auth work?");
+    expect(result).toContain("src/services/auth/login.ts");
+    expect(result).toContain("read_file");
+  });
+
+  it("returns original question when no matches", () => {
+    const result = buildQuestionHints("random question", []);
+    expect(result).toBe("random question");
+  });
+
+  it("includes topic name for context", () => {
+    const matches = [
+      { topic: "deployment", paths: ["Dockerfile"] },
+    ];
+    const result = buildQuestionHints("how to deploy?", matches);
+    expect(result).toContain("deployment");
+  });
+});

--- a/src/lib/topic-match.ts
+++ b/src/lib/topic-match.ts
@@ -1,0 +1,104 @@
+import type { TopicMap } from "./repo-index";
+
+/**
+ * Topic Pre-Matching — match questions to the repo index before calling the agent.
+ *
+ * Instead of relying on Claude to check the repo map (which it often ignores),
+ * we match the question against topics at the code level and inject file paths
+ * directly into the user message. This gives Claude concrete starting points.
+ */
+
+const STOP_WORDS = new Set([
+  "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+  "have", "has", "had", "do", "does", "did", "will", "would", "could",
+  "should", "may", "might", "can", "shall", "to", "of", "in", "for",
+  "on", "with", "at", "by", "from", "as", "into", "about", "between",
+  "through", "after", "before", "above", "below", "up", "down", "out",
+  "off", "over", "under", "again", "further", "then", "once", "here",
+  "there", "when", "where", "why", "how", "all", "each", "every",
+  "both", "few", "more", "most", "other", "some", "such", "no", "not",
+  "only", "own", "same", "so", "than", "too", "very", "just", "because",
+  "but", "and", "or", "if", "while", "that", "this", "what", "which",
+  "who", "whom", "me", "my", "our", "your", "its", "we", "you", "they",
+  "us", "it", "i", "he", "she", "tell", "give", "show", "explain",
+]);
+
+const MAX_PATHS_PER_TOPIC = 3;
+
+function extractKeywords(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 2 && !STOP_WORDS.has(w));
+}
+
+export interface TopicMatch {
+  topic: string;
+  paths: string[];
+}
+
+export function matchTopicsToQuestion(
+  question: string,
+  topics: TopicMap,
+): TopicMatch[] {
+  if (!question || Object.keys(topics).length === 0) return [];
+
+  const questionKeywords = extractKeywords(question);
+  if (questionKeywords.length === 0) return [];
+
+  const matches: TopicMatch[] = [];
+
+  for (const [topic, paths] of Object.entries(topics)) {
+    // Skip pseudo-topics (_historic, _vendor)
+    if (topic.startsWith("_")) continue;
+
+    // Build keyword set from topic name + file paths
+    const topicKeywords = new Set<string>();
+    for (const keyword of extractKeywords(topic)) {
+      topicKeywords.add(keyword);
+    }
+    for (const path of paths) {
+      for (const keyword of extractKeywords(path)) {
+        topicKeywords.add(keyword);
+      }
+    }
+
+    // Count keyword overlap
+    const overlap = questionKeywords.filter((k) => topicKeywords.has(k));
+    if (overlap.length >= 1) {
+      matches.push({
+        topic,
+        paths: paths.slice(0, MAX_PATHS_PER_TOPIC),
+      });
+    }
+  }
+
+  // Sort by relevance — more keyword overlap first
+  matches.sort((a, b) => {
+    const aOverlap = questionKeywords.filter((k) =>
+      extractKeywords(a.topic).includes(k) ||
+      a.paths.some((p) => extractKeywords(p).includes(k)),
+    ).length;
+    const bOverlap = questionKeywords.filter((k) =>
+      extractKeywords(b.topic).includes(k) ||
+      b.paths.some((p) => extractKeywords(p).includes(k)),
+    ).length;
+    return bOverlap - aOverlap;
+  });
+
+  return matches.slice(0, 3); // Max 3 topics
+}
+
+export function buildQuestionHints(
+  question: string,
+  matches: TopicMatch[],
+): string {
+  if (matches.length === 0) return question;
+
+  const hints = matches
+    .map((m) => m.paths.map((p) => `- ${p} (${m.topic})`).join("\n"))
+    .join("\n");
+
+  return `${question}\n\n[CONTEXT] The repo index suggests these files are relevant:\n${hints}\nStart with read_file on these. Only use search_code if these don't answer the question.`;
+}


### PR DESCRIPTION
## Problem

The search strategy prompt says "check the repo map first" but Claude ignores it and calls \`search_code\` anyway. Prompt instructions are suggestions — they can't force behavior. Logs confirm round 0 is typically \`search_code\` even when the index has the answer.

## Solution

Match the question against the topic index **at the code level** before calling \`runAgent()\`. If there's a match, inject file paths directly into the user message:

\`\`\`
Original: "tell us about the local setup process"

Augmented: "tell us about the local setup process

[CONTEXT] The repo index suggests these files are relevant:
- docs/development/local-setup.md (configuration)
- docs/setup/development.md (configuration)
Start with read_file on these. Only use search_code if these don't answer the question."
\`\`\`

Claude sees concrete paths in the message and naturally calls \`read_file\` on them — no prompt rule needed.

### How matching works

1. Extract keywords from the question (filter stop words)
2. Match against topic names + file paths in the cached index
3. Top 3 topics, max 3 files each
4. Falls back to un-augmented message when no match

## Files

| File | Change |
|------|--------|
| \`src/lib/topic-match.ts\` | New — matchTopicsToQuestion + buildQuestionHints |
| \`src/lib/topic-match.test.ts\` | New — 11 tests |
| \`src/lib/repo-index.ts\` | getCachedTopics() |
| \`src/app/api/slack/route.ts\` | Both mention + thread handlers augment message |

## Expected impact

**Before:** Round 0 = search_code → 10 results → read 3-5 files → 5 rounds
**After:** Round 0 = read_file (from hint) → 1-2 rounds, focused answer

## Test plan

- [x] 169 tests (11 new)
- [x] \`npm run typecheck\` + \`npm run build\` pass

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)