### PR TITLE
fix: Thread intelligence — skip @user mentions, exclude .claude/, multi-turn context, zombie cleanup

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -86,6 +86,17 @@ export async function POST(request: NextRequest) {
 
         const cleanMessage = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
 
+        // If this is a re-mention inside a thread, fetch history for context
+        // (fresh top-level mentions have no thread_ts — no history needed)
+        let mentionHistory: { role: "user" | "assistant"; content: string }[] | undefined;
+        if (event.thread_ts) {
+          const botId = await getBotUserId();
+          if (botId) {
+            const threadMsgs = await fetchThreadMessages(channel, threadTs);
+            mentionHistory = buildConversationHistory(threadMsgs, botId);
+          }
+        }
+
         // Pre-match question against topic index for concrete file hints
         const topics = await getCachedTopics();
         const topicMatches = matchTopicsToQuestion(cleanMessage, topics);
@@ -98,7 +109,7 @@ export async function POST(request: NextRequest) {
           if (thinkingTs) {
             await updateMessage(channel, thinkingTs, buildThinkingMessage(toolName, input));
           }
-        });
+        }, mentionHistory);
         rlog("agent_complete", { rounds: result.references.length, hasProposal: !!result.issueProposal, refCount: result.references.length });
 
         // Update thinking message to "composing" before posting answer

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -5,7 +5,7 @@ import {
   replyInThread,
   fetchMessage,
   getBotUserId,
-  isBotInThread,
+  fetchThreadMessages,
   updateMessage,
   deleteMessage,
 } from "@/lib/slack";
@@ -21,6 +21,7 @@ import { toSlackMrkdwn } from "@/lib/mrkdwn";
 import { createRequestLogger } from "@/lib/logger";
 import { getCachedTopics } from "@/lib/repo-index";
 import { matchTopicsToQuestion, buildQuestionHints } from "@/lib/topic-match";
+import { isAddressedToOtherUser, buildConversationHistory } from "@/lib/thread-filter";
 
 /**
  * Slack Events API webhook handler.
@@ -74,9 +75,11 @@ export async function POST(request: NextRequest) {
 
     // Ack now, process after response is sent (Vercel keeps fn alive)
     after(async () => {
+      // Hoist thinkingTs so finally can always clean it up
+      let thinkingTs: string | undefined;
       try {
         // Post thinking message and capture its ts for live updates
-        const thinkingTs = await replyInThread(
+        thinkingTs = await replyInThread(
           channel, threadTs,
           THINKING_HEADER,
         );
@@ -110,6 +113,7 @@ export async function POST(request: NextRequest) {
         // Delete thinking message — the answer replaces it
         if (thinkingTs) {
           await deleteMessage(channel, thinkingTs);
+          thinkingTs = undefined; // Mark as cleaned up
         }
 
         if (result.issueProposal) {
@@ -154,6 +158,11 @@ export async function POST(request: NextRequest) {
           threadTs,
           `Something went wrong while processing your request. Error: ${msg}`,
         );
+      } finally {
+        // Safety net: delete thinking message if it wasn't cleaned up
+        if (thinkingTs) {
+          await deleteMessage(channel, thinkingTs);
+        }
       }
     });
 
@@ -173,12 +182,19 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ ok: true });
     }
 
+    // Skip messages addressed to a specific non-bot user (e.g. "@vlad can you check?")
+    if (isAddressedToOtherUser(event.text ?? "", botId)) {
+      rlog("thread_skip_addressed_to_other", { channel: event.channel, threadTs: event.thread_ts });
+      return NextResponse.json({ ok: true });
+    }
+
     const channel: string = event.channel;
     const threadTs: string = event.thread_ts;
     const userMessage: string = event.text;
     rlog("thread_followup", { channel, threadTs });
 
     after(async () => {
+      let thinkTs: string | undefined;
       try {
         // Check for pending correction (from a 👎 reaction)
         const { kv } = await import("@vercel/kv");
@@ -211,17 +227,23 @@ export async function POST(request: NextRequest) {
           return;
         }
 
-        // Only respond if the bot is already in this thread
+        // Fetch thread messages — used for both participation check and context
         const bid = botId || (await getBotUserId());
-        if (!bid || !(await isBotInThread(channel, threadTs, bid))) return;
+        const threadMessages = await fetchThreadMessages(channel, threadTs);
+        const botInThread = bid ? threadMessages.some((m) => m.user === bid) : false;
+        if (!bid || !botInThread) return;
         rlog("followup_agent_start", { channel, threadTs });
 
-        const thinkTs = await replyInThread(
+        thinkTs = await replyInThread(
           channel, threadTs,
           THINKING_HEADER,
         );
 
         const cleanMessage = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
+
+        // Build proper multi-turn conversation history from thread
+        // (uses Anthropic's native message format, not string hacking)
+        const history = buildConversationHistory(threadMessages, bid);
 
         // Pre-match for thread follow-ups too
         const followupTopics = await getCachedTopics();
@@ -232,7 +254,7 @@ export async function POST(request: NextRequest) {
           if (thinkTs) {
             await updateMessage(channel, thinkTs, buildThinkingMessage(toolName, input));
           }
-        });
+        }, history);
 
         if (thinkTs) {
           await updateMessage(channel, thinkTs, buildThinkingMessage("composing", {}));
@@ -244,6 +266,7 @@ export async function POST(request: NextRequest) {
 
         if (thinkTs) {
           await deleteMessage(channel, thinkTs);
+          thinkTs = undefined; // Mark as cleaned up
         }
 
         if (result.issueProposal) {
@@ -285,6 +308,11 @@ export async function POST(request: NextRequest) {
           threadTs,
           `Something went wrong while processing your request. Error: ${msg}`,
         );
+      } finally {
+        // Safety net: delete thinking message if it wasn't cleaned up
+        if (thinkTs) {
+          await deleteMessage(channel, thinkTs);
+        }
       }
     });
 

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -253,11 +253,19 @@ export interface AgentResult {
 
 export type ProgressCallback = (toolName: string, input: Record<string, unknown>) => void | Promise<void>;
 
+export interface ConversationTurn {
+  role: "user" | "assistant";
+  content: string;
+}
+
 export async function runAgent(
   userMessage: string,
   onProgress?: ProgressCallback,
+  conversationHistory?: ConversationTurn[],
 ): Promise<AgentResult> {
+  // Build messages: optional history + current user message
   const messages: Anthropic.MessageParam[] = [
+    ...(conversationHistory ?? []),
     { role: "user", content: userMessage },
   ];
 

--- a/src/lib/path-filter.test.ts
+++ b/src/lib/path-filter.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { isToolingPath } from "./path-filter";
+
+describe("isToolingPath", () => {
+  it("returns true for .claude/ paths", () => {
+    expect(isToolingPath(".claude/skills/wizard/SKILL.md")).toBe(true);
+    expect(isToolingPath(".claude/settings.json")).toBe(true);
+    expect(isToolingPath(".claude/CLAUDE.md")).toBe(true);
+  });
+
+  it("returns false for regular project paths", () => {
+    expect(isToolingPath("src/auth.ts")).toBe(false);
+    expect(isToolingPath("docs/setup.md")).toBe(false);
+    expect(isToolingPath("CLAUDE.md")).toBe(false);
+  });
+
+  it("returns false for paths that contain claude but aren't .claude/", () => {
+    expect(isToolingPath("src/lib/claude.ts")).toBe(false);
+    expect(isToolingPath("docs/claude-integration.md")).toBe(false);
+  });
+});

--- a/src/lib/path-filter.ts
+++ b/src/lib/path-filter.ts
@@ -1,0 +1,17 @@
+/**
+ * Path filtering — identifies tooling/metadata paths that should be
+ * excluded from search results, file reads, and topic indexing.
+ *
+ * The .claude/ directory contains Claude Code configuration and skills —
+ * these are AI tooling files, not project source code.
+ */
+
+const TOOLING_PREFIXES = [".claude/"];
+
+/**
+ * Returns true if the path belongs to a tooling/metadata directory
+ * that should not be treated as project code.
+ */
+export function isToolingPath(path: string): boolean {
+  return TOOLING_PREFIXES.some((prefix) => path.startsWith(prefix));
+}

--- a/src/lib/repo-index.test.ts
+++ b/src/lib/repo-index.test.ts
@@ -105,6 +105,15 @@ describe("classifyTopics", () => {
     expect(allPaths).toContain("src/auth.ts");
   });
 
+  it("ignores .claude/ tooling paths", () => {
+    const paths = [".claude/skills/wizard/SKILL.md", ".claude/settings.json", "src/auth.ts"];
+    const topics = classifyTopics(paths);
+    const allPaths = Object.values(topics).flat();
+    expect(allPaths).not.toContain(".claude/skills/wizard/SKILL.md");
+    expect(allPaths).not.toContain(".claude/settings.json");
+    expect(allPaths).toContain("src/auth.ts");
+  });
+
   it("a file can appear in multiple topics", () => {
     const paths = ["tests/auth/login.test.ts"];
     const topics = classifyTopics(paths);

--- a/src/lib/repo-index.ts
+++ b/src/lib/repo-index.ts
@@ -23,7 +23,7 @@ const TOPIC_RULES: [string, RegExp][] = [
 ];
 
 // Fallback for repos without .battle-mage.json
-const DEFAULT_EXCLUDED_PREFIXES = ["vendor/", "node_modules/", ".git/", "dist/", "build/"];
+const DEFAULT_EXCLUDED_PREFIXES = ["vendor/", "node_modules/", ".git/", ".claude/", "dist/", "build/"];
 
 // ── Pure functions (exported for testing) ─────────────────────────────
 

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -99,22 +99,41 @@ export async function fetchMessage(
   }
 }
 
-// ── Check if bot is participating in a thread ────────────────────────
-export async function isBotInThread(
+// ── Fetch thread messages (used for context and participation check) ──
+export interface ThreadMessage {
+  user?: string;
+  text?: string;
+  bot_id?: string;
+}
+
+export async function fetchThreadMessages(
   channel: string,
   threadTs: string,
-  botUserId: string,
-): Promise<boolean> {
+): Promise<ThreadMessage[]> {
   try {
     const result = await slack.conversations.replies({
       channel,
       ts: threadTs,
       limit: 50,
     });
-    return result.messages?.some((m) => m.user === botUserId) ?? false;
+    return (result.messages ?? []).map((m) => ({
+      user: m.user,
+      text: m.text ?? "",
+      bot_id: m.bot_id,
+    }));
   } catch {
-    return false;
+    return [];
   }
+}
+
+// ── Check if bot is participating in a thread ────────────────────────
+export async function isBotInThread(
+  channel: string,
+  threadTs: string,
+  botUserId: string,
+): Promise<boolean> {
+  const messages = await fetchThreadMessages(channel, threadTs);
+  return messages.some((m) => m.user === botUserId);
 }
 
 // ── Get bot's own user ID (cached per cold start) ────────────────────

--- a/src/lib/thread-filter.test.ts
+++ b/src/lib/thread-filter.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { isAddressedToOtherUser, buildConversationHistory } from "./thread-filter";
+
+describe("isAddressedToOtherUser", () => {
+  const botId = "B001";
+
+  it("returns true when message @mentions a non-bot user", () => {
+    expect(isAddressedToOtherUser("<@U123> can you check this?", botId)).toBe(true);
+  });
+
+  it("returns false when message has no @mentions", () => {
+    expect(isAddressedToOtherUser("is this working?", botId)).toBe(false);
+  });
+
+  it("returns false when message only @mentions the bot", () => {
+    expect(isAddressedToOtherUser("<@B001> what's up?", botId)).toBe(false);
+  });
+
+  it("returns true when message @mentions both bot and another user", () => {
+    expect(isAddressedToOtherUser("<@B001> <@U456> what do you think?", botId)).toBe(true);
+  });
+
+  it("returns true when message starts with @mention (direct address)", () => {
+    expect(isAddressedToOtherUser("<@U789> looks like the bot is stuck", botId)).toBe(true);
+  });
+
+  it("returns false when no botId provided", () => {
+    expect(isAddressedToOtherUser("<@U123> hello", undefined)).toBe(false);
+  });
+
+  it("handles multiple non-bot mentions", () => {
+    expect(isAddressedToOtherUser("<@U111> <@U222> thoughts?", botId)).toBe(true);
+  });
+});
+
+describe("buildConversationHistory", () => {
+  const botId = "B001";
+
+  it("returns alternating user/assistant MessageParam array", () => {
+    const messages = [
+      { user: "U123", text: "<@B001> How does auth work?", bot_id: undefined },
+      { user: "B001", text: "Auth is handled in app/Services/Auth...", bot_id: "B001" },
+    ];
+    const result = buildConversationHistory(messages, botId);
+    expect(result).toHaveLength(2);
+    expect(result[0].role).toBe("user");
+    expect(result[1].role).toBe("assistant");
+  });
+
+  it("returns empty array when no messages", () => {
+    expect(buildConversationHistory([], botId)).toHaveLength(0);
+  });
+
+  it("strips @mentions from message text", () => {
+    const messages = [
+      { user: "U123", text: "<@B001> how does auth work?", bot_id: undefined },
+    ];
+    const result = buildConversationHistory(messages, botId);
+    expect(result[0].content).toBe("how does auth work?");
+  });
+
+  it("merges consecutive same-role messages instead of breaking alternation", () => {
+    // Two users in a row — should merge into one user message
+    const messages = [
+      { user: "U123", text: "First question", bot_id: undefined },
+      { user: "U456", text: "Second question", bot_id: undefined },
+      { user: "B001", text: "Here's the answer", bot_id: "B001" },
+    ];
+    const result = buildConversationHistory(messages, botId);
+    // Two user messages merged into one, then one assistant
+    expect(result).toHaveLength(2);
+    expect(result[0].role).toBe("user");
+    expect(result[0].content).toContain("First question");
+    expect(result[0].content).toContain("Second question");
+    expect(result[1].role).toBe("assistant");
+  });
+
+  it("truncates long messages", () => {
+    const longText = "x".repeat(600);
+    const messages = [{ user: "U123", text: longText, bot_id: undefined }];
+    const result = buildConversationHistory(messages, botId);
+    expect((result[0].content as string).length).toBeLessThan(510);
+  });
+
+  it("limits to most recent messages", () => {
+    const messages = Array.from({ length: 20 }, (_, i) => ({
+      user: i % 2 === 0 ? "U123" : "B001",
+      text: `Message ${i}`,
+      bot_id: i % 2 === 0 ? undefined : "B001",
+    }));
+    const result = buildConversationHistory(messages, botId);
+    // Should have at most MAX_CONTEXT_MESSAGES turns
+    expect(result.length).toBeLessThanOrEqual(10);
+  });
+
+  it("ensures first message is always role user (Anthropic requirement)", () => {
+    // Thread starts with bot message (e.g. the parent was a bot post)
+    const messages = [
+      { user: "B001", text: "I'm ready to help!", bot_id: "B001" },
+      { user: "U123", text: "Great, how does auth work?", bot_id: undefined },
+    ];
+    const result = buildConversationHistory(messages, botId);
+    expect(result[0].role).toBe("user");
+  });
+
+  it("ensures last message is role user (the current question context)", () => {
+    // History ends with assistant — current message will be appended by caller
+    const messages = [
+      { user: "U123", text: "How does auth work?", bot_id: undefined },
+      { user: "B001", text: "Auth uses JWT tokens...", bot_id: "B001" },
+    ];
+    const result = buildConversationHistory(messages, botId);
+    // Last is assistant — but this is the HISTORY, the caller appends the current question
+    // So this is fine. The key invariant is: first must be user.
+    expect(result[0].role).toBe("user");
+  });
+
+  it("skips empty messages after cleaning", () => {
+    const messages = [
+      { user: "U123", text: "<@B001>", bot_id: undefined }, // Only an @mention — empty after cleaning
+      { user: "U123", text: "How does auth work?", bot_id: undefined },
+    ];
+    const result = buildConversationHistory(messages, botId);
+    // The empty message should be skipped
+    const userMessages = result.filter((m) => m.role === "user");
+    expect(userMessages).toHaveLength(1);
+    expect(userMessages[0].content).toBe("How does auth work?");
+  });
+});

--- a/src/lib/thread-filter.test.ts
+++ b/src/lib/thread-filter.test.ts
@@ -16,8 +16,9 @@ describe("isAddressedToOtherUser", () => {
     expect(isAddressedToOtherUser("<@B001> what's up?", botId)).toBe(false);
   });
 
-  it("returns true when message @mentions both bot and another user", () => {
-    expect(isAddressedToOtherUser("<@B001> <@U456> what do you think?", botId)).toBe(true);
+  it("returns false when bot is also mentioned alongside another user", () => {
+    // "@bm can you answer @cole's question?" — bot explicitly invoked, let app_mention handle it
+    expect(isAddressedToOtherUser("<@B001> <@U456> what do you think?", botId)).toBe(false);
   });
 
   it("returns true when message starts with @mention (direct address)", () => {

--- a/src/lib/thread-filter.ts
+++ b/src/lib/thread-filter.ts
@@ -1,0 +1,103 @@
+/**
+ * Thread message filtering — pure functions for deciding whether
+ * BM should respond to a thread follow-up message, and for building
+ * proper multi-turn conversation history from Slack thread messages.
+ */
+
+const MENTION_RE = /<@([A-Z0-9]+)>/g;
+
+/**
+ * Returns true if the message @mentions a specific user who is NOT the bot.
+ * When a user writes "@vlad can you check this?", BM should stay silent.
+ */
+export function isAddressedToOtherUser(
+  text: string,
+  botUserId: string | undefined,
+): boolean {
+  if (!botUserId) return false;
+
+  const mentions = [...text.matchAll(MENTION_RE)].map((m) => m[1]);
+  if (mentions.length === 0) return false;
+
+  return mentions.some((id) => id !== botUserId);
+}
+
+// ── Conversation history builder ────────────────────────────────────
+
+export interface ThreadMessage {
+  user?: string;
+  text?: string;
+  bot_id?: string;
+}
+
+export interface MessageParam {
+  role: "user" | "assistant";
+  content: string;
+}
+
+const MAX_CONTEXT_MESSAGES = 10;
+const MAX_MESSAGE_LENGTH = 500;
+
+function cleanText(text: string): string {
+  return text.replace(/<@[A-Z0-9]+>/g, "").trim();
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + "...";
+}
+
+/**
+ * Builds proper alternating user/assistant message history from a Slack thread.
+ *
+ * This uses the Anthropic-native multi-turn format instead of string-hacking
+ * context into a single message. The result can be prepended to the messages
+ * array in runAgent().
+ *
+ * Key invariants:
+ * - First message is always role: "user" (Anthropic requirement)
+ * - Consecutive same-role messages are merged (Anthropic requirement)
+ * - Empty messages (after @mention stripping) are skipped
+ * - Capped at MAX_CONTEXT_MESSAGES most recent entries
+ */
+export function buildConversationHistory(
+  messages: ThreadMessage[],
+  botUserId: string,
+): MessageParam[] {
+  if (messages.length === 0) return [];
+
+  // Take the most recent messages
+  const recent = messages.slice(-MAX_CONTEXT_MESSAGES);
+
+  // Build raw turns with cleaned text
+  const rawTurns: MessageParam[] = [];
+  for (const m of recent) {
+    const text = truncate(cleanText(m.text ?? ""), MAX_MESSAGE_LENGTH);
+    if (!text) continue; // Skip empty messages
+
+    const role: "user" | "assistant" =
+      m.user === botUserId || m.bot_id ? "assistant" : "user";
+    rawTurns.push({ role, content: text });
+  }
+
+  if (rawTurns.length === 0) return [];
+
+  // Merge consecutive same-role messages (Anthropic requires strict alternation)
+  const merged: MessageParam[] = [rawTurns[0]];
+  for (let i = 1; i < rawTurns.length; i++) {
+    const prev = merged[merged.length - 1];
+    if (rawTurns[i].role === prev.role) {
+      prev.content += "\n" + rawTurns[i].content;
+    } else {
+      merged.push(rawTurns[i]);
+    }
+  }
+
+  // Ensure first message is user (Anthropic requirement)
+  // If thread starts with assistant, drop it
+  while (merged.length > 0 && merged[0].role === "assistant") {
+    merged.shift();
+  }
+
+  return merged;
+}

--- a/src/lib/thread-filter.ts
+++ b/src/lib/thread-filter.ts
@@ -7,8 +7,9 @@
 const MENTION_RE = /<@([A-Z0-9]+)>/g;
 
 /**
- * Returns true if the message @mentions a specific user who is NOT the bot.
- * When a user writes "@vlad can you check this?", BM should stay silent.
+ * Returns true if the message @mentions a specific user who is NOT the bot,
+ * AND does NOT also @mention the bot. If the bot is mentioned too
+ * (e.g. "@bm can you answer @cole's question?"), let app_mention handle it.
  */
 export function isAddressedToOtherUser(
   text: string,
@@ -19,7 +20,11 @@ export function isAddressedToOtherUser(
   const mentions = [...text.matchAll(MENTION_RE)].map((m) => m[1]);
   if (mentions.length === 0) return false;
 
-  return mentions.some((id) => id !== botUserId);
+  const mentionsBot = mentions.includes(botUserId);
+  const mentionsOther = mentions.some((id) => id !== botUserId);
+
+  // Only skip if someone else is mentioned AND the bot is NOT
+  return mentionsOther && !mentionsBot;
 }
 
 // ── Conversation history builder ────────────────────────────────────

--- a/src/tools/read-file.ts
+++ b/src/tools/read-file.ts
@@ -1,6 +1,7 @@
 import type { Tool } from "@anthropic-ai/sdk/resources/messages";
 import { readFile } from "@/lib/github";
 import type { Reference } from "@/tools";
+import { isToolingPath } from "@/lib/path-filter";
 
 export const readFileTool: Tool = {
   name: "read_file",
@@ -33,6 +34,11 @@ export async function executeReadFile(
 ): Promise<ReadFileResult> {
   const path = input.path as string;
   const ref = input.ref as string | undefined;
+
+  // Block reads of tooling paths (.claude/ etc.) — not project code
+  if (isToolingPath(path)) {
+    return { text: `Path "${path}" is a tooling/metadata directory and cannot be read.`, references: [] };
+  }
 
   const result = await readFile(path, ref);
 

--- a/src/tools/search-code.ts
+++ b/src/tools/search-code.ts
@@ -1,6 +1,7 @@
 import type { Tool } from "@anthropic-ai/sdk/resources/messages";
 import { searchCode } from "@/lib/github";
 import type { Reference } from "@/tools";
+import { isToolingPath } from "@/lib/path-filter";
 
 export const searchCodeTool: Tool = {
   name: "search_code",
@@ -30,13 +31,16 @@ export async function executeSearchCode(
   const query = input.query as string;
   const results = await searchCode(query);
 
-  if (results.length === 0) {
+  // Filter out tooling paths (.claude/ etc.) — not project code
+  const filtered = results.filter((r) => !isToolingPath(r.path));
+
+  if (filtered.length === 0) {
     return { text: `No results found for "${query}".`, references: [] };
   }
 
   // Search results are discovery aids — don't add them as references.
   // Only files the agent actually reads (via read_file) should be referenced.
-  const text = results
+  const text = filtered
     .map((r) => `- \`${r.path}\` (score: ${r.score}) — ${r.url}`)
     .join("\n");
 


### PR DESCRIPTION
## Summary
Four fixes for critical bugs observed in a single Slack interaction (#61):

- **Skip @user mentions** (#62): BM now stays silent when someone tags another user in a thread (e.g. `@vlad can you check?`)
- **Exclude .claude/ paths** (#63): Claude Code tooling files are filtered from search, read, and index — prevents hallucination from `.claude/skills/wizard/` docs
- **Multi-turn thread context** (#64): Follow-ups use Anthropic-native `messages[]` array instead of string-hacked context — Claude sees proper conversation history
- **Zombie thinking cleanup** (#65): `try/finally` ensures thinking messages are deleted even on errors

## Key architectural decisions
- Thread context uses Anthropic's native multi-turn format, not string concatenation
- `buildConversationHistory()` enforces API invariants: user-first, strict alternation, merge consecutive same-role
- Slack remains source of truth for thread messages (no KV cache — avoids stale data)
- `fetchThreadMessages` replaces `isBotInThread` — one API call instead of two

## Test plan
- [x] 20 new tests (169 → 189), all passing
- [x] TypeScript compiles clean
- [ ] Deploy and re-test with the original security question that triggered the timeout
- [ ] Verify `thread_skip_addressed_to_other` log event appears when @mentioning another user
- [ ] Verify follow-up messages show thread context in agent logs

Closes #62, closes #63, closes #64, closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)