### PR TITLE
fix: Observability gap — rich error logging, request correlation, echo filtering

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -57,8 +57,9 @@ export async function POST(request: NextRequest) {
   // ── Handle events ─────────────────────────────────────────────────
   const event = body.event;
 
-  // Ignore bot messages to prevent loops
-  if (!event || event.bot_id || event.subtype === "bot_message") {
+  // Ignore bot messages and echo events (message_changed, message_deleted, etc.)
+  // These fire when BM updates its own thinking messages — harmless but noisy
+  if (!event || event.bot_id || event.subtype) {
     return NextResponse.json({ ok: true });
   }
 
@@ -109,7 +110,7 @@ export async function POST(request: NextRequest) {
           if (thinkingTs) {
             await updateMessage(channel, thinkingTs, buildThinkingMessage(toolName, input));
           }
-        }, mentionHistory);
+        }, mentionHistory, rlog);
         rlog("agent_complete", { rounds: result.references.length, hasProposal: !!result.issueProposal, refCount: result.references.length });
 
         // Update thinking message to "composing" before posting answer
@@ -265,7 +266,7 @@ export async function POST(request: NextRequest) {
           if (thinkTs) {
             await updateMessage(channel, thinkTs, buildThinkingMessage(toolName, input));
           }
-        }, history);
+        }, history, rlog);
 
         if (thinkTs) {
           await updateMessage(channel, thinkTs, buildThinkingMessage("composing", {}));

--- a/src/lib/api-error.test.ts
+++ b/src/lib/api-error.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { classifyApiError, userErrorMessage } from "./api-error";
+
+describe("classifyApiError", () => {
+  it("classifies 429 as rate_limit", () => {
+    const err = { status: 429, error: { type: "rate_limit_error" }, message: "Rate limit exceeded" };
+    const info = classifyApiError(err);
+    expect(info.category).toBe("rate_limit");
+    expect(info.status).toBe(429);
+    expect(info.type).toBe("rate_limit_error");
+  });
+
+  it("classifies 401 as auth", () => {
+    const err = { status: 401, error: { type: "authentication_error" }, message: "Invalid API key" };
+    const info = classifyApiError(err);
+    expect(info.category).toBe("auth");
+  });
+
+  it("classifies 403 as auth", () => {
+    const err = { status: 403, error: { type: "permission_error" }, message: "Forbidden" };
+    const info = classifyApiError(err);
+    expect(info.category).toBe("auth");
+  });
+
+  it("classifies 529 as overloaded", () => {
+    const err = { status: 529, error: { type: "overloaded_error" }, message: "Overloaded" };
+    const info = classifyApiError(err);
+    expect(info.category).toBe("overloaded");
+  });
+
+  it("classifies not_found_error as model_error", () => {
+    const err = { status: 404, error: { type: "not_found_error" }, message: "model: claude-sonnet-4-20250514 not found" };
+    const info = classifyApiError(err);
+    expect(info.category).toBe("model_error");
+  });
+
+  it("classifies token overflow messages as context_too_large", () => {
+    const err = new Error("prompt is too long: 215432 tokens > 200000 maximum");
+    const info = classifyApiError(err);
+    expect(info.category).toBe("context_too_large");
+  });
+
+  it("classifies message containing 'too many tokens' as context_too_large", () => {
+    const err = new Error("Request too large: too many tokens in the request");
+    const info = classifyApiError(err);
+    expect(info.category).toBe("context_too_large");
+  });
+
+  it("classifies unknown errors as unknown", () => {
+    const err = new Error("Something unexpected happened");
+    const info = classifyApiError(err);
+    expect(info.category).toBe("unknown");
+    expect(info.status).toBe(0);
+  });
+
+  it("handles non-Error values gracefully", () => {
+    const info = classifyApiError("string error");
+    expect(info.category).toBe("unknown");
+    expect(info.message).toBe("string error");
+  });
+
+  it("truncates long messages to 300 chars", () => {
+    const err = new Error("x".repeat(500));
+    const info = classifyApiError(err);
+    expect(info.message.length).toBeLessThanOrEqual(300);
+  });
+
+  it("extracts error type from nested error.type", () => {
+    const err = { status: 400, error: { type: "invalid_request_error", message: "bad request" }, message: "Bad request" };
+    const info = classifyApiError(err);
+    expect(info.type).toBe("invalid_request_error");
+  });
+
+  it("handles missing error.type gracefully", () => {
+    const err = { status: 500, message: "Internal server error" };
+    const info = classifyApiError(err);
+    expect(info.type).toBe("");
+  });
+});
+
+describe("userErrorMessage", () => {
+  it("returns rate limit message for rate_limit category", () => {
+    const msg = userErrorMessage({ status: 429, type: "rate_limit_error", message: "", category: "rate_limit" });
+    expect(msg).toContain("rate-limited");
+  });
+
+  it("returns model error message for model_error category", () => {
+    const msg = userErrorMessage({ status: 404, type: "not_found_error", message: "", category: "model_error" });
+    expect(msg).toContain("model configuration");
+  });
+
+  it("returns overloaded message for overloaded category", () => {
+    const msg = userErrorMessage({ status: 529, type: "overloaded_error", message: "", category: "overloaded" });
+    expect(msg).toContain("overloaded");
+  });
+
+  it("returns auth message for auth category", () => {
+    const msg = userErrorMessage({ status: 401, type: "", message: "", category: "auth" });
+    expect(msg).toContain("authentication");
+  });
+
+  it("returns context message for context_too_large category", () => {
+    const msg = userErrorMessage({ status: 0, type: "", message: "", category: "context_too_large" });
+    expect(msg).toContain("too much context");
+  });
+
+  it("returns generic message for unknown category", () => {
+    const msg = userErrorMessage({ status: 0, type: "", message: "", category: "unknown" });
+    expect(msg).toContain("technical issue");
+  });
+});

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -1,0 +1,70 @@
+/**
+ * Anthropic API error classification — pure functions for extracting
+ * structured diagnostics from SDK errors and generating user-facing messages.
+ */
+
+export interface ApiErrorInfo {
+  /** HTTP status code (0 if not available) */
+  status: number;
+  /** Anthropic error type (e.g. "rate_limit_error", "model_not_found") */
+  type: string;
+  /** Raw error message (truncated for logging) */
+  message: string;
+  /** User-facing error category */
+  category: "rate_limit" | "model_error" | "overloaded" | "auth" | "context_too_large" | "unknown";
+}
+
+/**
+ * Extracts structured error info from an Anthropic SDK error.
+ *
+ * The SDK throws APIError with `.status`, `.error.type`, and `.message`.
+ * This function normalizes the output for logging and classification.
+ */
+export function classifyApiError(err: unknown): ApiErrorInfo {
+  const status = typeof (err as Record<string, unknown>)?.status === "number"
+    ? (err as Record<string, number>).status
+    : 0;
+
+  // The SDK puts the error type at err.error.type
+  const errorBody = (err as Record<string, unknown>)?.error;
+  const type = typeof errorBody === "object" && errorBody !== null
+    ? String((errorBody as Record<string, unknown>).type ?? "")
+    : "";
+
+  const message = err instanceof Error
+    ? err.message.slice(0, 300)
+    : String(err).slice(0, 300);
+
+  const category = categorize(status, type, message);
+
+  return { status, type, message, category };
+}
+
+function categorize(
+  status: number,
+  type: string,
+  message: string,
+): ApiErrorInfo["category"] {
+  if (status === 429 || type === "rate_limit_error") return "rate_limit";
+  if (status === 401 || status === 403 || type === "authentication_error") return "auth";
+  if (status === 529 || type === "overloaded_error") return "overloaded";
+  if (type === "not_found_error" || message.includes("model")) return "model_error";
+  if (message.includes("too long") || message.includes("too many tokens") || message.includes("context length")) return "context_too_large";
+  return "unknown";
+}
+
+const USER_MESSAGES: Record<ApiErrorInfo["category"], string> = {
+  rate_limit: "I'm being rate-limited by the AI provider. Please try again in a minute.",
+  model_error: "The AI model configuration has an issue. This needs attention from the maintainer.",
+  overloaded: "The AI service is currently overloaded. Please try again shortly.",
+  auth: "There's an authentication issue with the AI provider. This needs attention from the maintainer.",
+  context_too_large: "This question generated too much context for the AI to process. Try asking about a more specific topic.",
+  unknown: "I ran into a technical issue processing this request. Try asking a simpler or more specific question.",
+};
+
+/**
+ * Returns a user-facing error message based on the error category.
+ */
+export function userErrorMessage(info: ApiErrorInfo): string {
+  return USER_MESSAGES[info.category];
+}

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -5,7 +5,8 @@ import { readFile } from "@/lib/github";
 import { getKnowledgeAsMarkdown } from "@/lib/knowledge";
 import { getFeedbackAsMarkdown } from "@/lib/feedback";
 import { getOrRebuildIndex, getCachedConfig } from "@/lib/repo-index";
-import { log } from "@/lib/logger";
+import { log, type RequestLogger } from "@/lib/logger";
+import { classifyApiError, userErrorMessage } from "@/lib/api-error";
 import { shouldWarnBudget, shouldForceStop } from "@/lib/time-budget";
 import type { BattleMageConfig } from "@/lib/config";
 
@@ -262,7 +263,11 @@ export async function runAgent(
   userMessage: string,
   onProgress?: ProgressCallback,
   conversationHistory?: ConversationTurn[],
+  rlog?: RequestLogger,
 ): Promise<AgentResult> {
+  // Use request-scoped logger if provided, fall back to bare log
+  const _log: RequestLogger = rlog ?? log;
+
   // Build messages: optional history + current user message
   const messages: Anthropic.MessageParam[] = [
     ...(conversationHistory ?? []),
@@ -273,14 +278,14 @@ export async function runAgent(
   const allReferences: Reference[] = [];
   const startTime = Date.now();
   const systemPrompt = await buildSystemPrompt();
-  log("agent_start", { promptLength: systemPrompt.length, question: userMessage.slice(0, 100) });
+  _log("agent_start", { promptLength: systemPrompt.length, question: userMessage.slice(0, 100) });
 
   let warned = false;
 
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
     // Time budget check — force-stop if over 5 minutes
     if (shouldForceStop(startTime)) {
-      log("agent_timeout", { rounds: round, duration_ms: Date.now() - startTime });
+      _log("agent_timeout", { rounds: round, duration_ms: Date.now() - startTime });
       const seen = new Set<string>();
       const finalRefs = allReferences.filter((r) => {
         if (seen.has(r.url)) return false;
@@ -304,10 +309,16 @@ export async function runAgent(
         messages,
       });
     } catch (apiErr) {
-      const msg = apiErr instanceof Error ? apiErr.message : String(apiErr);
-      log("agent_api_error", { round, message: msg.slice(0, 200) });
+      const errInfo = classifyApiError(apiErr);
+      _log("agent_api_error", {
+        round,
+        status: errInfo.status,
+        type: errInfo.type,
+        category: errInfo.category,
+        message: errInfo.message,
+      });
       return {
-        text: "I ran into a technical issue processing this request. Try asking a simpler or more specific question.",
+        text: userErrorMessage(errInfo),
         issueProposal,
         references: [],
       };
@@ -332,7 +343,7 @@ export async function runAgent(
         if (b.type === "text") return b.text;
         return "";
       }).join("\n");
-      log("agent_complete", { rounds: round + 1, refCount: allReferences.length, hasProposal: !!issueProposal, duration_ms: Date.now() - startTime });
+      _log("agent_complete", { rounds: round + 1, refCount: allReferences.length, hasProposal: !!issueProposal, duration_ms: Date.now() - startTime });
       return { text, issueProposal, references: dedupeRefs() };
     }
 
@@ -362,7 +373,7 @@ export async function runAgent(
 
       try {
         // Fire progress callback before executing the tool
-        log("agent_tool_call", { tool: block.name, round, input: JSON.stringify(block.input).slice(0, 200) });
+        _log("agent_tool_call", { tool: block.name, round, input: JSON.stringify(block.input).slice(0, 200) });
         if (onProgress) {
           await onProgress(block.name, block.input as Record<string, unknown>);
         }
@@ -406,7 +417,7 @@ export async function runAgent(
     // Inject time budget warning by appending to the last tool result
     if (!warned && shouldWarnBudget(startTime) && toolResults.length > 0) {
       warned = true;
-      log("agent_budget_warning", { round, elapsed_ms: Date.now() - startTime });
+      _log("agent_budget_warning", { round, elapsed_ms: Date.now() - startTime });
       const lastResult = toolResults[toolResults.length - 1];
       const existingContent = typeof lastResult.content === "string" ? lastResult.content : "";
       lastResult.content = existingContent + "\n\n[SYSTEM] You are running low on time. Synthesize your answer NOW with what you have. Do not make more tool calls unless absolutely critical.";

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -11,14 +11,23 @@
  */
 
 export function log(event: string, data?: Record<string, unknown>): void {
-  console.log(JSON.stringify({ event, ...data, ts: Date.now() }));
+  const entry = JSON.stringify({ event, ...data, ts: Date.now() });
+  // Use console.error for error events — Vercel shows these at "error" level
+  // which makes them filterable and visually distinct in the log viewer
+  if (event.includes("error")) {
+    console.error(entry);
+  } else {
+    console.log(entry);
+  }
 }
 
 /**
  * Create a request-scoped logger with a unique ID.
  * All calls from the same logger share a requestId for correlation.
  */
-export function createRequestLogger(): (event: string, data?: Record<string, unknown>) => void {
+export type RequestLogger = (event: string, data?: Record<string, unknown>) => void;
+
+export function createRequestLogger(): RequestLogger {
   const requestId = Math.random().toString(36).slice(2, 10);
   return (event: string, data?: Record<string, unknown>) => {
     log(event, { requestId, ...data });


### PR DESCRIPTION
## Summary

Closes #67

- **API error classification**: New `classifyApiError()` extracts status, type, and category from Anthropic SDK errors. User sees "rate-limited, try again" instead of generic "technical issue" message.
- **Request correlation**: `runAgent()` now accepts the route handler's `RequestLogger`, so all agent loop logs (tool calls, errors, completion) share the same `requestId` — correlatable in Vercel logs.
- **Error log level**: Error events use `console.error()` so Vercel shows them at error level, filterable and visually distinct.
- **Echo event filtering**: Changed `event.subtype === "bot_message"` to `event.subtype` to filter all Slack echo events (`message_changed`, `message_deleted`), reducing ~12 log entries to ~2 per request.

## Files changed

| File | Change |
|------|--------|
| `src/lib/api-error.ts` | New — error classifier with 6 categories |
| `src/lib/api-error.test.ts` | New — 18 tests |
| `src/lib/logger.ts` | `RequestLogger` type export + `console.error` routing |
| `src/lib/claude.ts` | Accepts `rlog` param, rich error logging |
| `src/app/api/slack/route.ts` | Passes `rlog` to `runAgent()`, subtype filter |

## Test plan

- [x] 207 tests pass (18 new + 189 existing)
- [x] Production build clean
- [ ] Deploy and re-test `@bm can you explain about app:init` — error should now show category
- [ ] Verify Vercel logs show error-level entries in red
- [ ] Verify log noise reduced (~2 entries instead of ~12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)