### PR TITLE
fix: Improve log visibility + update model to claude-sonnet-4-6

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -72,9 +72,12 @@ export async function POST(request: NextRequest) {
     const channel: string = event.channel;
     const threadTs: string = event.thread_ts || event.ts;
     const userMessage: string = event.text;
-    rlog("mention_received", { channel, user: event.user, question: userMessage.slice(0, 100) });
+    rlog("mention_start", { channel, user: event.user, thread: !!event.thread_ts, question: userMessage.slice(0, 100) });
 
     // Ack now, process after response is sent (Vercel keeps fn alive)
+    // NOTE: Logs inside after() are NOT visible in Vercel Hobby dashboard per-invocation view.
+    // The "mention_start" line above is the only one visible. Agent loop details
+    // are visible via `vercel logs --no-follow` CLI or on Vercel Pro.
     after(async () => {
       // Hoist thinkingTs so finally can always clean it up
       let thinkingTs: string | undefined;
@@ -203,7 +206,7 @@ export async function POST(request: NextRequest) {
     const channel: string = event.channel;
     const threadTs: string = event.thread_ts;
     const userMessage: string = event.text;
-    rlog("thread_followup", { channel, threadTs });
+    rlog("thread_followup_start", { channel, threadTs, user: event.user, question: userMessage.slice(0, 100) });
 
     after(async () => {
       let thinkTs: string | undefined;

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -13,7 +13,7 @@ import type { BattleMageConfig } from "@/lib/config";
 // ── Anthropic client ──────────────────────────────────────────────────
 const anthropic = new Anthropic(); // reads ANTHROPIC_API_KEY from env
 
-const MODEL = "claude-sonnet-4-20250514";
+const MODEL = "claude-sonnet-4-6";
 export const MAX_TOOL_ROUNDS = 15;
 
 // ── Fetch context files from target repo (cached per cold start) ─────


### PR DESCRIPTION
## Summary

Closes #68. Follow-up to #67.

### Logging visibility
Vercel Hobby dashboard only shows synchronous log lines per invocation — logs from inside `after()` callbacks are invisible in the per-invocation view (only visible via `vercel logs --no-follow` CLI or Vercel Pro).

- Renamed `mention_received` → `mention_start` and `thread_followup` → `thread_followup_start` with richer context (user, question text, thread flag) so the one visible log line per request carries maximum diagnostic value
- Added code comments documenting this platform limitation

### Model update
- Updated from `claude-sonnet-4-20250514` (dated snapshot from May 2025) to `claude-sonnet-4-6` (current Sonnet)
- Prevents future deprecation risk and gets latest model capabilities

## Test plan

- [x] 207 tests pass
- [x] Production build clean
- [ ] After deploy, verify `mention_start` appears in Vercel log viewer with user + question
- [ ] Verify BM answers questions successfully on new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)