### PR TITLE
perf: Prompt caching via cache_control on stable system prompt and tools (#71)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,7 +146,22 @@ The `<output-contract>` block is the single most important piece of prompt engin
 
 ### Why the stable/volatile split
 
-The zoning sets up a future Anthropic prompt-caching pass (tracked in #71): a single `cache_control: {type: "ephemeral"}` breakpoint placed at the end of the stable zone will keep ~80% of the system prompt in cache across turns, since only the volatile tail changes between a question and its follow-up. XML tags also give the model stronger steering signals than plain-text headings.
+The zoning enables Anthropic prompt caching. A single `cache_control: {type: "ephemeral"}` breakpoint sits at the end of the stable zone, so the entire stable prompt is cached and served from cache on subsequent turns in the same thread (5-minute TTL). The volatile tail (KB, feedback, repo-index) changes per turn and stays outside the cache. XML tags also give the model stronger steering signals than plain-text headings.
+
+### Prompt caching (active)
+
+`assembleSystemBlocks()` returns an `Anthropic.TextBlockParam[]` rather than a plain string. The first block carries `cache_control: {type: "ephemeral"}` — Anthropic caches every block up through that marker. The second block (volatile data) has no cache_control and is processed uncached on every turn.
+
+The `tools` array in `src/tools/index.ts` is similarly cached: the last tool (`save_knowledge`) carries the cache_control marker so all seven tool definitions cache together.
+
+Cache metrics are logged in the `agent_complete` event per turn:
+
+- `cache_read_tokens` — tokens served from cache (fast path)
+- `cache_creation_tokens` — tokens written to cache on a miss
+- `input_tokens` — uncached input (the volatile tail + messages)
+- `output_tokens` — model output
+
+A warm thread should see `cache_read_tokens` dominate after the first turn. A cold turn shows all input as `cache_creation_tokens` — expected on the first request and after any 5-minute idle period. Sonnet's minimum cacheable size is 1024 tokens; our stable zone is well above that.
 
 ## The Agent Loop
 

--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { assembleSystemPrompt, MAX_TOOL_ROUNDS } from "./claude";
+import { assembleSystemPrompt, assembleSystemBlocks, MAX_TOOL_ROUNDS } from "./claude";
 
 describe("assembleSystemPrompt", () => {
   const baseArgs = {
@@ -378,5 +378,85 @@ describe("assembleSystemPrompt", () => {
       expect(body).toContain("let me check");
       expect(body).toContain("[text](url)");
     });
+  });
+});
+
+describe("assembleSystemBlocks — prompt caching", () => {
+  const baseArgs = {
+    owner: "acme",
+    repo: "backend",
+    claudeMd: null,
+    knowledge: null,
+    feedback: null,
+    repoIndex: null,
+    pathAnnotations: null,
+  };
+
+  it("returns an array of text content blocks", () => {
+    const blocks = assembleSystemBlocks(baseArgs);
+    expect(Array.isArray(blocks)).toBe(true);
+    expect(blocks.length).toBeGreaterThanOrEqual(2);
+    for (const block of blocks) {
+      expect(block.type).toBe("text");
+      expect(typeof block.text).toBe("string");
+      expect(block.text.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("marks ONLY the stable (first) block with ephemeral cache_control", () => {
+    const blocks = assembleSystemBlocks(baseArgs);
+    expect(blocks[0].cache_control).toEqual({ type: "ephemeral" });
+    for (let i = 1; i < blocks.length; i++) {
+      expect(
+        blocks[i].cache_control,
+        `block[${i}] must not be cached — it is the volatile zone`,
+      ).toBeUndefined();
+    }
+  });
+
+  it("stable block ends at </output-contract> — nothing volatile above the breakpoint", () => {
+    const blocks = assembleSystemBlocks({
+      ...baseArgs,
+      claudeMd: "CLAUDE_MARKER",
+      knowledge: "- KB_MARKER",
+      repoIndex: "- *x*: REPO_INDEX_MARKER",
+    });
+    const stable = blocks[0].text;
+    expect(stable).toContain("</output-contract>");
+    // None of the volatile markers may leak into the cached block
+    expect(stable).not.toContain("CLAUDE_MARKER");
+    expect(stable).not.toContain("KB_MARKER");
+    expect(stable).not.toContain("REPO_INDEX_MARKER");
+    expect(stable).not.toContain("Project Context");
+    expect(stable).not.toContain("learned corrections");
+  });
+
+  it("volatile block carries repo-context and conditional data", () => {
+    const blocks = assembleSystemBlocks({
+      ...baseArgs,
+      claudeMd: "CLAUDE_MARKER",
+      knowledge: "- KB_MARKER",
+    });
+    const volatile = blocks.slice(1).map((b) => b.text).join("\n");
+    expect(volatile).toContain("<repo-context>");
+    expect(volatile).toContain("acme");
+    expect(volatile).toContain("backend");
+    expect(volatile).toContain("CLAUDE_MARKER");
+    expect(volatile).toContain("KB_MARKER");
+  });
+
+  it("concatenated blocks match assembleSystemPrompt output byte-for-byte", () => {
+    // Invariant: the block-based API and the string API produce identical
+    // content — only the cache shape differs.
+    const inputs = {
+      ...baseArgs,
+      claudeMd: "# Project\nAll about widgets",
+      knowledge: "- a fact",
+      feedback: "- some feedback",
+      repoIndex: "- *topic*: src/foo.ts",
+    };
+    const fromBlocks = assembleSystemBlocks(inputs).map((b) => b.text).join("");
+    const fromString = assembleSystemPrompt(inputs);
+    expect(fromBlocks).toBe(fromString);
   });
 });

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -249,15 +249,10 @@ Repository: ${repo}
 </repo-context>`;
 }
 
-export function assembleSystemPrompt(inputs: PromptInputs): string {
-  const { owner, repo, claudeMd, knowledge, feedback, repoIndex, pathAnnotations } = inputs;
-
+function buildStableZone(inputs: PromptInputs): string {
   const today = new Date().toISOString().split("T")[0];
-
-  // Stable zone — ordered for cache-control alignment (identity first,
-  // output-contract last — future cache breakpoint goes after </output-contract>).
-  const stableZone = [
-    buildIdentitySection(owner, repo),
+  return [
+    buildIdentitySection(inputs.owner, inputs.repo),
     buildCorePrinciplesSection(),
     buildSourceHierarchySection(),
     buildToolsSection(),
@@ -265,8 +260,10 @@ export function assembleSystemPrompt(inputs: PromptInputs): string {
     buildKnowledgeBaseUsageSection(),
     buildOutputContractSection(today),
   ].join("\n\n");
+}
 
-  // Volatile zone — conditional data sections, headers retained for test invariants.
+function buildVolatileZone(inputs: PromptInputs): string {
+  const { owner, repo, claudeMd, knowledge, feedback, repoIndex, pathAnnotations } = inputs;
   const contextSection = claudeMd
     ? `\n## Project Context (from CLAUDE.md)\n\n${claudeMd}\n`
     : "";
@@ -281,17 +278,36 @@ export function assembleSystemPrompt(inputs: PromptInputs): string {
     : "";
   const annotationsSection = buildAnnotationsSection(pathAnnotations);
 
-  return `${stableZone}
+  return `\n\n${buildRepoContextSection(owner, repo)}\n${contextSection}${repoIndexSection}${annotationsSection}${knowledgeSection}${feedbackSection}`;
+}
 
-${buildRepoContextSection(owner, repo)}
-${contextSection}${repoIndexSection}${annotationsSection}${knowledgeSection}${feedbackSection}`;
+export function assembleSystemPrompt(inputs: PromptInputs): string {
+  return buildStableZone(inputs) + buildVolatileZone(inputs);
+}
+
+// Returns the system prompt split for Anthropic prompt caching. The stable
+// block carries an ephemeral cache_control breakpoint — Anthropic caches
+// every content block up through and including that marker, so the entire
+// stable zone is served from cache on subsequent turns in the same thread.
+export function assembleSystemBlocks(inputs: PromptInputs): Anthropic.TextBlockParam[] {
+  return [
+    {
+      type: "text",
+      text: buildStableZone(inputs),
+      cache_control: { type: "ephemeral" },
+    },
+    {
+      type: "text",
+      text: buildVolatileZone(inputs),
+    },
+  ];
 }
 
 // ── Async wrapper that fetches data then assembles ────────────────────
-async function buildSystemPrompt(): Promise<string> {
+async function buildSystemBlocks(): Promise<Anthropic.TextBlockParam[]> {
   const repoIndex = await getOrRebuildIndex();
   const config = await getCachedConfig();
-  return assembleSystemPrompt({
+  return assembleSystemBlocks({
     owner: process.env.GITHUB_OWNER,
     repo: process.env.GITHUB_REPO,
     claudeMd: await getClaudeMd(),
@@ -335,10 +351,15 @@ export async function runAgent(
   let issueProposal: IssueProposal | undefined;
   const allReferences: Reference[] = [];
   const startTime = Date.now();
-  const systemPrompt = await buildSystemPrompt();
-  _log("agent_start", { promptLength: systemPrompt.length, question: userMessage.slice(0, 100) });
+  const systemBlocks = await buildSystemBlocks();
+  const promptLength = systemBlocks.reduce((n, b) => n + b.text.length, 0);
+  _log("agent_start", { promptLength, question: userMessage.slice(0, 100) });
 
   let warned = false;
+  let totalCacheRead = 0;
+  let totalCacheCreation = 0;
+  let totalInput = 0;
+  let totalOutput = 0;
 
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
     // Time budget check — force-stop if over 5 minutes
@@ -362,10 +383,14 @@ export async function runAgent(
       response = await anthropic.messages.create({
         model: MODEL,
         max_tokens: 4096,
-        system: systemPrompt,
+        system: systemBlocks,
         tools,
         messages,
       });
+      totalInput += response.usage.input_tokens;
+      totalOutput += response.usage.output_tokens;
+      totalCacheRead += response.usage.cache_read_input_tokens ?? 0;
+      totalCacheCreation += response.usage.cache_creation_input_tokens ?? 0;
     } catch (apiErr) {
       const errInfo = classifyApiError(apiErr);
       _log("agent_api_error", {
@@ -401,7 +426,16 @@ export async function runAgent(
         if (b.type === "text") return b.text;
         return "";
       }).join("\n");
-      _log("agent_complete", { rounds: round + 1, refCount: allReferences.length, hasProposal: !!issueProposal, duration_ms: Date.now() - startTime });
+      _log("agent_complete", {
+        rounds: round + 1,
+        refCount: allReferences.length,
+        hasProposal: !!issueProposal,
+        duration_ms: Date.now() - startTime,
+        input_tokens: totalInput,
+        output_tokens: totalOutput,
+        cache_read_tokens: totalCacheRead,
+        cache_creation_tokens: totalCacheCreation,
+      });
       return { text, issueProposal, references: dedupeRefs() };
     }
 

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { tools } from "./index";
+
+describe("tools registry — prompt caching", () => {
+  it("has all 7 tools", () => {
+    expect(tools).toHaveLength(7);
+  });
+
+  it("caches the tool definitions — only the LAST tool carries cache_control", () => {
+    // Anthropic caches every block up to and including the one marked with
+    // cache_control. Marking only the last tool caches the entire tools array.
+    const last = tools[tools.length - 1];
+    expect(last.cache_control, "last tool must mark the cache breakpoint").toEqual({
+      type: "ephemeral",
+    });
+    for (let i = 0; i < tools.length - 1; i++) {
+      expect(
+        tools[i].cache_control,
+        `tool[${i}] (${tools[i].name}) must not carry cache_control`,
+      ).toBeUndefined();
+    }
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,6 +9,8 @@ import { listCommitsTool, executeListCommits } from "./list-commits";
 import { listPRsTool, executeListPRs } from "./list-prs";
 
 // ── Tool registry ─────────────────────────────────────────────────────
+// Anthropic caches every block up through the one marked with cache_control.
+// Marking only the LAST tool caches the entire tools array as one chunk.
 export const tools: Tool[] = [
   searchCodeTool,
   readFileTool,
@@ -16,7 +18,7 @@ export const tools: Tool[] = [
   listCommitsTool,
   listPRsTool,
   createIssueTool,
-  saveKnowledgeTool,
+  { ...saveKnowledgeTool, cache_control: { type: "ephemeral" } },
 ];
 
 // ── References ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Switches the Anthropic `system` field from a plain string to a **content-block array** where the first block carries `cache_control: {type: "ephemeral"}`. Caches the entire stable zone (identity → core-principles → source-hierarchy → tools → search-strategy → knowledge-base-usage → output-contract). 5-minute TTL.
- Marks the last tool definition (`save_knowledge`) with the same cache_control, so all seven tool specs cache together.
- Emits cache metrics in the `agent_complete` log: `cache_read_tokens`, `cache_creation_tokens`, `input_tokens`, `output_tokens`.

## Why this matters
The XML zoning from #74 was designed to enable this. For a typical thread with 3–5 follow-ups, this should reduce input-token cost by ~40–60% after the first turn and cut first-token latency. Matches the pattern used by getsentry/junior (their pi-ai SDK does this automatically).

## Changes
- `src/lib/claude.ts` — extracts `buildStableZone`/`buildVolatileZone` from the existing assembler, adds `assembleSystemBlocks(): Anthropic.TextBlockParam[]`, updates `runAgent` to pass blocks to `system`, aggregates usage across tool rounds, logs totals at `agent_complete`. `assembleSystemPrompt` unchanged externally — byte-for-byte identical output.
- `src/tools/index.ts` — spreads `save_knowledge` with `cache_control: { type: "ephemeral" }`.
- `src/tools/index.test.ts` — new file, 2 tests: all 7 tools present, only the last carries cache_control.
- `src/lib/claude.test.ts` — 5 new tests for `assembleSystemBlocks` (array shape, cache_control placement, stable/volatile split, byte-for-byte invariant).
- `docs/architecture.md` — documents caching is now active and describes the new cache metrics.

## Invariants preserved
- `assembleSystemPrompt(inputs)` returns exactly the same string as before (new test asserts `stable + volatile === assembleSystemPrompt`).
- All 13 pre-existing test files unchanged; 222 existing tests + 7 new = 229/229 pass.
- No runtime behavior change visible to Slack users.
- Null/undefined guarding on `cache_read_input_tokens` / `cache_creation_input_tokens` (SDK marks them optional).

## Test plan
- [x] `npm test` — 229/229 pass locally
- [x] `npx tsc --noEmit` — clean
- [ ] Post-merge: tail Vercel function logs for `agent_complete` events; confirm `cache_read_tokens` > 0 on the second turn in a thread
- [ ] Post-merge: confirm `cache_creation_tokens` appears on cold turn and stays ~constant (expected: roughly the stable-zone size, ~2k tokens)

## Closes
Closes #71

Part of the roadmap in #84. Next up: #72 (streaming) and #73 validation via #85 (eval harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)