### PR TITLE
feat: Stream Claude responses with throttled Slack message edits (#72)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,11 +165,13 @@ A warm thread should see `cache_read_tokens` dominate after the first turn. A co
 
 ## The Agent Loop
 
-The agent loop is a standard Claude tool-use loop with a hard cap of 15 rounds:
+The agent loop is a streaming Claude tool-use loop with a hard cap of 15 rounds:
 
 ```
 for round in 0..MAX_TOOL_ROUNDS:
-    response = claude.messages.create(system, tools, messages)
+    stream = claude.messages.stream(system, tools, messages)
+    stream.on("text", (_delta, snapshot) => onTextDelta(snapshot))   // Slack streaming
+    response = await stream.finalMessage()
 
     if response.stop_reason == "end_turn":
         return text + references
@@ -185,7 +187,34 @@ if loop exhausted:
     return "hit maximum tool calls" message
 ```
 
-Key behaviors:
+Every round uses `anthropic.messages.stream()` and subscribes to `text` events. On the final round — where Claude produces only text (no `tool_use`) — deltas flow through to Slack in near-real-time. On tool-use rounds, the text event typically doesn't fire (the model emits only tool_use blocks under the output contract), so progress emoji owns the message.
+
+On any streaming error (SDK transport blip), `runAgent` falls back transparently to `anthropic.messages.create()` for that round — the turn keeps going, just without live deltas.
+
+### Streaming into Slack
+
+Text deltas are coalesced by `createThrottledUpdater` in `src/lib/slack-throttle.ts`:
+
+- First update fires immediately.
+- Rapid subsequent updates within 1200 ms are coalesced and fire once with the latest accumulated snapshot — safely below Slack's ~1 edit/sec per-message rate limit.
+- `flush()` drains any pending edit before the final-answer write, preventing a race.
+
+Slack mrkdwn conversion (`toSlackMrkdwn`) runs on every streamed edit as a safety net — with the output contract in place, the model emits single-asterisk bold natively so conversion is near-idempotent.
+
+### One-message lifecycle
+
+The thinking message is created once and **reused as the final answer** — no delete-and-repost flicker. Sequence:
+
+1. Post thinking message: "Battle Mage is working…"
+2. Tool round: emoji + status via `onProgress` → `updateMessage(thinkingTs, ...)`
+3. Final round: text deltas via `onTextDelta` → throttled `updateMessage(thinkingTs, ...)`
+4. `runAgent` returns; `streamThrottle.flush()` drains pending edits
+5. Final edit: formatted text + references footer (and proposal block if present) → `updateMessage(thinkingTs, finalBody)`
+6. Store Q&A context using the former `thinkingTs` (now the answer `ts`)
+
+The `finally` block still deletes the thinking message as a safety net if the turn crashed mid-flight.
+
+### Other key behaviors
 
 - **References are collected from tool results**, not from Claude's text. Each tool that accesses a file or issue returns structured `Reference` objects with labels, URLs, and types (`file`, `doc`, `issue`, `pr`, `commit`).
 - **References are ranked** by the source-of-truth hierarchy before display: code files first, then tests, then cited refs, then docs, then uncited list results. This is done by `rankReferences()` in `references.ts`.

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -121,6 +121,10 @@ export async function POST(request: NextRequest) {
         const result = await runAgent(
           augmentedMessage,
           async (toolName, input) => {
+            // Progress emoji takes over — drop any pending streamed text that
+            // was queued during the prior round, otherwise it could land and
+            // overwrite the emoji after this call.
+            streamThrottle.cancel();
             if (thinkingTs) {
               await updateMessage(channel, thinkingTs, buildThinkingMessage(toolName, input));
             }
@@ -131,7 +135,8 @@ export async function POST(request: NextRequest) {
         );
         // Drain any pending streamed edit so it doesn't race the final write
         await streamThrottle.flush();
-        rlog("agent_complete", { rounds: result.references.length, hasProposal: !!result.issueProposal, refCount: result.references.length });
+        // `agent_complete` is already emitted by runAgent with rounds, token
+        // usage, and cache metrics — don't duplicate it at the route level.
 
         const text = toSlackMrkdwn(result.text);
         const rankedRefs = rankReferences(result.references, result.text);
@@ -293,6 +298,9 @@ export async function POST(request: NextRequest) {
         const result = await runAgent(
           followupMessage,
           async (toolName, input) => {
+            // See the mention handler: cancel pending streamed text so
+            // the emoji progress isn't overwritten by a late flush.
+            followupThrottle.cancel();
             if (thinkTs) {
               await updateMessage(channel, thinkTs, buildThinkingMessage(toolName, input));
             }

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -18,6 +18,7 @@ import { getAllKnowledge } from "@/lib/knowledge";
 import { buildCorrectionActions } from "@/lib/auto-correct";
 import { buildThinkingMessage, THINKING_HEADER } from "@/lib/progress";
 import { toSlackMrkdwn } from "@/lib/mrkdwn";
+import { createThrottledUpdater } from "@/lib/slack-throttle";
 import { createRequestLogger } from "@/lib/logger";
 import { getCachedTopics } from "@/lib/repo-index";
 import { matchTopicsToQuestion, buildQuestionHints } from "@/lib/topic-match";
@@ -109,27 +110,32 @@ export async function POST(request: NextRequest) {
           rlog("topic_hints_injected", { topics: topicMatches.map((m) => m.topic), fileCount: topicMatches.reduce((s, m) => s + m.paths.length, 0) });
         }
 
-        const result = await runAgent(augmentedMessage, async (toolName, input) => {
+        // Throttle streaming text deltas into the thinking message. Slack's
+        // chat.update is ~1/sec per message; 1200ms keeps us safely under.
+        const streamThrottle = createThrottledUpdater(async (snapshot) => {
           if (thinkingTs) {
-            await updateMessage(channel, thinkingTs, buildThinkingMessage(toolName, input));
+            await updateMessage(channel, thinkingTs, toSlackMrkdwn(snapshot));
           }
-        }, mentionHistory, rlog);
-        rlog("agent_complete", { rounds: result.references.length, hasProposal: !!result.issueProposal, refCount: result.references.length });
+        }, 1200);
 
-        // Update thinking message to "composing" before posting answer
-        if (thinkingTs) {
-          await updateMessage(channel, thinkingTs, buildThinkingMessage("composing", {}));
-        }
+        const result = await runAgent(
+          augmentedMessage,
+          async (toolName, input) => {
+            if (thinkingTs) {
+              await updateMessage(channel, thinkingTs, buildThinkingMessage(toolName, input));
+            }
+          },
+          mentionHistory,
+          rlog,
+          (snapshot) => streamThrottle.update(snapshot),
+        );
+        // Drain any pending streamed edit so it doesn't race the final write
+        await streamThrottle.flush();
+        rlog("agent_complete", { rounds: result.references.length, hasProposal: !!result.issueProposal, refCount: result.references.length });
 
         const text = toSlackMrkdwn(result.text);
         const rankedRefs = rankReferences(result.references, result.text);
         const refsFooter = formatReferences(rankedRefs);
-
-        // Delete thinking message — the answer replaces it
-        if (thinkingTs) {
-          await deleteMessage(channel, thinkingTs);
-          thinkingTs = undefined; // Mark as cleaned up
-        }
 
         if (result.issueProposal) {
           const proposal = result.issueProposal;
@@ -137,23 +143,35 @@ export async function POST(request: NextRequest) {
             ? `\nLabels: ${proposal.labels.join(", ")}`
             : "";
 
-          await replyInThread(
-            channel,
-            threadTs,
-            [
-              text,
-              "",
-              "───────────────────",
-              `*Proposed Issue:* ${proposal.title}${labelsText}`,
-              "",
-              proposal.body,
-              "",
-              "React with :white_check_mark: to create this issue, or ignore to cancel.",
-            ].join("\n") + refsFooter,
-          );
+          const finalBody = [
+            text,
+            "",
+            "───────────────────",
+            `*Proposed Issue:* ${proposal.title}${labelsText}`,
+            "",
+            proposal.body,
+            "",
+            "React with :white_check_mark: to create this issue, or ignore to cancel.",
+          ].join("\n") + refsFooter;
+
+          if (thinkingTs) {
+            // Reuse the thinking/streamed message as the final answer.
+            await updateMessage(channel, thinkingTs, finalBody);
+            thinkingTs = undefined; // Mark as finalized — prevent finally-cleanup.
+          } else {
+            await replyInThread(channel, threadTs, finalBody);
+          }
           rlog("answer_posted", { channel, threadTs });
         } else {
-          const replyTs = await replyInThread(channel, threadTs, text + refsFooter);
+          const finalBody = text + refsFooter;
+          let replyTs: string | undefined;
+          if (thinkingTs) {
+            await updateMessage(channel, thinkingTs, finalBody);
+            replyTs = thinkingTs;
+            thinkingTs = undefined; // Mark as finalized.
+          } else {
+            replyTs = await replyInThread(channel, threadTs, finalBody);
+          }
           rlog("answer_posted", { channel, threadTs });
 
           // Store Q&A context so 👍/👎 reactions can reference it
@@ -265,24 +283,29 @@ export async function POST(request: NextRequest) {
         const followupMatches = matchTopicsToQuestion(cleanMessage, followupTopics);
         const followupMessage = buildQuestionHints(cleanMessage, followupMatches);
 
-        const result = await runAgent(followupMessage, async (toolName, input) => {
+        // Throttle streaming text deltas into the thinking message.
+        const followupThrottle = createThrottledUpdater(async (snapshot) => {
           if (thinkTs) {
-            await updateMessage(channel, thinkTs, buildThinkingMessage(toolName, input));
+            await updateMessage(channel, thinkTs, toSlackMrkdwn(snapshot));
           }
-        }, history, rlog);
+        }, 1200);
 
-        if (thinkTs) {
-          await updateMessage(channel, thinkTs, buildThinkingMessage("composing", {}));
-        }
+        const result = await runAgent(
+          followupMessage,
+          async (toolName, input) => {
+            if (thinkTs) {
+              await updateMessage(channel, thinkTs, buildThinkingMessage(toolName, input));
+            }
+          },
+          history,
+          rlog,
+          (snapshot) => followupThrottle.update(snapshot),
+        );
+        await followupThrottle.flush();
 
         const text = toSlackMrkdwn(result.text);
         const rankedRefs = rankReferences(result.references, result.text);
         const refsFooter = formatReferences(rankedRefs);
-
-        if (thinkTs) {
-          await deleteMessage(channel, thinkTs);
-          thinkTs = undefined; // Mark as cleaned up
-        }
 
         if (result.issueProposal) {
           const proposal = result.issueProposal;
@@ -290,22 +313,33 @@ export async function POST(request: NextRequest) {
             ? `\nLabels: ${proposal.labels.join(", ")}`
             : "";
 
-          await replyInThread(
-            channel,
-            threadTs,
-            [
-              text,
-              "",
-              "───────────────────",
-              `*Proposed Issue:* ${proposal.title}${labelsText}`,
-              "",
-              proposal.body,
-              "",
-              "React with :white_check_mark: to create this issue, or ignore to cancel.",
-            ].join("\n") + refsFooter,
-          );
+          const finalBody = [
+            text,
+            "",
+            "───────────────────",
+            `*Proposed Issue:* ${proposal.title}${labelsText}`,
+            "",
+            proposal.body,
+            "",
+            "React with :white_check_mark: to create this issue, or ignore to cancel.",
+          ].join("\n") + refsFooter;
+
+          if (thinkTs) {
+            await updateMessage(channel, thinkTs, finalBody);
+            thinkTs = undefined;
+          } else {
+            await replyInThread(channel, threadTs, finalBody);
+          }
         } else {
-          const replyTs = await replyInThread(channel, threadTs, text + refsFooter);
+          const finalBody = text + refsFooter;
+          let replyTs: string | undefined;
+          if (thinkTs) {
+            await updateMessage(channel, thinkTs, finalBody);
+            replyTs = thinkTs;
+            thinkTs = undefined;
+          } else {
+            replyTs = await replyInThread(channel, threadTs, finalBody);
+          }
 
           if (replyTs) {
             await storeQAContext(channel, replyTs, {

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -124,7 +124,7 @@ export async function POST(request: NextRequest) {
             // Progress emoji takes over — drop any pending streamed text that
             // was queued during the prior round, otherwise it could land and
             // overwrite the emoji after this call.
-            streamThrottle.cancel();
+            await streamThrottle.cancel();
             if (thinkingTs) {
               await updateMessage(channel, thinkingTs, buildThinkingMessage(toolName, input));
             }
@@ -300,7 +300,7 @@ export async function POST(request: NextRequest) {
           async (toolName, input) => {
             // See the mention handler: cancel pending streamed text so
             // the emoji progress isn't overwritten by a late flush.
-            followupThrottle.cancel();
+            await followupThrottle.cancel();
             if (thinkTs) {
               await updateMessage(channel, thinkTs, buildThinkingMessage(toolName, input));
             }

--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { assembleSystemPrompt, assembleSystemBlocks, MAX_TOOL_ROUNDS } from "./claude";
+import { describe, it, expect, vi } from "vitest";
+import { assembleSystemPrompt, assembleSystemBlocks, safeInvokeTextDelta, MAX_TOOL_ROUNDS } from "./claude";
 
 describe("assembleSystemPrompt", () => {
   const baseArgs = {
@@ -458,5 +458,66 @@ describe("assembleSystemBlocks — prompt caching", () => {
     const fromBlocks = assembleSystemBlocks(inputs).map((b) => b.text).join("");
     const fromString = assembleSystemPrompt(inputs);
     expect(fromBlocks).toBe(fromString);
+  });
+});
+
+describe("safeInvokeTextDelta — streaming callback safety", () => {
+  it("invokes the callback with the snapshot", async () => {
+    const cb = vi.fn();
+    safeInvokeTextDelta(cb, "Hello world");
+    // Microtask-scheduled — flush the queue
+    await Promise.resolve();
+    expect(cb).toHaveBeenCalledOnce();
+    expect(cb).toHaveBeenCalledWith("Hello world");
+  });
+
+  it("is a no-op when the callback is undefined", () => {
+    expect(() => safeInvokeTextDelta(undefined, "anything")).not.toThrow();
+  });
+
+  it("swallows synchronous throws from the callback", async () => {
+    const cb = vi.fn(() => {
+      throw new Error("sync boom");
+    });
+    expect(() => safeInvokeTextDelta(cb, "x")).not.toThrow();
+    // Flush the microtask where the callback actually runs
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(cb).toHaveBeenCalled();
+  });
+
+  it("swallows async rejections from the callback (no unhandled promise rejection)", async () => {
+    const cb = vi.fn(async () => {
+      throw new Error("async boom");
+    });
+    safeInvokeTextDelta(cb, "y");
+    // Let the rejection + catch() propagate through the microtask queue
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(cb).toHaveBeenCalled();
+    // If the rejection were unhandled, vitest would fail the test here.
+  });
+
+  it("supports sync-returning callbacks", async () => {
+    let seen = "";
+    const cb = (snap: string): void => {
+      seen = snap;
+    };
+    safeInvokeTextDelta(cb, "streamed");
+    await Promise.resolve();
+    expect(seen).toBe("streamed");
+  });
+
+  it("supports async-returning callbacks", async () => {
+    let seen = "";
+    const cb = async (snap: string): Promise<void> => {
+      await Promise.resolve();
+      seen = snap;
+    };
+    safeInvokeTextDelta(cb, "async streamed");
+    // Two awaits for the inner await + the outer .then
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(seen).toBe("async streamed");
   });
 });

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -329,6 +329,19 @@ export interface AgentResult {
 export type ProgressCallback = (toolName: string, input: Record<string, unknown>) => void | Promise<void>;
 export type TextDeltaCallback = (snapshot: string) => void | Promise<void>;
 
+// Invokes an optional text-delta callback safely. Swallows both synchronous
+// throws and async rejections so a faulty handler cannot surface as an
+// unhandled rejection and destabilize the runtime. Exported for testing.
+export function safeInvokeTextDelta(
+  onTextDelta: TextDeltaCallback | undefined,
+  snapshot: string,
+): void {
+  if (!onTextDelta) return;
+  Promise.resolve()
+    .then(() => onTextDelta(snapshot))
+    .catch(() => {});
+}
+
 export interface ConversationTurn {
   role: "user" | "assistant";
   content: string;
@@ -342,12 +355,9 @@ async function anthropicCall(
 ): Promise<Anthropic.Message> {
   try {
     const stream = anthropic.messages.stream(params);
-    if (onTextDelta) {
-      stream.on("text", (_delta, snapshot) => {
-        // Fire-and-forget — the throttled updater handles its own errors.
-        void onTextDelta(snapshot);
-      });
-    }
+    stream.on("text", (_delta, snapshot) => {
+      safeInvokeTextDelta(onTextDelta, snapshot);
+    });
     return await stream.finalMessage();
   } catch (streamErr) {
     _log("agent_stream_fallback", {

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -327,10 +327,35 @@ export interface AgentResult {
 }
 
 export type ProgressCallback = (toolName: string, input: Record<string, unknown>) => void | Promise<void>;
+export type TextDeltaCallback = (snapshot: string) => void | Promise<void>;
 
 export interface ConversationTurn {
   role: "user" | "assistant";
   content: string;
+}
+
+async function anthropicCall(
+  params: Anthropic.MessageCreateParamsNonStreaming,
+  onTextDelta: TextDeltaCallback | undefined,
+  _log: RequestLogger,
+  round: number,
+): Promise<Anthropic.Message> {
+  try {
+    const stream = anthropic.messages.stream(params);
+    if (onTextDelta) {
+      stream.on("text", (_delta, snapshot) => {
+        // Fire-and-forget — the throttled updater handles its own errors.
+        void onTextDelta(snapshot);
+      });
+    }
+    return await stream.finalMessage();
+  } catch (streamErr) {
+    _log("agent_stream_fallback", {
+      round,
+      error: streamErr instanceof Error ? streamErr.message : String(streamErr),
+    });
+    return await anthropic.messages.create(params);
+  }
 }
 
 export async function runAgent(
@@ -338,6 +363,7 @@ export async function runAgent(
   onProgress?: ProgressCallback,
   conversationHistory?: ConversationTurn[],
   rlog?: RequestLogger,
+  onTextDelta?: TextDeltaCallback,
 ): Promise<AgentResult> {
   // Use request-scoped logger if provided, fall back to bare log
   const _log: RequestLogger = rlog ?? log;
@@ -380,13 +406,18 @@ export async function runAgent(
 
     let response;
     try {
-      response = await anthropic.messages.create({
-        model: MODEL,
-        max_tokens: 4096,
-        system: systemBlocks,
-        tools,
-        messages,
-      });
+      response = await anthropicCall(
+        {
+          model: MODEL,
+          max_tokens: 4096,
+          system: systemBlocks,
+          tools,
+          messages,
+        },
+        onTextDelta,
+        _log,
+        round,
+      );
       totalInput += response.usage.input_tokens;
       totalOutput += response.usage.output_tokens;
       totalCacheRead += response.usage.cache_read_input_tokens ?? 0;

--- a/src/lib/slack-throttle.test.ts
+++ b/src/lib/slack-throttle.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createThrottledUpdater } from "./slack-throttle";
+
+describe("createThrottledUpdater", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires the first update immediately", async () => {
+    const fn = vi.fn(async (_text: string) => {});
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    throttle.update("first");
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fn).toHaveBeenCalledOnce();
+    expect(fn).toHaveBeenCalledWith("first");
+  });
+
+  it("coalesces rapid updates within the min interval into one deferred call with the latest text", async () => {
+    const fn = vi.fn(async (_text: string) => {});
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    throttle.update("a"); // immediate
+    await vi.advanceTimersByTimeAsync(0);
+    throttle.update("b"); // deferred
+    throttle.update("c"); // deferred, replaces b
+    throttle.update("d"); // deferred, replaces c
+
+    // Before the interval elapses, still only 1 call
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // After interval: the deferred flush fires with the LATEST text
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(2, "d");
+  });
+
+  it("fires immediately if enough time has elapsed since the last flush", async () => {
+    const fn = vi.fn(async (_text: string) => {});
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    throttle.update("a");
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1500); // well past interval
+    throttle.update("b");
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(2, "b");
+  });
+
+  it("flush() forces the pending update immediately and clears the timer", async () => {
+    const fn = vi.fn(async (_text: string) => {});
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    throttle.update("first"); // fires immediately
+    await vi.advanceTimersByTimeAsync(0);
+    throttle.update("second"); // deferred
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await throttle.flush();
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(2, "second");
+
+    // After flush, a later update that's within the interval still defers correctly
+    throttle.update("third");
+    expect(fn).toHaveBeenCalledTimes(2); // not yet
+  });
+
+  it("flush() is a no-op when nothing is pending", async () => {
+    const fn = vi.fn(async (_text: string) => {});
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    await throttle.flush();
+    expect(fn).not.toHaveBeenCalled();
+
+    throttle.update("x");
+    await vi.advanceTimersByTimeAsync(0);
+    await throttle.flush();
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it("swallows errors from the update function without breaking throttling", async () => {
+    const fn = vi.fn(async (_text: string) => {
+      throw new Error("slack rate limit");
+    });
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    throttle.update("boom");
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Subsequent update should still be accepted
+    await vi.advanceTimersByTimeAsync(1500);
+    throttle.update("after");
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/slack-throttle.test.ts
+++ b/src/lib/slack-throttle.test.ts
@@ -101,4 +101,84 @@ describe("createThrottledUpdater", () => {
 
     expect(fn).toHaveBeenCalledTimes(2);
   });
+
+  it("serializes fn() — never runs concurrently even when fn is slower than the interval", async () => {
+    let inflight = 0;
+    let maxInflight = 0;
+    const fn = vi.fn(async (_text: string) => {
+      inflight++;
+      maxInflight = Math.max(maxInflight, inflight);
+      await new Promise((r) => setTimeout(r, 2000)); // slow fn
+      inflight--;
+    });
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    // t=0: fires immediately, fn("a") starts a 2000ms call
+    throttle.update("a");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(inflight).toBe(1);
+
+    // t=1500: interval has elapsed but "a" is still in flight — must NOT start "b"
+    await vi.advanceTimersByTimeAsync(1500);
+    throttle.update("b");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(
+      maxInflight,
+      "second fn() call started before first finished — concurrent writes",
+    ).toBe(1);
+
+    // Let "a" finish; "b" may then start (serialized)
+    await vi.advanceTimersByTimeAsync(2500);
+    expect(maxInflight).toBe(1);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("flush() awaits an in-flight fn() before returning", async () => {
+    let completed = false;
+    const fn = vi.fn(async (_text: string) => {
+      await new Promise((r) => setTimeout(r, 2000));
+      completed = true;
+    });
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    throttle.update("x");
+    await vi.advanceTimersByTimeAsync(0); // fn starts
+    expect(completed).toBe(false);
+
+    const flushDone = vi.fn();
+    const flushPromise = throttle.flush().then(flushDone);
+
+    // Before fn finishes: flush should NOT have resolved
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(completed).toBe(false);
+    expect(flushDone).not.toHaveBeenCalled();
+
+    // Let fn finish
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushPromise;
+    expect(completed).toBe(true);
+    expect(flushDone).toHaveBeenCalled();
+  });
+
+  it("cancel() drops pending text and clears the timer — no further fn() calls", async () => {
+    const fn = vi.fn(async (_text: string) => {});
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    // First update fires immediately
+    throttle.update("first");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Queue a deferred update, then cancel — the timer must not fire
+    throttle.update("pending");
+    throttle.cancel();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fn).toHaveBeenCalledTimes(1); // still just "first"
+
+    // After cancel, update() still works for fresh calls
+    throttle.update("after-cancel");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(2, "after-cancel");
+  });
 });

--- a/src/lib/slack-throttle.test.ts
+++ b/src/lib/slack-throttle.test.ts
@@ -171,7 +171,7 @@ describe("createThrottledUpdater", () => {
 
     // Queue a deferred update, then cancel — the timer must not fire
     throttle.update("pending");
-    throttle.cancel();
+    await throttle.cancel();
     await vi.advanceTimersByTimeAsync(5000);
     expect(fn).toHaveBeenCalledTimes(1); // still just "first"
 
@@ -180,5 +180,36 @@ describe("createThrottledUpdater", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(fn).toHaveBeenCalledTimes(2);
     expect(fn).toHaveBeenNthCalledWith(2, "after-cancel");
+  });
+
+  it("cancel() awaits an in-flight fn() — no stale writes can land after it resolves", async () => {
+    // Scenario: a slow streaming edit is still running when onProgress fires
+    // and calls cancel() before writing an emoji update. cancel() must block
+    // until the streamed write is done, otherwise the emoji could be
+    // overwritten by the delayed Slack response.
+    let completed = false;
+    const fn = vi.fn(async (_text: string) => {
+      await new Promise((r) => setTimeout(r, 2000));
+      completed = true;
+    });
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    throttle.update("streamed"); // starts fn, takes 2000ms
+    await vi.advanceTimersByTimeAsync(0);
+    expect(completed).toBe(false);
+
+    // cancel() must NOT resolve before fn completes
+    const cancelDone = vi.fn();
+    const cancelPromise = throttle.cancel().then(cancelDone);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(completed).toBe(false);
+    expect(cancelDone).not.toHaveBeenCalled();
+
+    // Let fn finish
+    await vi.advanceTimersByTimeAsync(1000);
+    await cancelPromise;
+    expect(completed).toBe(true);
+    expect(cancelDone).toHaveBeenCalled();
   });
 });

--- a/src/lib/slack-throttle.ts
+++ b/src/lib/slack-throttle.ts
@@ -1,7 +1,7 @@
 export interface ThrottledUpdater {
   update(text: string): void;
   flush(): Promise<void>;
-  cancel(): void;
+  cancel(): Promise<void>;
 }
 
 // Coalesces rapid update() calls into at most one flush per minIntervalMs,
@@ -92,12 +92,20 @@ export function createThrottledUpdater(
         }
       }
     },
-    cancel(): void {
+    async cancel(): Promise<void> {
+      // Drop the deferred timer and any pending text immediately.
       if (timer) {
         clearTimeout(timer);
         timer = null;
       }
       pendingText = null;
+      // If a fn() call is already running, await it so the caller can be
+      // sure no throttled Slack write will land after cancel() resolves —
+      // important for the route to avoid stale streamed text overwriting
+      // a fresh emoji progress update on the same message.
+      if (busy) {
+        await inFlight.catch(() => {});
+      }
     },
   };
 }

--- a/src/lib/slack-throttle.ts
+++ b/src/lib/slack-throttle.ts
@@ -1,12 +1,22 @@
 export interface ThrottledUpdater {
   update(text: string): void;
   flush(): Promise<void>;
+  cancel(): void;
 }
 
-// Coalesces rapid update() calls into at most one flush per minIntervalMs.
-// The first call fires immediately; further calls within the interval are
-// queued and collapsed to the LATEST text. flush() forces a pending write
-// immediately and is safe to call repeatedly or when nothing is pending.
+// Coalesces rapid update() calls into at most one flush per minIntervalMs,
+// and serializes flushes so fn() never runs concurrently — important when
+// fn is an async Slack chat.update that can exceed the interval under rate
+// limiting.
+//
+// - First update fires immediately (if not busy).
+// - Subsequent updates within the interval collapse to the LATEST text.
+// - If fn takes longer than the interval, further updates wait for it;
+//   the next fn() call is scheduled onto the in-flight chain.
+// - flush() awaits any in-flight fn() AND any pending text, returning only
+//   when Slack has observed the final state.
+// - cancel() drops pending text and clears the timer without firing —
+//   used by the route when emoji progress takes over from streamed text.
 export function createThrottledUpdater(
   fn: (text: string) => Promise<void>,
   minIntervalMs: number,
@@ -14,50 +24,80 @@ export function createThrottledUpdater(
 ): ThrottledUpdater {
   let lastFlushAt = -Infinity;
   let pendingText: string | null = null;
-  let pendingPromise: Promise<void> | null = null;
+  let inFlight: Promise<void> = Promise.resolve();
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let busy = false;
 
-  const doFlush = async (text: string): Promise<void> => {
-    lastFlushAt = now();
+  function fireNow(): void {
+    if (pendingText === null || busy) return;
+    const text = pendingText;
     pendingText = null;
-    try {
-      await fn(text);
-    } catch {
-      // Swallow — transient Slack errors (rate limit, message deleted) must not
-      // break the agent loop. The next update will retry.
+    busy = true;
+    inFlight = (async () => {
+      try {
+        await fn(text);
+      } catch {
+        // Swallow — transient Slack errors (rate limit, deleted message)
+        // must not break the agent loop.
+      }
+      busy = false;
+      lastFlushAt = now();
+      // A later update() may have arrived while fn() was running;
+      // re-check schedule so it gets picked up.
+      maybeSchedule();
+    })();
+  }
+
+  function maybeSchedule(): void {
+    if (pendingText === null || busy || timer) return;
+    const elapsed = now() - lastFlushAt;
+    if (elapsed >= minIntervalMs) {
+      fireNow();
+      return;
     }
-  };
+    const delay = Math.max(0, minIntervalMs - elapsed);
+    timer = setTimeout(() => {
+      timer = null;
+      fireNow();
+    }, delay);
+  }
 
   return {
     update(text: string): void {
       pendingText = text;
-      const elapsed = now() - lastFlushAt;
-      if (elapsed >= minIntervalMs && !timer) {
-        pendingPromise = doFlush(text);
-        return;
-      }
-      if (!timer) {
-        const delay = Math.max(0, minIntervalMs - elapsed);
-        timer = setTimeout(() => {
-          timer = null;
-          const t = pendingText;
-          if (t !== null) {
-            pendingPromise = doFlush(t);
-          }
-        }, delay);
-      }
+      maybeSchedule();
     },
     async flush(): Promise<void> {
       if (timer) {
         clearTimeout(timer);
         timer = null;
       }
-      if (pendingPromise) {
-        await pendingPromise.catch(() => {});
+      // Drain any currently running fn() call first.
+      await inFlight.catch(() => {});
+      // If the above finalizer scheduled another fireNow, drain that too.
+      while (busy || pendingText !== null) {
+        if (pendingText !== null && !busy) {
+          const text = pendingText;
+          pendingText = null;
+          busy = true;
+          try {
+            await fn(text);
+          } catch {
+            // swallow
+          }
+          busy = false;
+          lastFlushAt = now();
+        } else if (busy) {
+          await inFlight.catch(() => {});
+        }
       }
-      if (pendingText !== null) {
-        await doFlush(pendingText);
+    },
+    cancel(): void {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
       }
+      pendingText = null;
     },
   };
 }

--- a/src/lib/slack-throttle.ts
+++ b/src/lib/slack-throttle.ts
@@ -1,0 +1,63 @@
+export interface ThrottledUpdater {
+  update(text: string): void;
+  flush(): Promise<void>;
+}
+
+// Coalesces rapid update() calls into at most one flush per minIntervalMs.
+// The first call fires immediately; further calls within the interval are
+// queued and collapsed to the LATEST text. flush() forces a pending write
+// immediately and is safe to call repeatedly or when nothing is pending.
+export function createThrottledUpdater(
+  fn: (text: string) => Promise<void>,
+  minIntervalMs: number,
+  now: () => number = Date.now,
+): ThrottledUpdater {
+  let lastFlushAt = -Infinity;
+  let pendingText: string | null = null;
+  let pendingPromise: Promise<void> | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const doFlush = async (text: string): Promise<void> => {
+    lastFlushAt = now();
+    pendingText = null;
+    try {
+      await fn(text);
+    } catch {
+      // Swallow — transient Slack errors (rate limit, message deleted) must not
+      // break the agent loop. The next update will retry.
+    }
+  };
+
+  return {
+    update(text: string): void {
+      pendingText = text;
+      const elapsed = now() - lastFlushAt;
+      if (elapsed >= minIntervalMs && !timer) {
+        pendingPromise = doFlush(text);
+        return;
+      }
+      if (!timer) {
+        const delay = Math.max(0, minIntervalMs - elapsed);
+        timer = setTimeout(() => {
+          timer = null;
+          const t = pendingText;
+          if (t !== null) {
+            pendingPromise = doFlush(t);
+          }
+        }, delay);
+      }
+    },
+    async flush(): Promise<void> {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      if (pendingPromise) {
+        await pendingPromise.catch(() => {});
+      }
+      if (pendingText !== null) {
+        await doFlush(pendingText);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Switches the agent loop to `anthropic.messages.stream()` and subscribes to text events. On the final round (text-only, no tool_use) deltas stream into the Slack thinking message via a new `onTextDelta` callback — user sees the answer appearing as it's generated instead of waiting for the whole response.
- Reuses the thinking message as the final answer — **one-message lifecycle**. No more delete-and-repost flicker after streaming built up the answer.
- Applied to both the `@bm` mention handler AND the thread-follow-up handler for consistent UX.
- On streaming error, transparently falls back to `messages.create()` for that round — turn keeps going, just without live deltas.

## Why this matters
Final piece of Phase 1 in the [junior-comparison roadmap](https://github.com/vlad-ko/battle-mage/issues/84). For a typical turn — 3 tool calls (~10s) then ~3s of answer generation — the user now sees the first text within ~300ms of the model starting to respond, instead of waiting for the full response. Makes the bot feel dramatically more alive during the final synthesis phase.

## Changes
- `src/lib/slack-throttle.ts` (new, 54 lines) — pure coalescing updater. First update fires immediately; rapid subsequent updates within 1200ms collapse to the latest snapshot; `flush()` drains pending edits.
- `src/lib/slack-throttle.test.ts` (new, 6 tests) — immediate fire, coalescing with fake timers, interval respect, flush, flush-noop, error swallowing.
- `src/lib/claude.ts` — adds `TextDeltaCallback` type and optional `onTextDelta` parameter to `runAgent`; extracts `anthropicCall()` helper that tries streaming first and falls back to non-streaming on error (logged as `agent_stream_fallback`).
- `src/app/api/slack/route.ts` — wires `onTextDelta` through `createThrottledUpdater(1200ms)` to `updateMessage`. Removes delete-and-repost in favor of final `updateMessage(thinkingTs, finalBody)`. Both mention and follow-up handlers.
- `docs/architecture.md` — new "Streaming into Slack" and "One-message lifecycle" sections.

## Throttling choice
Slack's `chat.update` is effectively ~1/sec per message. 1200ms interval coalesces stream bursts to ~1 Slack API call/sec. `toSlackMrkdwn` runs on every streamed edit as a safety net; with the output contract from #73 in place, the model already emits single-asterisk bold, so conversion is near-idempotent — no visible format flicker.

## Invariants preserved
- Tool rounds unchanged — emoji + status via `onProgress` still owns the message during tool_use rounds.
- Existing `finally` block still deletes the thinking message as a safety net on mid-flight errors.
- Issue-proposal flow still produces a bot message containing the proposal text that a user can ✅-react to.
- Q&A context storage still wired up (now keyed by the former `thinkingTs`, which is now the answer `ts`).
- Full suite 235/235 green. TypeScript clean.

## Test plan
- [x] `npm test` — 229 + 6 new = 235 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Post-merge Slack smoke: `@bm` a simple question; verify text streams in, message finalizes with refs footer, no flicker
- [ ] Post-merge Slack smoke: follow-up in same thread; verify same streaming behavior
- [ ] Post-merge Slack smoke: ask for an issue — verify proposal flow still ✅-reacts correctly
- [ ] Post-merge Vercel logs: confirm no `agent_stream_fallback` events during happy-path turns

## Phase 1 complete
With this PR, the four Phase-1 items from the [junior teardown roadmap](https://github.com/vlad-ko/battle-mage/issues/84) are shipped:
- ✅ #73 — Output contract
- ✅ #74 — XML prompt refactor
- ✅ #71 — Prompt caching
- ✅ #72 — **Streaming (this PR)**

Next up: Phase 2 opens with #85 eval harness to make the remaining improvements measurable.

## Closes
Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)