### PR TITLE
fix: Flush logs at end of every after() block to close #90 observability gap

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -19,7 +19,7 @@ import { buildCorrectionActions } from "@/lib/auto-correct";
 import { buildThinkingMessage, THINKING_HEADER } from "@/lib/progress";
 import { toSlackMrkdwn } from "@/lib/mrkdwn";
 import { createThrottledUpdater } from "@/lib/slack-throttle";
-import { createRequestLogger } from "@/lib/logger";
+import { createRequestLogger, flushLogs } from "@/lib/logger";
 import { getCachedTopics } from "@/lib/repo-index";
 import { matchTopicsToQuestion, buildQuestionHints } from "@/lib/topic-match";
 import { isAddressedToOtherUser, buildConversationHistory } from "@/lib/thread-filter";
@@ -76,9 +76,9 @@ export async function POST(request: NextRequest) {
     rlog("mention_start", { channel, user: event.user, thread: !!event.thread_ts, question: userMessage.slice(0, 100) });
 
     // Ack now, process after response is sent (Vercel keeps fn alive)
-    // NOTE: Logs inside after() are NOT visible in Vercel Hobby dashboard per-invocation view.
-    // The "mention_start" line above is the only one visible. Agent loop details
-    // are visible via `vercel logs --no-follow` CLI or on Vercel Pro.
+    // Logs inside after() need an explicit event-loop yield (flushLogs) to
+    // reach Vercel's log drain — see #90. Every after() block below ends
+    // with `await flushLogs(rlog, "<flow>")` inside its finally clause.
     after(async () => {
       // Hoist thinkingTs so finally can always clean it up
       let thinkingTs: string | undefined;
@@ -201,6 +201,8 @@ export async function POST(request: NextRequest) {
         if (thinkingTs) {
           await deleteMessage(channel, thinkingTs);
         }
+        // Yield so Vercel captures the after() block's logs — see #90.
+        await flushLogs(rlog, "mention");
       }
     });
 
@@ -370,6 +372,7 @@ export async function POST(request: NextRequest) {
         if (thinkTs) {
           await deleteMessage(channel, thinkTs);
         }
+        await flushLogs(rlog, "thread_followup");
       }
     });
 
@@ -434,6 +437,8 @@ export async function POST(request: NextRequest) {
         } catch {
           // Can't reply — just log
         }
+      } finally {
+        await flushLogs(rlog, "reaction_checkmark");
       }
     });
 
@@ -476,6 +481,8 @@ export async function POST(request: NextRequest) {
         } catch { /* already reacted or can't react — ignore */ }
       } catch (err) {
         rlog("error", { flow: "reaction_thumbsup", message: err instanceof Error ? err.message : String(err) });
+      } finally {
+        await flushLogs(rlog, "reaction_thumbsup");
       }
     });
 
@@ -541,6 +548,8 @@ export async function POST(request: NextRequest) {
         );
       } catch (err) {
         rlog("error", { flow: "reaction_thumbsdown", message: err instanceof Error ? err.message : String(err) });
+      } finally {
+        await flushLogs(rlog, "reaction_thumbsdown");
       }
     });
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -33,3 +33,28 @@ export function createRequestLogger(): RequestLogger {
     log(event, { requestId, ...data });
   };
 }
+
+/**
+ * Emit a final `turn_end` log event and yield the Node event loop so
+ * stdout drains before Vercel hibernates the function container.
+ *
+ * Fix for #90: logs emitted from inside Next.js `after()` callbacks were
+ * being dropped in prod. The primary `mention_start` log (sync path)
+ * reaches Vercel's log drain fine; all subsequent events inside the
+ * async `after()` body (agent_start, agent_tool_call, agent_complete,
+ * cache metrics, answer_posted…) disappeared. Giving Node one tick via
+ * setImmediate lets stdout flush before the container shuts down.
+ *
+ * Place this as the last statement in every `after()` body — ideally
+ * inside a `finally` block so it runs even on errors. The `turn_end`
+ * event itself acts as a canary: if it appears in production logs,
+ * the flush worked and so did every earlier log in the same turn.
+ */
+export async function flushLogs(rlog: RequestLogger, flow: string): Promise<void> {
+  try {
+    rlog("turn_end", { flow });
+  } catch {
+    // Never let a logging error break the post-response flow.
+  }
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}


### PR DESCRIPTION
## Summary
Adds a small `flushLogs(rlog, flow)` helper that emits a final `turn_end` canary event and then yields one event-loop tick via `setImmediate`. Called from a `finally` block at the end of every `after()` callback in the Slack route so that Node.js stdout drains before Vercel hibernates the function container.

## Why
Post-merge smoke of PR #88 revealed that every structured log emitted from inside `after()` — `agent_start`, `agent_tool_call`, `agent_complete` (including #71 cache metrics), `answer_posted`, `topic_hints_injected` — is dropped before reaching Vercel's log drain. Only `mention_start` (sync path, pre-`after`) and Slack retry noise surfaced. Full writeup in #90.

Without this fix, Phase 2 of the [junior roadmap (#84)](https://github.com/vlad-ko/battle-mage/issues/84) is unmeasurable in production — we can't validate #71 cache hit rate, #72 streaming, or any of #75–78 after they ship.

## Design
This is the smallest plausible fix: one event-loop yield per `after()`. Rationale:
- `console.log` itself works fine — `mention_start` (same logger, sync path) surfaces correctly. So the logger is not the bug.
- Something about Node's stdout buffering + Vercel's log capture during `after()`'s post-response lifetime drops in-flight writes when the container hibernates. A single `setImmediate` tick lets stdout drain first.
- The `turn_end` event is a canary. If it appears in prod logs, the yield worked and every earlier log in the same turn should also be present.

**Escalation path** if this doesn't surface logs in prod (documented in #90 too):
1. Bump `setImmediate` → `setTimeout(resolve, 50)` — larger flush window.
2. Swap `console.log` → `process.stdout.write` to bypass any console-layer buffering.
3. Introduce a real log drain (Axiom / Datadog) or OpenTelemetry span sink — larger change tracked in #81.

## Changes
- `src/lib/logger.ts` (+25): new `flushLogs(rlog, flow)` helper with a thorough docstring explaining #90.
- `src/app/api/slack/route.ts` (+13 / −4):
  - Import `flushLogs`.
  - Applied in `finally` of all 5 `after()` blocks: `mention`, `thread_followup`, `reaction_checkmark`, `reaction_thumbsup`, `reaction_thumbsdown`.
  - Removed a stale comment above the mention handler that documented the gap as a known limitation — it's now addressed.

## Invariants preserved
- No new tests (this is a runtime-behavior fix; unit tests can't observe Vercel's log capture).
- No behavioral change to any handler — `flushLogs` runs last, after response is sent and after any finally cleanup.
- `npm test` — 269/269 pass.
- `npx tsc --noEmit` — clean.

## Test plan
- [x] `npm test` — 269/269
- [x] `npx tsc --noEmit` — clean
- [ ] **Post-merge smoke (primary verification)**:
  ```bash
  # After merge + deploy, ask @bm a question in Slack, then:
  vercel logs --environment production --since 5m --json --limit 200 \
    | jq -r 'select(.message != "") | .message | fromjson? | "\(.ts) \(.requestId) \(.event)"' \
    | sort
  ```
  Expected events for one turn (correlated by `requestId`):
  `mention_start → agent_start → agent_tool_call (x N) → agent_complete → answer_posted → turn_end`

  With cache metrics visible in `agent_complete`: `cache_read_tokens`, `cache_creation_tokens`, `input_tokens`, `output_tokens`.

- [ ] **Cache-hit confirmation**: send a follow-up question in the same thread within 5 minutes; `agent_complete` should show `cache_read_tokens` ≈ the stable-zone size (~2k).

- [ ] **If post-merge smoke fails** (turn_end absent or intermediate logs absent): #90 remains open and we escalate per the path above.

Refs #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)