### PR TITLE
debug: Cold-start canary for Sentry observability diagnostic (#90)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp"
+    }
+  }
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,12 +1,55 @@
 import * as Sentry from "@sentry/nextjs";
 
 export async function register() {
+  // [DIAGNOSTIC] Prove whether Next.js is loading this file at runtime.
+  // If this line doesn't show in Vercel logs, instrumentation.ts is not
+  // being picked up and Sentry.init never runs — see #90 investigation.
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify({
+      event: "instrumentation_register_start",
+      runtime: process.env.NEXT_RUNTIME ?? "unknown",
+      ts: Date.now(),
+    }),
+  );
+
   if (process.env.NEXT_RUNTIME === "nodejs") {
     await import("../sentry.server.config");
   }
 
   if (process.env.NEXT_RUNTIME === "edge") {
     await import("../sentry.edge.config");
+  }
+
+  // [DIAGNOSTIC] Force an Issue in Sentry after init. Issues tab is always
+  // on (unlike the Logs feature), so if this shows up we know init worked.
+  // Remove once observability is verified end-to-end.
+  try {
+    Sentry.captureException(
+      new Error(
+        `bm cold-start canary — runtime=${process.env.NEXT_RUNTIME} commit=${
+          process.env.VERCEL_GIT_COMMIT_SHA ?? "local"
+        }`,
+      ),
+    );
+    await Sentry.flush(2000);
+    // eslint-disable-next-line no-console
+    console.log(
+      JSON.stringify({
+        event: "instrumentation_canary_flushed",
+        runtime: process.env.NEXT_RUNTIME ?? "unknown",
+        ts: Date.now(),
+      }),
+    );
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(
+      JSON.stringify({
+        event: "instrumentation_canary_error",
+        message: err instanceof Error ? err.message : String(err),
+        ts: Date.now(),
+      }),
+    );
   }
 }
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,5 +1,13 @@
 import * as Sentry from "@sentry/nextjs";
 
+// Module-level single-fire flag: ensures the diagnostic canary emits at
+// most ONE Issue per container lifetime, not one per register() call or
+// per request. A long-lived serverless container might handle thousands
+// of requests; spamming Sentry would pollute the dashboard and burn
+// event quota. One Issue per cold-start container is enough to tell us
+// whether Sentry.init is working.
+let canaryFired = false;
+
 export async function register() {
   // [DIAGNOSTIC] Prove whether Next.js is loading this file at runtime.
   // If this line doesn't show in Vercel logs, instrumentation.ts is not
@@ -21,35 +29,42 @@ export async function register() {
     await import("../sentry.edge.config");
   }
 
-  // [DIAGNOSTIC] Force an Issue in Sentry after init. Issues tab is always
-  // on (unlike the Logs feature), so if this shows up we know init worked.
-  // Remove once observability is verified end-to-end.
-  try {
-    Sentry.captureException(
-      new Error(
-        `bm cold-start canary — runtime=${process.env.NEXT_RUNTIME} commit=${
-          process.env.VERCEL_GIT_COMMIT_SHA ?? "local"
-        }`,
-      ),
-    );
-    await Sentry.flush(2000);
-    // eslint-disable-next-line no-console
-    console.log(
-      JSON.stringify({
-        event: "instrumentation_canary_flushed",
-        runtime: process.env.NEXT_RUNTIME ?? "unknown",
-        ts: Date.now(),
-      }),
-    );
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error(
-      JSON.stringify({
-        event: "instrumentation_canary_error",
-        message: err instanceof Error ? err.message : String(err),
-        ts: Date.now(),
-      }),
-    );
+  // [DIAGNOSTIC] One-shot canary that forces an Issue in Sentry after
+  // init. If this Issue appears in the dashboard, Sentry.init works and
+  // the problem is in our logger's Sentry.logger call path. If it does
+  // NOT appear, instrumentation.ts is not being loaded by Next.js.
+  //
+  // Fire-and-forget — Sentry's transport will drain on function teardown
+  // via vercelWaitUntil. Awaiting flush() here would put up to 2s of
+  // latency on the cold-start critical path.
+  if (!canaryFired) {
+    canaryFired = true;
+    try {
+      Sentry.captureException(
+        new Error(
+          `bm cold-start canary — runtime=${process.env.NEXT_RUNTIME} commit=${
+            process.env.VERCEL_GIT_COMMIT_SHA ?? "local"
+          }`,
+        ),
+      );
+      // eslint-disable-next-line no-console
+      console.log(
+        JSON.stringify({
+          event: "instrumentation_canary_captured",
+          runtime: process.env.NEXT_RUNTIME ?? "unknown",
+          ts: Date.now(),
+        }),
+      );
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(
+        JSON.stringify({
+          event: "instrumentation_canary_error",
+          message: err instanceof Error ? err.message : String(err),
+          ts: Date.now(),
+        }),
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Diagnostic-only PR — merge-then-revert

Production smoke confirmed DSN/project routing work (my sandbox sent a test event, user confirmed it arrived in Sentry dashboard). But the deployed app's own logs still aren't reaching Sentry. Two possibilities:

1. `src/instrumentation.ts` is not being picked up by Next.js 15 → `Sentry.init` never runs → every `Sentry.logger.info` call is a silent no-op.
2. `Sentry.init` IS running but our logger's `Sentry.logger.info` path is broken.

This commit adds two markers to `register()` that distinguish the cases:

- **console.log canary** — proves Next.js calls `register()` at runtime.
- **`Sentry.captureException(new Error("cold-start canary"))` + `flush(2000)`** — bypasses our logger abstraction. Forces an **Issue** (Issues tab is always on, unlike the Logs feature). If this shows in Sentry → init works, problem is in logger. If NOT → instrumentation.ts isn't loading.

## Test plan post-merge
1. Wait for prod deploy
2. Cold-start the function (hit the landing page or send `@bm` in Slack)
3. Check Vercel logs for the two `instrumentation_*` events
4. Check Sentry Issues tab for `bm cold-start canary`
5. Interpret per the three outcomes in the commit message

## Cleanup
Once we know the answer, revert this commit (or open a follow-up to remove the canary).

Refs #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)