### PR TITLE
debug: Sentry Logs canaries + consoleLoggingIntegration (#90)

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -31,4 +31,11 @@ Sentry.init({
 
   // Off — same rationale as server config.
   sendDefaultPii: false,
+
+  integrations: [
+    // Mirrors server config — capture console.* as Sentry Logs on the
+    // edge runtime too. The Slack webhook lands on nodejs today, but
+    // middleware and future edge routes would otherwise lose logs.
+    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
+  ],
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -60,5 +60,12 @@ Sentry.init({
       recordInputs: true,
       recordOutputs: true,
     }),
+    // Auto-ships every console.log / .warn / .error as a Sentry Log.
+    // Complements the explicit Sentry.logger.info() path in logger.ts:
+    // our logger already emits JSON via console.log on every event, so
+    // this integration is a second, independent transport to Sentry's
+    // Logs UI. Was added after PR #95's canary proved events land but
+    // Sentry.logger.info() did not — see #90.
+    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
   ],
 });

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -54,20 +54,52 @@ export async function register() {
     canaryFired = true;
     const runtime = process.env.NEXT_RUNTIME ?? "unknown";
     const commit = process.env.VERCEL_GIT_COMMIT_SHA ?? "local";
+
+    // Each canary is isolated in its own try/catch so one path failing
+    // (e.g. Sentry.logger undefined) can't mask the others — the whole
+    // point of this PR is a truth table across three independent paths.
+
+    // Canary 1 — captureException (baseline; known working per PR #95)
     try {
       Sentry.captureException(
         new Error(`bm cold-start canary — runtime=${runtime} commit=${commit}`),
       );
-      // Explicit v10 Logs API — same call shape logger.ts uses on every
-      // log(). If this one doesn't land, logger.ts never will.
-      Sentry.logger.info("bm_cold_start_logs_canary", {
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(
+        JSON.stringify({
+          event: "canary_exception_error",
+          message: err instanceof Error ? err.message : String(err),
+          ts: Date.now(),
+        }),
+      );
+    }
+
+    // Canary 2 — explicit v10 Logs API. Optional-chain because logger.ts
+    // treats Sentry.logger as possibly absent (see src/lib/logger.ts:34).
+    // If logger is undefined the call short-circuits silently — captured
+    // as the "logger.info canary missing" branch of the truth table.
+    try {
+      Sentry.logger?.info("bm_cold_start_logs_canary", {
         path: "sentry.logger.info",
         runtime,
         commit,
       });
-      // Plain console.log — captured only if consoleLoggingIntegration
-      // is wired. Distinctive event name makes it grep-able in both
-      // Vercel logs AND (if integration works) Sentry Logs UI.
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(
+        JSON.stringify({
+          event: "canary_logger_error",
+          message: err instanceof Error ? err.message : String(err),
+          ts: Date.now(),
+        }),
+      );
+    }
+
+    // Canary 3 — plain console.log, captured by consoleLoggingIntegration
+    // in sentry.server.config.ts. Grep-able in Vercel logs regardless of
+    // whether the integration ships it to Sentry.
+    try {
       // eslint-disable-next-line no-console
       console.log(
         JSON.stringify({
@@ -78,24 +110,19 @@ export async function register() {
           ts: Date.now(),
         }),
       );
-      // eslint-disable-next-line no-console
-      console.log(
-        JSON.stringify({
-          event: "instrumentation_canary_captured",
-          runtime,
-          ts: Date.now(),
-        }),
-      );
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(
-        JSON.stringify({
-          event: "instrumentation_canary_error",
-          message: err instanceof Error ? err.message : String(err),
-          ts: Date.now(),
-        }),
-      );
+    } catch {
+      // console.log throwing would be extraordinary; nowhere to report.
     }
+
+    // Trailer: proves the canary block ran end-to-end.
+    // eslint-disable-next-line no-console
+    console.log(
+      JSON.stringify({
+        event: "instrumentation_canary_captured",
+        runtime,
+        ts: Date.now(),
+      }),
+    );
   }
 }
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -29,29 +29,60 @@ export async function register() {
     await import("../sentry.edge.config");
   }
 
-  // [DIAGNOSTIC] One-shot canary that forces an Issue in Sentry after
-  // init. If this Issue appears in the dashboard, Sentry.init works and
-  // the problem is in our logger's Sentry.logger call path. If it does
-  // NOT appear, instrumentation.ts is not being loaded by Next.js.
+  // [DIAGNOSTIC] One-shot canaries exercising all three Sentry paths.
+  // PR #95 proved Sentry.captureException lands (events ✓) but explicit
+  // Sentry.logger.info() calls from our logger.ts produce nothing in the
+  // Logs UI. This pass adds two more canaries to isolate which path is
+  // actually broken:
+  //   1. captureException — baseline, already known working
+  //   2. Sentry.logger.info — explicit v10 Logs API; should land if
+  //      enableLogs is respected and the SDK isn't silently bailing
+  //   3. plain console.log — lands in Sentry only if the paired
+  //      consoleLoggingIntegration (see sentry.server.config.ts) is
+  //      picking up stdout
+  //
+  // After deploy + one cold-start, the truth table tells us:
+  //   2 lands + 3 lands → both paths healthy; logger.ts bug
+  //   2 missing + 3 lands → Sentry.logger.* broken; adopt console path
+  //   2 lands + 3 missing → console integration misconfigured
+  //   both missing → org-level Logs feature not enabled on sentry.io
   //
   // Fire-and-forget — Sentry's transport will drain on function teardown
   // via vercelWaitUntil. Awaiting flush() here would put up to 2s of
   // latency on the cold-start critical path.
   if (!canaryFired) {
     canaryFired = true;
+    const runtime = process.env.NEXT_RUNTIME ?? "unknown";
+    const commit = process.env.VERCEL_GIT_COMMIT_SHA ?? "local";
     try {
       Sentry.captureException(
-        new Error(
-          `bm cold-start canary — runtime=${process.env.NEXT_RUNTIME} commit=${
-            process.env.VERCEL_GIT_COMMIT_SHA ?? "local"
-          }`,
-        ),
+        new Error(`bm cold-start canary — runtime=${runtime} commit=${commit}`),
+      );
+      // Explicit v10 Logs API — same call shape logger.ts uses on every
+      // log(). If this one doesn't land, logger.ts never will.
+      Sentry.logger.info("bm_cold_start_logs_canary", {
+        path: "sentry.logger.info",
+        runtime,
+        commit,
+      });
+      // Plain console.log — captured only if consoleLoggingIntegration
+      // is wired. Distinctive event name makes it grep-able in both
+      // Vercel logs AND (if integration works) Sentry Logs UI.
+      // eslint-disable-next-line no-console
+      console.log(
+        JSON.stringify({
+          event: "bm_cold_start_console_canary",
+          path: "console.log",
+          runtime,
+          commit,
+          ts: Date.now(),
+        }),
       );
       // eslint-disable-next-line no-console
       console.log(
         JSON.stringify({
           event: "instrumentation_canary_captured",
-          runtime: process.env.NEXT_RUNTIME ?? "unknown",
+          runtime,
           ts: Date.now(),
         }),
       );


### PR DESCRIPTION
## Summary

- Adds two more one-shot canaries to `src/instrumentation.ts` — one for `Sentry.logger.info()` (v10 Logs API) and one for plain `console.log` — alongside the existing `Sentry.captureException` canary from PR #95.
- Adds `Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] })` to `sentry.server.config.ts` and `sentry.edge.config.ts`. Our `logger.ts` already emits `console.log(JSON.stringify(...))` on every event, so this integration gives us a second, independent transport to Sentry's Logs UI.

## Why

PR #95's canary proved `Sentry.captureException` reaches Sentry (events arrive in the Issues dashboard), but explicit `Sentry.logger.info()` calls from `src/lib/logger.ts` still don't land in the Logs UI. Events ✓, logs ✗.

## Truth Table

After merge + deploy + one Slack `@bm` question (cold start):

| `logger.info` canary | `console.log` canary | Diagnosis |
|---|---|---|
| ✅ | ✅ | Both paths healthy. Bug is in `logger.ts` (likely the `if (Sentry.logger)` check or payload shape). |
| ❌ | ✅ | `Sentry.logger.*` is broken in this environment. Simplify `logger.ts` to rely solely on the console integration path. |
| ✅ | ❌ | Console integration misconfigured. |
| ❌ | ❌ | Logs feature not enabled at the org/project level on sentry.io. Flip the toggle. |

## Test plan

- [ ] Typecheck + 288/288 unit tests pass locally (done).
- [ ] Merge, wait for prod deploy (~1 min).
- [ ] Send `@bm` question in Slack to trigger cold start.
- [ ] Check Sentry Logs UI for `bm_cold_start_logs_canary` and `bm_cold_start_console_canary`.
- [ ] Apply truth-table diagnosis → follow-up PR fixes the actual path.
- [ ] Revert this branch once diagnosis is complete (along with PR #95's canary code).

Refs #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)