### PR TITLE
feat: Debounced rotating status updates (closes #78)

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -19,6 +19,12 @@ import { buildCorrectionActions } from "@/lib/auto-correct";
 import { buildThinkingMessage, THINKING_HEADER } from "@/lib/progress";
 import { toSlackMrkdwn } from "@/lib/mrkdwn";
 import { createThrottledUpdater } from "@/lib/slack-throttle";
+import {
+  createStatusScheduler,
+  DEFAULT_STATUS_DEBOUNCE_MS,
+  DEFAULT_STATUS_ROTATION_MS,
+  DEFAULT_STATUS_ROTATION_TEXT,
+} from "@/lib/status-scheduler";
 import { createRequestLogger, flushLogs } from "@/lib/logger";
 import { getCachedTopics } from "@/lib/repo-index";
 import { matchTopicsToQuestion, buildQuestionHints } from "@/lib/topic-match";
@@ -118,23 +124,42 @@ export async function POST(request: NextRequest) {
           }
         }, 1200);
 
+        // Debounced + rotating status updater for tool-progress messages.
+        // Fixes #78: previously every onProgress did a direct chat.update,
+        // so parallel-tool bursts (#77) could fire 3+ edits in under a
+        // second and trip Slack's rate limit. The scheduler coalesces
+        // rapid schedules and emits a "still working…" heartbeat every
+        // 30s of silence so Slack doesn't auto-dim the thinking badge.
+        const statusScheduler = createStatusScheduler(
+          async (text) => {
+            if (thinkingTs) {
+              await updateMessage(channel, thinkingTs, text);
+            }
+          },
+          {
+            debounceMs: DEFAULT_STATUS_DEBOUNCE_MS,
+            rotationMs: DEFAULT_STATUS_ROTATION_MS,
+            rotationText: DEFAULT_STATUS_ROTATION_TEXT,
+          },
+        );
+
         const result = await runAgent(
           augmentedMessage,
           async (toolName, input) => {
-            // Progress emoji takes over — drop any pending streamed text that
-            // was queued during the prior round, otherwise it could land and
-            // overwrite the emoji after this call.
+            // Progress emoji takes over — drop any pending streamed text
+            // that was queued during the prior round, otherwise it could
+            // land and overwrite the emoji after this call.
             await streamThrottle.cancel();
-            if (thinkingTs) {
-              await updateMessage(channel, thinkingTs, buildThinkingMessage(toolName, input));
-            }
+            statusScheduler.schedule(buildThinkingMessage(toolName, input));
           },
           mentionHistory,
           rlog,
           (snapshot) => streamThrottle.update(snapshot),
         );
-        // Drain any pending streamed edit so it doesn't race the final write
+        // Drain any pending streamed edit AND pending status before
+        // the final write so neither can race or overwrite the answer.
         await streamThrottle.flush();
+        await statusScheduler.flush();
         // `agent_complete` is already emitted by runAgent with rounds, token
         // usage, and cache metrics — don't duplicate it at the route level.
 
@@ -297,21 +322,34 @@ export async function POST(request: NextRequest) {
           }
         }, 1200);
 
+        // Mirror of the mention-flow scheduler — see #78.
+        const followupStatus = createStatusScheduler(
+          async (text) => {
+            if (thinkTs) {
+              await updateMessage(channel, thinkTs, text);
+            }
+          },
+          {
+            debounceMs: DEFAULT_STATUS_DEBOUNCE_MS,
+            rotationMs: DEFAULT_STATUS_ROTATION_MS,
+            rotationText: DEFAULT_STATUS_ROTATION_TEXT,
+          },
+        );
+
         const result = await runAgent(
           followupMessage,
           async (toolName, input) => {
             // See the mention handler: cancel pending streamed text so
             // the emoji progress isn't overwritten by a late flush.
             await followupThrottle.cancel();
-            if (thinkTs) {
-              await updateMessage(channel, thinkTs, buildThinkingMessage(toolName, input));
-            }
+            followupStatus.schedule(buildThinkingMessage(toolName, input));
           },
           history,
           rlog,
           (snapshot) => followupThrottle.update(snapshot),
         );
         await followupThrottle.flush();
+        await followupStatus.flush();
 
         const text = toSlackMrkdwn(result.text);
         const rankedRefs = rankReferences(result.references, result.text);

--- a/src/lib/status-scheduler.test.ts
+++ b/src/lib/status-scheduler.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  createStatusScheduler,
+  DEFAULT_STATUS_DEBOUNCE_MS,
+  DEFAULT_STATUS_ROTATION_MS,
+  DEFAULT_STATUS_ROTATION_TEXT,
+} from "./status-scheduler";
+
+describe("createStatusScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const config = {
+    debounceMs: 1000,
+    rotationMs: 30_000,
+    rotationText: "still working…",
+  };
+
+  it("fires fn with the scheduled text after the debounce interval", async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createStatusScheduler(fn, config);
+
+    scheduler.schedule("searching…");
+    // First schedule fires immediately (no prior flush).
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).toHaveBeenCalledWith("searching…");
+  });
+
+  it("coalesces rapid schedule calls into one fn call with the latest text", async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createStatusScheduler(fn, config);
+
+    scheduler.schedule("step 1");
+    // Fire the first immediate schedule.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Burst of updates inside the debounce window coalesces.
+    scheduler.schedule("step 2");
+    scheduler.schedule("step 3");
+    scheduler.schedule("step 4");
+
+    // Not yet — still inside debounce window since last fire.
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // After full debounce window: exactly one more call, with the LATEST text.
+    await vi.advanceTimersByTimeAsync(600);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith("step 4");
+  });
+
+  it("fires rotationText after rotationMs of silence", async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createStatusScheduler(fn, config);
+
+    scheduler.schedule("searching…");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Fast-forward past the rotation interval; no new schedules.
+    await vi.advanceTimersByTimeAsync(config.rotationMs + 100);
+
+    // Rotation tick fires the rotationText.
+    expect(fn).toHaveBeenCalledWith("still working…");
+    expect(fn.mock.calls.some((c) => c[0] === "still working…")).toBe(true);
+  });
+
+  it("does not fire rotation if schedule() is called within the rotation window", async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createStatusScheduler(fn, config);
+
+    scheduler.schedule("A");
+    await vi.advanceTimersByTimeAsync(0);
+    // Trigger another schedule before rotation would have fired.
+    await vi.advanceTimersByTimeAsync(20_000);
+    scheduler.schedule("B");
+    await vi.advanceTimersByTimeAsync(1100);
+
+    // Two normal calls so far; no rotation yet.
+    expect(fn.mock.calls.filter((c) => c[0] === "still working…")).toHaveLength(0);
+    expect(fn).toHaveBeenCalledWith("A");
+    expect(fn).toHaveBeenCalledWith("B");
+  });
+
+  it("re-arms rotation after firing so long idle periods get multiple ticks", async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createStatusScheduler(fn, {
+      ...config,
+      rotationMs: 10_000,
+    });
+
+    scheduler.schedule("initial");
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Wait out two full rotation cycles with no schedule() calls.
+    await vi.advanceTimersByTimeAsync(10_100);
+    await vi.advanceTimersByTimeAsync(10_100);
+
+    const rotationCalls = fn.mock.calls.filter((c) => c[0] === "still working…");
+    expect(rotationCalls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("flush() forces the pending update and stops rotation", async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createStatusScheduler(fn, config);
+
+    scheduler.schedule("first");
+    await vi.advanceTimersByTimeAsync(0);
+    scheduler.schedule("pending");
+
+    // Before flush: only the initial fire.
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    const flushPromise = scheduler.flush();
+    await vi.runAllTimersAsync();
+    await flushPromise;
+
+    // flush forced the pending update through.
+    expect(fn).toHaveBeenCalledWith("pending");
+
+    // No rotation after flush even if we wait indefinitely.
+    fn.mockClear();
+    await vi.advanceTimersByTimeAsync(config.rotationMs + 1000);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("cancel() drops pending text AND stops rotation", async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createStatusScheduler(fn, config);
+
+    scheduler.schedule("first");
+    await vi.advanceTimersByTimeAsync(0);
+    scheduler.schedule("should be dropped");
+
+    const cancelPromise = scheduler.cancel();
+    await vi.runAllTimersAsync();
+    await cancelPromise;
+
+    // Only the initial fire; the dropped text never fired.
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).not.toHaveBeenCalledWith("should be dropped");
+
+    // No rotation either.
+    fn.mockClear();
+    await vi.advanceTimersByTimeAsync(config.rotationMs + 1000);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("swallows fn errors so a failing chat.update doesn't crash the agent", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("slack_rate_limited"));
+    const scheduler = createStatusScheduler(fn, config);
+
+    scheduler.schedule("doomed");
+    // Drive the immediate fire + let its rejection propagate through the
+    // throttle's internal catch (must not bubble). Use cancel() to stop
+    // the rotation timer — otherwise runAllTimers would loop forever
+    // because rotation re-arms itself.
+    await vi.advanceTimersByTimeAsync(100);
+    await scheduler.cancel();
+
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it("rotationMs = 0 disables rotation entirely", async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createStatusScheduler(fn, { ...config, rotationMs: 0 });
+
+    scheduler.schedule("once");
+    await vi.advanceTimersByTimeAsync(0);
+    fn.mockClear();
+
+    // No rotation should fire no matter how long we wait.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe("default constants", () => {
+  it("DEFAULT_STATUS_DEBOUNCE_MS is in the 1-2s range", () => {
+    // Junior's pattern: 1-2 second debounce keeps updates readable
+    // while staying under Slack's 1/sec rate limit.
+    expect(DEFAULT_STATUS_DEBOUNCE_MS).toBeGreaterThanOrEqual(1000);
+    expect(DEFAULT_STATUS_DEBOUNCE_MS).toBeLessThanOrEqual(2000);
+  });
+
+  it("DEFAULT_STATUS_ROTATION_MS is in the 20-60s range", () => {
+    // Slack auto-dims inactive messages around 30-60s; rotate within that.
+    expect(DEFAULT_STATUS_ROTATION_MS).toBeGreaterThanOrEqual(20_000);
+    expect(DEFAULT_STATUS_ROTATION_MS).toBeLessThanOrEqual(60_000);
+  });
+
+  it("DEFAULT_STATUS_ROTATION_TEXT is a non-empty string", () => {
+    expect(DEFAULT_STATUS_ROTATION_TEXT).toBeTypeOf("string");
+    expect(DEFAULT_STATUS_ROTATION_TEXT.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/status-scheduler.ts
+++ b/src/lib/status-scheduler.ts
@@ -1,0 +1,92 @@
+/**
+ * Status-update scheduler for long-running agent turns.
+ *
+ * Wraps `createThrottledUpdater` with two additional behaviors:
+ *
+ * 1. **Coalesced updates.** Rapid `schedule()` calls (e.g., a burst from
+ *    parallel tool dispatch — see #77) collapse into at most one Slack
+ *    `chat.update` per `debounceMs`, with the LATEST text winning. Prevents
+ *    UI flicker and Slack's ~1/sec per-message rate limit from biting.
+ *
+ * 2. **Rotation heartbeat.** If no `schedule()` arrives for `rotationMs`,
+ *    the scheduler fires `rotationText` as a "still working…" heartbeat.
+ *    Stops Slack from auto-dimming the thinking message during long
+ *    Anthropic calls (e.g., a 40-second model response).
+ *
+ * Errors from `fn` are swallowed — a failing `chat.update` (rate-limited,
+ * message deleted, network blip) must never crash the agent loop.
+ *
+ * See #78.
+ */
+
+import { createThrottledUpdater } from "./slack-throttle";
+
+export interface StatusSchedulerConfig {
+  /** Minimum ms between successive fn() calls. Coalesces bursts. */
+  debounceMs: number;
+  /**
+   * Rotation interval — if no schedule() call for this long, fn is
+   * called with `rotationText`. Set to 0 to disable rotation.
+   */
+  rotationMs: number;
+  /** Text to use for the periodic rotation heartbeat. */
+  rotationText: string;
+}
+
+export interface StatusScheduler {
+  /** Queue an update. Coalesced with any pending update in the debounce window. */
+  schedule(text: string): void;
+  /** Force any pending update through AND stop rotation. Call on turn end. */
+  flush(): Promise<void>;
+  /** Drop any pending update AND stop rotation. Call when replacing this updater. */
+  cancel(): Promise<void>;
+}
+
+export function createStatusScheduler(
+  fn: (text: string) => Promise<void>,
+  config: StatusSchedulerConfig,
+): StatusScheduler {
+  const throttle = createThrottledUpdater(fn, config.debounceMs);
+  let rotationTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function stopRotation(): void {
+    if (rotationTimer) {
+      clearTimeout(rotationTimer);
+      rotationTimer = null;
+    }
+  }
+
+  // Re-arms a one-shot timer that fires rotationText after rotationMs.
+  // Any schedule() call calls armRotation again, restarting the window.
+  // When the timer fires it also re-arms itself so idle periods get
+  // multiple rotation ticks, not just one.
+  function armRotation(): void {
+    stopRotation();
+    if (config.rotationMs <= 0) return;
+    rotationTimer = setTimeout(() => {
+      throttle.update(config.rotationText);
+      armRotation();
+    }, config.rotationMs);
+  }
+
+  return {
+    schedule(text: string): void {
+      throttle.update(text);
+      armRotation();
+    },
+    async flush(): Promise<void> {
+      stopRotation();
+      await throttle.flush();
+    },
+    async cancel(): Promise<void> {
+      stopRotation();
+      await throttle.cancel();
+    },
+  };
+}
+
+// Sensible defaults derived from Slack's rate-limit reality + UX research
+// on how long a status needs to be visible to be read.
+export const DEFAULT_STATUS_DEBOUNCE_MS = 1200;
+export const DEFAULT_STATUS_ROTATION_MS = 30_000;
+export const DEFAULT_STATUS_ROTATION_TEXT = "🧠 Still working on it...";


### PR DESCRIPTION
## Summary

Replaces the un-debounced `onProgress → updateMessage` pattern with a `StatusScheduler` that coalesces rapid updates and emits a "still working…" heartbeat when idle. Two real issues made worse by #77's parallel tool dispatch:

1. **Slack `chat.update` rate limiting.** Parallel-tool bursts now fire 3-4 `onProgress` callbacks in <1s, each doing a direct Slack update — well over Slack's ~1/sec per-message cap. Caused intermittent UI flicker and 429s.
2. **Auto-dimming during long rounds.** When an Anthropic round runs 30-40s with no tool calls, Slack fades the thinking message. A periodic heartbeat keeps it "alive".

## Changes

- **New `src/lib/status-scheduler.ts`** (92 lines) wraps `createThrottledUpdater` with a rotation timer.
  - `schedule(text)` — queues an update, coalesced inside the debounce window.
  - `flush()` — forces pending + stops rotation. Call at turn end.
  - `cancel()` — drops pending + stops rotation. Call when replacing the updater.
  - Rotation re-arms itself so long idle periods get multiple heartbeats.
- **Defaults**: `DEFAULT_STATUS_DEBOUNCE_MS=1200` (stays under Slack's rate limit), `DEFAULT_STATUS_ROTATION_MS=30_000` (ahead of Slack's auto-dim), `DEFAULT_STATUS_ROTATION_TEXT = "🧠 Still working on it..."`.
- **Route integration**: both `app_mention` and `message` (thread_followup) flows swap the direct `updateMessage` in `onProgress` for `statusScheduler.schedule(...)`. Explicit `await statusScheduler.flush()` before the final answer write prevents a stale status from landing after the answer.
- **Tests** (`status-scheduler.test.ts`, 12 new, 328 total). Uses `vi.useFakeTimers()` for deterministic scheduling — no wall-clock flake.

## Test plan

- [x] 328/328 pass locally (+12 new). Typecheck clean.
- [ ] Post-merge smoke: send a question that triggers parallel tool dispatch (comparative query — "compare X vs Y in our repo"). Confirm:
  - Slack's thinking message updates smoothly (no rapid flicker) — you should see <1 update per second even with 3-4 parallel tools firing.
  - On a long round (30+ seconds of Anthropic thinking with no tool calls), the "🧠 Still working on it..." heartbeat appears instead of the message going stale.
- [ ] Check wealthbot Sentry Logs for absence of Slack 429 errors on multi-tool turns.

## Invariants preserved

- `streamThrottle.cancel()` still fires first in `onProgress` so stale streamed text can't land on top of a status update.
- `await streamThrottle.flush()` + `await statusScheduler.flush()` both drain before the final `updateMessage(finalAnswer)`, preventing any race against the final write.
- Scheduler's `fn` errors are swallowed (consistent with existing `createThrottledUpdater` behavior) — agent never crashes due to a transient Slack update failure.

Closes #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)