### PR TITLE
fix: Handle late MessageStream errors + capture stack traces (refs #100)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ Thumbs.db
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+# Claude Code runtime artifacts
+.claude/scheduled_tasks.lock

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { after } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 import {
   verifySlackSignature,
   replyInThread,
@@ -216,6 +217,11 @@ export async function POST(request: NextRequest) {
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Unknown error";
         rlog("error", { flow: "mention", message: msg });
+        // Also capture as a Sentry Issue so the stack trace surfaces
+        // in the dashboard — `rlog` alone produces a Log entry without
+        // a stack, which is how #100 stayed a mystery (we knew the
+        // error message but not what line in the after() body threw it).
+        Sentry.captureException(err, { tags: { flow: "mention" } });
         await replyInThread(
           channel,
           threadTs,
@@ -400,6 +406,7 @@ export async function POST(request: NextRequest) {
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Unknown error";
         rlog("error", { flow: "thread_followup", message: msg });
+        Sentry.captureException(err, { tags: { flow: "thread_followup" } });
         await replyInThread(
           channel,
           threadTs,
@@ -463,6 +470,7 @@ export async function POST(request: NextRequest) {
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : "Unknown error";
         rlog("error", { flow: "reaction_checkmark", message: errMsg });
+        Sentry.captureException(err, { tags: { flow: "reaction_checkmark" } });
         // Best-effort reply — use thread_ts if available
         try {
           const msg = await fetchMessage(channel, messageTs);
@@ -519,6 +527,7 @@ export async function POST(request: NextRequest) {
         } catch { /* already reacted or can't react — ignore */ }
       } catch (err) {
         rlog("error", { flow: "reaction_thumbsup", message: err instanceof Error ? err.message : String(err) });
+        Sentry.captureException(err, { tags: { flow: "reaction_thumbsup" } });
       } finally {
         await flushLogs(rlog, "reaction_thumbsup");
       }
@@ -586,6 +595,7 @@ export async function POST(request: NextRequest) {
         );
       } catch (err) {
         rlog("error", { flow: "reaction_thumbsdown", message: err instanceof Error ? err.message : String(err) });
+        Sentry.captureException(err, { tags: { flow: "reaction_thumbsdown" } });
       } finally {
         await flushLogs(rlog, "reaction_thumbsdown");
       }

--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -6,6 +6,7 @@ import {
   truncateToolResult,
   estimateMessagesTokens,
   executeToolsInParallel,
+  logStreamError,
   FAST_MODEL,
   MAX_TOOL_ROUNDS,
   TOOL_RESULT_MAX_CHARS,
@@ -710,6 +711,62 @@ describe("estimateMessagesTokens — cumulative context budgeting", () => {
     expect(MESSAGES_SAFE_BUDGET_TOKENS).toBeGreaterThan(50_000);
     // Must leave room for system prompt + tools + output + safety
     expect(MESSAGES_SAFE_BUDGET_TOKENS).toBeLessThan(180_000);
+  });
+});
+
+describe("logStreamError", () => {
+  // Factory returns an "error" handler suitable for stream.on("error", ...).
+  // Goal: prevent late error events from MessageStream (emitted AFTER
+  // finalMessage has resolved) from surfacing as unhandled rejections —
+  // those caused msg_too_long errors to bubble through unrelated awaits
+  // in the route handler. See #100.
+
+  it("returns a function that logs agent_stream_error with round + message", () => {
+    const log = vi.fn();
+    const handler = logStreamError(3, log);
+
+    handler(new Error("connection reset"));
+
+    expect(log).toHaveBeenCalledOnce();
+    expect(log).toHaveBeenCalledWith("agent_stream_error", expect.objectContaining({
+      round: 3,
+      message: "connection reset",
+    }));
+  });
+
+  it("coerces non-Error throwables to string", () => {
+    const log = vi.fn();
+    const handler = logStreamError(0, log);
+
+    handler("raw string error");
+    handler({ weird: "object" });
+    handler(42);
+
+    expect(log).toHaveBeenCalledTimes(3);
+    expect(log.mock.calls[0][1].message).toBe("raw string error");
+    expect(log.mock.calls[1][1].message).toContain("object");
+    expect(log.mock.calls[2][1].message).toBe("42");
+  });
+
+  it("does not throw or return a rejected promise", () => {
+    const log = vi.fn();
+    const handler = logStreamError(0, log);
+
+    // The whole point — stream.on("error", handler) must never re-throw,
+    // otherwise Node's EventEmitter would crash the async context.
+    expect(() => handler(new Error("boom"))).not.toThrow();
+  });
+
+  it("preserves the Error prototype check when message is missing", () => {
+    const log = vi.fn();
+    const handler = logStreamError(0, log);
+
+    const err = new Error(); // empty message
+    handler(err);
+
+    // We always log a non-undefined message field so Sentry has something
+    // to filter on — empty string is fine, undefined is not.
+    expect(log.mock.calls[0][1].message).toBeTypeOf("string");
   });
 });
 

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -429,6 +429,28 @@ export interface ConversationTurn {
   content: string;
 }
 
+// Factory for a `stream.on("error", ...)` handler. The @anthropic-ai/sdk
+// MessageStream can emit `error` events AFTER `finalMessage()` has
+// resolved (e.g. if the underlying HTTP connection receives a late error
+// frame). Node's EventEmitter throws synchronously on an `error` event
+// without a listener, which on Vercel surfaces as an unhandled rejection
+// bubbling through the NEXT await — that's why #100 saw `msg_too_long`
+// land in the route's catch block 85ms AFTER `agent_complete` fired.
+//
+// Register this as a no-throw listener so late errors are merely logged
+// and the async context stays clean. Exported for unit testing.
+export function logStreamError(
+  round: number,
+  logger: RequestLogger,
+): (err: unknown) => void {
+  return (err: unknown) => {
+    logger("agent_stream_error", {
+      round,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  };
+}
+
 async function anthropicCall(
   params: Anthropic.MessageCreateParamsNonStreaming,
   onTextDelta: TextDeltaCallback | undefined,
@@ -440,6 +462,10 @@ async function anthropicCall(
     stream.on("text", (_delta, snapshot) => {
       safeInvokeTextDelta(onTextDelta, snapshot);
     });
+    // MUST register before finalMessage resolves. Without this listener,
+    // a late `error` event after finalMessage() returns becomes an
+    // unhandled rejection bubbling through the next await. See #100.
+    stream.on("error", logStreamError(round, _log));
     return await stream.finalMessage();
   } catch (streamErr) {
     _log("agent_stream_fallback", {


### PR DESCRIPTION
## Summary

Two defensive changes to diagnose and narrow #100 (the mystery `msg_too_long` that surfaces post-`runAgent` with no Anthropic call in-between).

### Change 1 — Late MessageStream error handling

**Hypothesis:** `@anthropic-ai/sdk`'s `MessageStream` can emit an `error` event AFTER `finalMessage()` has resolved (late HTTP frame, buffered connection error). `anthropicCall` subscribed only to `"text"` — no `"error"` listener — so Node's `EventEmitter` threw synchronously on the error event, which on Vercel bubbles as an unhandled rejection through the next `await` in scope (`streamThrottle.flush` → `updateMessage`), landing in the route's catch with the Anthropic-shaped message.

**Fix:** new exported `logStreamError(round, logger)` factory in `claude.ts`. Returns a handler suitable for `stream.on("error", ...)`; logs `agent_stream_error` with round + coerced message, never throws. Registered alongside the existing `"text"` listener in `anthropicCall`. Eliminates the unhandled-rejection class of the bug.

### Change 2 — Stack trace capture in route catch blocks

**Problem:** every route catch today calls `rlog("error", ...)` which produces a Sentry Log entry with the message but **no stack trace**. That's how #100 stayed a mystery — we knew the message but not the line that threw it.

**Fix:** `Sentry.captureException(err, { tags: { flow: "..." } })` added to all 5 catch blocks (`mention`, `thread_followup`, `reaction_checkmark`, `reaction_thumbsup`, `reaction_thumbsdown`). Next reproduction surfaces as a Sentry Issue with the full stack — even if Change 1 isn't the root cause, we'll see exactly where the error throws.

## Files

- `src/lib/claude.ts` — new `logStreamError`, stream error listener in `anthropicCall`
- `src/lib/claude.test.ts` — 4 new tests for the factory (shape, coercion, no-throw, non-undefined message)
- `src/app/api/slack/route.ts` — Sentry import + captureException in 5 catches
- `.gitignore` — add `.claude/scheduled_tasks.lock` (Claude Code runtime artifact)

## Test plan

- [x] 332/332 pass locally (+4 new). Typecheck clean.
- [ ] Post-merge verify: send a comparative query that previously reliably triggered msg_too_long ("compare our X vs Y integration"). If the fix is correct, BM answers without the error. If the error STILL happens, wealthbot Sentry will now show a new Issue with the stack — that gives us the real root cause.

## Out of scope

- **Full reproduction test** (stream emits "error" post-finalMessage). Mocking the SDK's MessageStream event interface is fragile; the pure-function tests for `logStreamError` cover handler behavior, and the one-line SDK wiring (`stream.on("error", handler)`) is typecheck-verified.
- Scope deferred items from #100 (`stream.removeAllListeners()` / `stream.abort()`): listeners are GC'd with the stream object; abort is not needed because `finalMessage()`'s natural completion closes the stream.

Refs #100. Does not close — we want a post-deploy reproduction (or absence thereof) to validate before closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)