### PR TITLE
feat: Compact telemetry footer on replies (closes #79)

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_STATUS_ROTATION_MS,
   DEFAULT_STATUS_ROTATION_TEXT,
 } from "@/lib/status-scheduler";
+import { formatReplyFooter, isReplyFooterEnabled } from "@/lib/reply-footer";
 import { createRequestLogger, flushLogs } from "@/lib/logger";
 import { getCachedTopics } from "@/lib/repo-index";
 import { matchTopicsToQuestion, buildQuestionHints } from "@/lib/topic-match";
@@ -167,6 +168,11 @@ export async function POST(request: NextRequest) {
         const text = toSlackMrkdwn(result.text);
         const rankedRefs = rankReferences(result.references, result.text);
         const refsFooter = formatReferences(rankedRefs);
+        // Optional compact telemetry footer (#79). Disabled by default;
+        // enable with BM_REPLY_FOOTER=1 in the Vercel env.
+        const replyFooter = isReplyFooterEnabled(process.env)
+          ? formatReplyFooter(result.metrics, rlog.requestId)
+          : "";
 
         if (result.issueProposal) {
           const proposal = result.issueProposal;
@@ -183,7 +189,7 @@ export async function POST(request: NextRequest) {
             proposal.body,
             "",
             "React with :white_check_mark: to create this issue, or ignore to cancel.",
-          ].join("\n") + refsFooter;
+          ].join("\n") + refsFooter + replyFooter;
 
           if (thinkingTs) {
             // Reuse the thinking/streamed message as the final answer.
@@ -194,7 +200,7 @@ export async function POST(request: NextRequest) {
           }
           rlog("answer_posted", { channel, threadTs });
         } else {
-          const finalBody = text + refsFooter;
+          const finalBody = text + refsFooter + replyFooter;
           let replyTs: string | undefined;
           if (thinkingTs) {
             await updateMessage(channel, thinkingTs, finalBody);
@@ -360,6 +366,10 @@ export async function POST(request: NextRequest) {
         const text = toSlackMrkdwn(result.text);
         const rankedRefs = rankReferences(result.references, result.text);
         const refsFooter = formatReferences(rankedRefs);
+        // Optional compact telemetry footer (#79) — mirrors the mention flow.
+        const replyFooter = isReplyFooterEnabled(process.env)
+          ? formatReplyFooter(result.metrics, rlog.requestId)
+          : "";
 
         if (result.issueProposal) {
           const proposal = result.issueProposal;
@@ -376,7 +386,7 @@ export async function POST(request: NextRequest) {
             proposal.body,
             "",
             "React with :white_check_mark: to create this issue, or ignore to cancel.",
-          ].join("\n") + refsFooter;
+          ].join("\n") + refsFooter + replyFooter;
 
           if (thinkTs) {
             await updateMessage(channel, thinkTs, finalBody);
@@ -385,7 +395,7 @@ export async function POST(request: NextRequest) {
             await replyInThread(channel, threadTs, finalBody);
           }
         } else {
-          const finalBody = text + refsFooter;
+          const finalBody = text + refsFooter + replyFooter;
           let replyTs: string | undefined;
           if (thinkTs) {
             await updateMessage(channel, thinkTs, finalBody);

--- a/src/evals/run-eval.ts
+++ b/src/evals/run-eval.ts
@@ -1,5 +1,5 @@
 import { runAgent, type AgentResult } from "@/lib/claude";
-import type { RequestLogger } from "@/lib/logger";
+import type { LogFn } from "@/lib/logger";
 
 function requireEnv(name: string): void {
   if (!process.env[name]) {
@@ -13,7 +13,7 @@ function requireEnv(name: string): void {
 // Drops all structured log events so eval runs don't pollute vitest output
 // with per-round agent JSON. Override by setting EVAL_VERBOSE=1 in the
 // environment when debugging a failing eval.
-const silentLog: RequestLogger =
+const silentLog: LogFn =
   process.env.EVAL_VERBOSE
     ? (event, data) => {
         // eslint-disable-next-line no-console

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -5,11 +5,12 @@ import { readFile } from "@/lib/github";
 import { getKnowledgeAsMarkdown } from "@/lib/knowledge";
 import { getFeedbackAsMarkdown } from "@/lib/feedback";
 import { getOrRebuildIndex, getCachedConfig } from "@/lib/repo-index";
-import { log, type RequestLogger } from "@/lib/logger";
+import { log, type LogFn, type RequestLogger } from "@/lib/logger";
 import { classifyApiError, userErrorMessage } from "@/lib/api-error";
 import { shouldWarnBudget, shouldForceStop } from "@/lib/time-budget";
 import type { BattleMageConfig } from "@/lib/config";
 import { compactThread, shouldCompact } from "@/lib/compaction";
+import type { AgentMetrics } from "@/lib/reply-footer";
 
 // ── Anthropic client ──────────────────────────────────────────────────
 const anthropic = new Anthropic(); // reads ANTHROPIC_API_KEY from env
@@ -406,6 +407,13 @@ export interface AgentResult {
   text: string;
   issueProposal?: IssueProposal;
   references: Reference[];
+  /**
+   * Per-turn telemetry snapshot: duration, token usage, cache reads,
+   * round count. Always populated — every return path computes it from
+   * the current counters. Consumed by the optional reply footer in
+   * route.ts (see #79); also useful for any future debug tooling.
+   */
+  metrics: AgentMetrics;
 }
 
 export type ProgressCallback = (toolName: string, input: Record<string, unknown>) => void | Promise<void>;
@@ -441,7 +449,7 @@ export interface ConversationTurn {
 // and the async context stays clean. Exported for unit testing.
 export function logStreamError(
   round: number,
-  logger: RequestLogger,
+  logger: LogFn,
 ): (err: unknown) => void {
   return (err: unknown) => {
     logger("agent_stream_error", {
@@ -454,7 +462,7 @@ export function logStreamError(
 async function anthropicCall(
   params: Anthropic.MessageCreateParamsNonStreaming,
   onTextDelta: TextDeltaCallback | undefined,
-  _log: RequestLogger,
+  _log: LogFn,
   round: number,
 ): Promise<Anthropic.Message> {
   try {
@@ -480,11 +488,13 @@ export async function runAgent(
   userMessage: string,
   onProgress?: ProgressCallback,
   conversationHistory?: ConversationTurn[],
-  rlog?: RequestLogger,
+  rlog?: LogFn,
   onTextDelta?: TextDeltaCallback,
 ): Promise<AgentResult> {
-  // Use request-scoped logger if provided, fall back to bare log
-  const _log: RequestLogger = rlog ?? log;
+  // Use request-scoped logger if provided, fall back to bare log. Typed
+  // as LogFn because runAgent itself only calls the logger (the route
+  // keeps the full RequestLogger for the reply footer's requestId).
+  const _log: LogFn = rlog ?? log;
 
   // Compact conversation history if it exceeds the trigger. Runs before
   // the messages array is built so the round-0 request is already slim.
@@ -514,6 +524,17 @@ export async function runAgent(
 
   let warned = false;
   let contextWarned = false;
+  // Snapshot current counters at any return point. All AgentResult values
+  // carry a `metrics` field populated via this closure so the reply
+  // footer (#79) can render it without branching on error vs. happy path.
+  const buildMetrics = (rounds: number): AgentMetrics => ({
+    duration_ms: Date.now() - startTime,
+    input_tokens: totalInput,
+    output_tokens: totalOutput,
+    cache_read_tokens: totalCacheRead,
+    cache_creation_tokens: totalCacheCreation,
+    rounds,
+  });
   let totalCacheRead = 0;
   let totalCacheCreation = 0;
   let totalInput = 0;
@@ -533,6 +554,7 @@ export async function runAgent(
         text: "I've been working on this for a while and want to give you what I have so far rather than keep you waiting. Here's my answer based on what I've found:\n\n_I ran out of time before completing a thorough analysis. Ask a follow-up question if you need more detail on a specific area._",
         issueProposal,
         references: finalRefs,
+        metrics: buildMetrics(round),
       };
     }
 
@@ -568,6 +590,7 @@ export async function runAgent(
         text: userErrorMessage(errInfo),
         issueProposal,
         references: [],
+        metrics: buildMetrics(round),
       };
     }
 
@@ -601,7 +624,7 @@ export async function runAgent(
         cache_creation_tokens: totalCacheCreation,
         model: MODEL,
       });
-      return { text, issueProposal, references: dedupeRefs() };
+      return { text, issueProposal, references: dedupeRefs(), metrics: buildMetrics(round + 1) };
     }
 
     // Process tool calls
@@ -616,7 +639,12 @@ export async function runAgent(
         if (b.type === "text") return b.text;
         return "";
       }).join("\n");
-      return { text: text || "I wasn't able to process that request.", issueProposal, references: dedupeRefs() };
+      return {
+        text: text || "I wasn't able to process that request.",
+        issueProposal,
+        references: dedupeRefs(),
+        metrics: buildMetrics(round + 1),
+      };
     }
 
     // Context-budget exhaustion guard: if we already warned and the model
@@ -632,6 +660,7 @@ export async function runAgent(
           "I gathered a lot of context while researching this. Here's what I've found so far — please ask a narrower follow-up if you need more detail on a specific area.",
         issueProposal,
         references: dedupeRefs(),
+        metrics: buildMetrics(round + 1),
       };
     }
 
@@ -699,6 +728,7 @@ export async function runAgent(
     text: "I hit the maximum number of tool calls for this request. Here's what I found so far — please ask a more specific question if you need more detail.",
     issueProposal,
     references: finalRefs,
+    metrics: buildMetrics(MAX_TOOL_ROUNDS),
   };
 }
 
@@ -714,7 +744,7 @@ export async function runAgent(
 
 export interface ParallelToolsContext {
   round: number;
-  log: RequestLogger;
+  log: LogFn;
   onProgress?: ProgressCallback;
   executor?: (name: string, input: Record<string, unknown>) => Promise<ToolResult>;
 }

--- a/src/lib/compaction.ts
+++ b/src/lib/compaction.ts
@@ -24,7 +24,7 @@
 
 import Anthropic from "@anthropic-ai/sdk";
 import { FAST_MODEL, type ConversationTurn } from "@/lib/claude";
-import { log as defaultLog, type RequestLogger } from "@/lib/logger";
+import { log as defaultLog, type LogFn } from "@/lib/logger";
 
 // Shared client. Same instance as claude.ts via singleton at module-eval
 // time. Reads ANTHROPIC_API_KEY from env.
@@ -72,7 +72,7 @@ export function shouldCompact(history: ConversationTurn[]): boolean {
 
 export interface CompactContext {
   /** Logger for thread_compacted / thread_compaction_error events. */
-  log?: RequestLogger;
+  log?: LogFn;
   /** Injectable compactor for tests. In prod defaults to a Haiku call. */
   compactor?: (prompt: string) => Promise<string>;
 }

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -140,7 +140,7 @@ describe("flushLogs", () => {
   });
 
   it("does not throw when the logger itself throws", async () => {
-    const throwing: import("./logger").RequestLogger = () => {
+    const throwing: import("./logger").LogFn = () => {
       throw new Error("logger broke");
     };
     // Must not reject — post-response flow depends on this invariant.

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -32,16 +32,30 @@ export function log(event: string, data?: Record<string, unknown>): void {
 }
 
 /**
- * Create a request-scoped logger with a unique ID.
- * All calls from the same logger share a requestId for correlation.
+ * A plain log function — event name + optional data. Use this as the
+ * parameter type anywhere a caller only needs to INVOKE the logger
+ * (the overwhelming majority of internal call sites). Accepts both a
+ * bare function and a full RequestLogger.
  */
-export type RequestLogger = (event: string, data?: Record<string, unknown>) => void;
+export type LogFn = (event: string, data?: Record<string, unknown>) => void;
+
+/**
+ * Request-scoped logger: callable like LogFn, plus exposes the shared
+ * `requestId` as a property so surfaces that render it (e.g., the reply
+ * footer in #79) can read it without regenerating one. All calls from
+ * the same logger share that requestId for correlation.
+ */
+export type RequestLogger = LogFn & {
+  readonly requestId: string;
+};
 
 export function createRequestLogger(): RequestLogger {
   const requestId = Math.random().toString(36).slice(2, 10);
-  return (event: string, data?: Record<string, unknown>) => {
+  const fn = (event: string, data?: Record<string, unknown>) => {
     log(event, { requestId, ...data });
   };
+  // Attach requestId as a readable property on the function object.
+  return Object.assign(fn, { requestId });
 }
 
 /**
@@ -53,7 +67,7 @@ export function createRequestLogger(): RequestLogger {
  * event itself acts as a canary: if it appears in production logs,
  * the flush worked and so did every earlier log in the same turn.
  */
-export async function flushLogs(rlog: RequestLogger, flow: string): Promise<void> {
+export async function flushLogs(rlog: LogFn, flow: string): Promise<void> {
   try {
     rlog("turn_end", { flow });
   } catch {

--- a/src/lib/reply-footer.test.ts
+++ b/src/lib/reply-footer.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatReplyFooter,
+  formatDurationCompact,
+  formatTokensCompact,
+  isReplyFooterEnabled,
+  type AgentMetrics,
+} from "./reply-footer";
+
+const baseMetrics: AgentMetrics = {
+  duration_ms: 45_000,
+  input_tokens: 3_200,
+  output_tokens: 820,
+  cache_read_tokens: 500,
+  cache_creation_tokens: 0,
+  rounds: 3,
+};
+
+describe("formatDurationCompact", () => {
+  it("formats sub-second durations as 0s", () => {
+    expect(formatDurationCompact(420)).toBe("0s");
+  });
+
+  it("formats seconds as Ns", () => {
+    expect(formatDurationCompact(1_000)).toBe("1s");
+    expect(formatDurationCompact(45_000)).toBe("45s");
+    expect(formatDurationCompact(59_999)).toBe("59s");
+  });
+
+  it("formats minutes+seconds as MmSs for >= 1 minute", () => {
+    expect(formatDurationCompact(60_000)).toBe("1m0s");
+    expect(formatDurationCompact(65_000)).toBe("1m5s");
+    expect(formatDurationCompact(125_000)).toBe("2m5s");
+  });
+
+  it("handles zero cleanly", () => {
+    expect(formatDurationCompact(0)).toBe("0s");
+  });
+
+  it("handles negative as 0s (defensive)", () => {
+    // runAgent could theoretically produce a negative if clocks jump —
+    // defensively clamp rather than show `-5s`.
+    expect(formatDurationCompact(-1000)).toBe("0s");
+  });
+});
+
+describe("formatTokensCompact", () => {
+  it("formats small values (<1000) as integer", () => {
+    expect(formatTokensCompact(0)).toBe("0");
+    expect(formatTokensCompact(500)).toBe("500");
+    expect(formatTokensCompact(999)).toBe("999");
+  });
+
+  it("formats 1k-10k with one decimal place", () => {
+    expect(formatTokensCompact(1_000)).toBe("1.0k");
+    expect(formatTokensCompact(3_200)).toBe("3.2k");
+    expect(formatTokensCompact(9_900)).toBe("9.9k");
+  });
+
+  it("formats 10k+ without decimals", () => {
+    expect(formatTokensCompact(10_000)).toBe("10k");
+    expect(formatTokensCompact(48_500)).toBe("49k"); // rounds
+    expect(formatTokensCompact(150_000)).toBe("150k");
+  });
+});
+
+describe("formatReplyFooter", () => {
+  it("returns a single italic Slack line with all metrics", () => {
+    const footer = formatReplyFooter(baseMetrics, "abc12345");
+    // Slack italic: _..._ — stripped of the leading newline (separator
+    // from the preceding block), the rest is on one line.
+    const content = footer.replace(/^\n/, "");
+    expect(content).toMatch(/^_.*_$/);
+    expect(content).not.toContain("\n");
+  });
+
+  it("includes duration, input tokens, output tokens, request ID", () => {
+    const footer = formatReplyFooter(baseMetrics, "abc12345");
+    expect(footer).toContain("45s");
+    expect(footer).toContain("3.2k in");
+    expect(footer).toContain("820 out");
+    expect(footer).toContain("abc12345");
+  });
+
+  it("omits cache_read when zero", () => {
+    const metrics = { ...baseMetrics, cache_read_tokens: 0 };
+    const footer = formatReplyFooter(metrics, "abc12345");
+    expect(footer).not.toContain("cached");
+  });
+
+  it("includes cache_read when non-zero", () => {
+    const footer = formatReplyFooter(baseMetrics, "abc12345");
+    expect(footer).toContain("500 cached");
+  });
+
+  it("truncates long request IDs to first 8 chars", () => {
+    const footer = formatReplyFooter(baseMetrics, "0123456789abcdef");
+    expect(footer).toContain("01234567");
+    expect(footer).not.toContain("89abcdef");
+  });
+
+  it("handles short request IDs gracefully (no padding)", () => {
+    const footer = formatReplyFooter(baseMetrics, "abc");
+    expect(footer).toContain("abc");
+  });
+
+  it("uses middot separators between fields", () => {
+    const footer = formatReplyFooter(baseMetrics, "abc12345");
+    // At least two middots expected: duration · in · out · id
+    expect(footer.match(/·/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("starts with a leading newline so it drops below the preceding block", () => {
+    // Route will concatenate the footer after references; a leading newline
+    // ensures visual separation without the caller having to add one.
+    const footer = formatReplyFooter(baseMetrics, "abc12345");
+    expect(footer.startsWith("\n")).toBe(true);
+  });
+});
+
+describe("isReplyFooterEnabled", () => {
+  it("returns true when BM_REPLY_FOOTER is \"1\"", () => {
+    expect(isReplyFooterEnabled({ BM_REPLY_FOOTER: "1" })).toBe(true);
+  });
+
+  it("returns true when BM_REPLY_FOOTER is \"true\"", () => {
+    expect(isReplyFooterEnabled({ BM_REPLY_FOOTER: "true" })).toBe(true);
+  });
+
+  it("is case-insensitive on \"true\"", () => {
+    expect(isReplyFooterEnabled({ BM_REPLY_FOOTER: "True" })).toBe(true);
+    expect(isReplyFooterEnabled({ BM_REPLY_FOOTER: "TRUE" })).toBe(true);
+  });
+
+  it("returns false when unset", () => {
+    expect(isReplyFooterEnabled({})).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isReplyFooterEnabled({ BM_REPLY_FOOTER: "" })).toBe(false);
+  });
+
+  it("returns false for \"0\" or \"false\"", () => {
+    expect(isReplyFooterEnabled({ BM_REPLY_FOOTER: "0" })).toBe(false);
+    expect(isReplyFooterEnabled({ BM_REPLY_FOOTER: "false" })).toBe(false);
+  });
+});

--- a/src/lib/reply-footer.ts
+++ b/src/lib/reply-footer.ts
@@ -1,0 +1,67 @@
+/**
+ * Compact telemetry footer for replies.
+ *
+ * Appends a single italic Slack line showing duration, token usage, cache
+ * metrics, and request ID to answer messages. Disabled by default; enable
+ * with `BM_REPLY_FOOTER=1`. Junior's `_45s · 3.2k in · 0.8k out · abc12345_`
+ * pattern — turns a black-box agent reply into something you can debug at
+ * a glance.
+ *
+ * See #79.
+ */
+
+export interface AgentMetrics {
+  duration_ms: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  rounds: number;
+}
+
+export function formatDurationCompact(ms: number): string {
+  if (ms < 1000) return "0s"; // includes negative / zero / sub-second
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds - minutes * 60;
+  return `${minutes}m${seconds}s`;
+}
+
+export function formatTokensCompact(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 10_000) {
+    // One decimal place for the 1k-10k range where precision matters.
+    const scaled = Math.round(n / 100) / 10;
+    return `${scaled.toFixed(1)}k`;
+  }
+  // Over 10k, round to nearest thousand — precision doesn't help at scale.
+  return `${Math.round(n / 1000)}k`;
+}
+
+export function formatReplyFooter(metrics: AgentMetrics, requestId: string): string {
+  const parts: string[] = [];
+  parts.push(formatDurationCompact(metrics.duration_ms));
+  parts.push(`${formatTokensCompact(metrics.input_tokens)} in`);
+  parts.push(`${formatTokensCompact(metrics.output_tokens)} out`);
+  if (metrics.cache_read_tokens > 0) {
+    parts.push(`${formatTokensCompact(metrics.cache_read_tokens)} cached`);
+  }
+  parts.push(requestId.slice(0, 8));
+  // Leading newline provides visual separation from any preceding block
+  // (references footer, proposal body) without forcing every caller to
+  // add their own.
+  return `\n_${parts.join(" · ")}_`;
+}
+
+/**
+ * Reads BM_REPLY_FOOTER from the given env. Accepts "1", "true" (any case)
+ * as truthy. Takes an env object for testability — pass `process.env` in
+ * production.
+ */
+export function isReplyFooterEnabled(env: Record<string, string | undefined>): boolean {
+  const raw = env.BM_REPLY_FOOTER;
+  if (!raw) return false;
+  const normalized = raw.toLowerCase();
+  return normalized === "1" || normalized === "true";
+}


### PR DESCRIPTION
## Summary

Adds an optional single-line footer to every BM reply:

`_45s · 3.2k in · 820 out · 500 cached · abc12345_`

Disabled by default. Enable with `BM_REPLY_FOOTER=1` in the Vercel env. Turns a black-box answer into something you can debug at a glance — \"that reply was weird\" → immediately visible if it took 2 minutes, burned 50k tokens, or hit no cache.

## Changes

- **New `src/lib/reply-footer.ts`**: `AgentMetrics` interface, pure formatters (`formatDurationCompact`, `formatTokensCompact`), `formatReplyFooter(metrics, requestId)`, `isReplyFooterEnabled(env)`. Three-tier token formatting (integer, \"3.2k\" decimal, \"49k\" rounded); clamps negative durations; omits cache metric when zero; truncates requestId to first 8 chars.
- **`src/lib/claude.ts`**: `AgentResult` gains `metrics: AgentMetrics` (always populated). `buildMetrics(rounds)` closure in `runAgent` injected at all 5 return paths so every caller — including error paths and force-stops — gets telemetry.
- **`src/lib/logger.ts`**: new `LogFn` type for callable-only loggers; `RequestLogger` extends it with `requestId`. Internal consumers retype to `LogFn` (narrower); only the route needs the full `RequestLogger` for the footer.
- **`src/app/api/slack/route.ts`**: footer appended after references in both mention and thread_followup flows, gated by `isReplyFooterEnabled(process.env)`. Empty string when disabled — zero visible change for default users.

## Test plan

- [x] 22 new tests in `reply-footer.test.ts` covering formatter edge cases (sub-second, minute rollover, negative clamp, K-notation tiers, cache-zero omit, ID truncation, italic wrap, leading newline, env-var truthy/falsy).
- [x] Existing tests updated for the LogFn split.
- [x] 354/354 total pass. Typecheck clean.
- [ ] Post-merge smoke: set `BM_REPLY_FOOTER=1` in Vercel prod env → next `@bm` question includes the footer. Set back to unset or 0 → footer goes away.

## Out of scope

- Rounds count in the footer — easy add, left off v1 for line-compactness. Metrics object carries it for any future use.
- OTel trace ID (depends on #81 — Vercel AI SDK migration). When that lands, footer can swap `requestId` for `trace_id` without changing structure.

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)