### PR TITLE
feat: Inject Slack thread participants as <@USERID> tokens (closes #80)

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -27,6 +27,11 @@ import {
   DEFAULT_STATUS_ROTATION_TEXT,
 } from "@/lib/status-scheduler";
 import { formatReplyFooter, isReplyFooterEnabled } from "@/lib/reply-footer";
+import {
+  extractParticipantIds,
+  resolveParticipants,
+  type Participant,
+} from "@/lib/slack-users";
 import { createRequestLogger, flushLogs } from "@/lib/logger";
 import { getCachedTopics } from "@/lib/repo-index";
 import { matchTopicsToQuestion, buildQuestionHints } from "@/lib/topic-match";
@@ -99,14 +104,31 @@ export async function POST(request: NextRequest) {
 
         const cleanMessage = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
 
-        // If this is a re-mention inside a thread, fetch history for context
-        // (fresh top-level mentions have no thread_ts — no history needed)
+        // Thread participants for #80: resolve user IDs to display names
+        // so the agent can @-mention correctly. Populated for BOTH fresh
+        // mentions (participants = invoking user + anyone they mentioned)
+        // and thread follow-ups (all thread authors + anyone mentioned).
         let mentionHistory: { role: "user" | "assistant"; content: string }[] | undefined;
+        let mentionParticipants: Participant[] | undefined;
+        const botId = await getBotUserId();
         if (event.thread_ts) {
-          const botId = await getBotUserId();
+          const threadMsgs = await fetchThreadMessages(channel, threadTs);
           if (botId) {
-            const threadMsgs = await fetchThreadMessages(channel, threadTs);
             mentionHistory = buildConversationHistory(threadMsgs, botId);
+          }
+          const ids = extractParticipantIds(threadMsgs, botId);
+          if (ids.length > 0) {
+            mentionParticipants = await resolveParticipants(ids);
+          }
+        } else {
+          // Fresh top-level mention — the only participant signal is the
+          // invoking user + anyone they mentioned in the message body.
+          const ids = extractParticipantIds(
+            [{ user: event.user, text: userMessage }],
+            botId,
+          );
+          if (ids.length > 0) {
+            mentionParticipants = await resolveParticipants(ids);
           }
         }
 
@@ -157,6 +179,7 @@ export async function POST(request: NextRequest) {
           mentionHistory,
           rlog,
           (snapshot) => streamThrottle.update(snapshot),
+          mentionParticipants,
         );
         // Drain any pending streamed edit AND pending status before
         // the final write so neither can race or overwrite the answer.
@@ -322,6 +345,13 @@ export async function POST(request: NextRequest) {
         // (uses Anthropic's native message format, not string hacking)
         const history = buildConversationHistory(threadMessages, bid);
 
+        // Thread participants for #80 — resolve IDs now so the agent can
+        // @-mention teammates in its answer.
+        const followupParticipantIds = extractParticipantIds(threadMessages, bid);
+        const followupParticipants = followupParticipantIds.length > 0
+          ? await resolveParticipants(followupParticipantIds)
+          : undefined;
+
         // Pre-match for thread follow-ups too
         const followupTopics = await getCachedTopics();
         const followupMatches = matchTopicsToQuestion(cleanMessage, followupTopics);
@@ -359,6 +389,7 @@ export async function POST(request: NextRequest) {
           history,
           rlog,
           (snapshot) => followupThrottle.update(snapshot),
+          followupParticipants,
         );
         await followupThrottle.flush();
         await followupStatus.flush();

--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -116,6 +116,34 @@ describe("assembleSystemPrompt", () => {
       expect(prompt).toContain("Feedback");
     });
 
+    it("includes thread participants block when provided (#80)", () => {
+      const prompt = assembleSystemPrompt({
+        ...baseArgs,
+        participants: [
+          { id: "U12345", displayName: "Vlad" },
+          { id: "U67890", displayName: "Cole" },
+        ],
+      });
+      // Header is present
+      expect(prompt).toContain("Thread Participants");
+      // Each participant rendered as "- Name (<@ID>)"
+      expect(prompt).toContain("- Vlad (<@U12345>)");
+      expect(prompt).toContain("- Cole (<@U67890>)");
+      // Guidance: the rule about not using a bare `@name`
+      expect(prompt).toContain("<@USERID>");
+      expect(prompt).toContain("bare");
+    });
+
+    it("omits participants section when undefined", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      expect(prompt).not.toContain("Thread Participants");
+    });
+
+    it("omits participants section when empty array", () => {
+      const prompt = assembleSystemPrompt({ ...baseArgs, participants: [] });
+      expect(prompt).not.toContain("Thread Participants");
+    });
+
     it("omits feedback section when null", () => {
       const prompt = assembleSystemPrompt(baseArgs);
       expect(prompt).not.toContain("User Feedback");

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -11,6 +11,7 @@ import { shouldWarnBudget, shouldForceStop } from "@/lib/time-budget";
 import type { BattleMageConfig } from "@/lib/config";
 import { compactThread, shouldCompact } from "@/lib/compaction";
 import type { AgentMetrics } from "@/lib/reply-footer";
+import type { Participant } from "@/lib/slack-users";
 
 // ── Anthropic client ──────────────────────────────────────────────────
 const anthropic = new Anthropic(); // reads ANTHROPIC_API_KEY from env
@@ -140,6 +141,12 @@ export interface PromptInputs {
   feedback: string | null;
   repoIndex: string | null;
   pathAnnotations: BattleMageConfig | null;
+  /**
+   * Resolved Slack thread participants — `<@USERID>` tokens + display
+   * names that the model can @-mention without calling a tool. Omit or
+   * pass an empty array to skip the block entirely. See #80.
+   */
+  participants?: Participant[];
 }
 
 function buildAnnotationsSection(config: BattleMageConfig | null): string {
@@ -345,8 +352,23 @@ function buildStableZone(inputs: PromptInputs): string {
   ].join("\n\n");
 }
 
+function buildParticipantsSection(participants: Participant[] | undefined): string {
+  if (!participants || participants.length === 0) return "";
+  const lines = participants
+    .map((p) => `- ${p.displayName} (<@${p.id}>)`)
+    .join("\n");
+  // Keep the rule short and unambiguous — bare `@name` tokens never render
+  // as a live mention in Slack, only `<@USERID>` does. Telling the model
+  // this avoids "@cole" strings that look right in chat but don't ping.
+  return (
+    `\n## Thread Participants\n\n` +
+    `When referring to a participant below, use the exact \`<@USERID>\` token from the list — never a bare \`@name\` (Slack only renders the \`<@...>\` form as a real mention). If someone is not in this list, don't try to @-mention them.\n\n` +
+    `${lines}\n`
+  );
+}
+
 function buildVolatileZone(inputs: PromptInputs): string {
-  const { owner, repo, claudeMd, knowledge, feedback, repoIndex, pathAnnotations } = inputs;
+  const { owner, repo, claudeMd, knowledge, feedback, repoIndex, pathAnnotations, participants } = inputs;
   const contextSection = claudeMd
     ? `\n## Project Context (from CLAUDE.md)\n\n${claudeMd}\n`
     : "";
@@ -360,8 +382,9 @@ function buildVolatileZone(inputs: PromptInputs): string {
     ? `\n## Repository Map (auto-generated index)\n\nThis map shows the key areas of the repo. Use it to jump directly to relevant files with \`read_file\` instead of searching blind. The map is rebuilt automatically when the repo changes.\n\n${repoIndex}\n`
     : "";
   const annotationsSection = buildAnnotationsSection(pathAnnotations);
+  const participantsSection = buildParticipantsSection(participants);
 
-  return `\n\n${buildRepoContextSection(owner, repo)}\n${contextSection}${repoIndexSection}${annotationsSection}${knowledgeSection}${feedbackSection}`;
+  return `\n\n${buildRepoContextSection(owner, repo)}\n${contextSection}${repoIndexSection}${annotationsSection}${knowledgeSection}${feedbackSection}${participantsSection}`;
 }
 
 export function assembleSystemPrompt(inputs: PromptInputs): string {
@@ -387,7 +410,9 @@ export function assembleSystemBlocks(inputs: PromptInputs): Anthropic.TextBlockP
 }
 
 // ── Async wrapper that fetches data then assembles ────────────────────
-async function buildSystemBlocks(): Promise<Anthropic.TextBlockParam[]> {
+async function buildSystemBlocks(
+  participants?: Participant[],
+): Promise<Anthropic.TextBlockParam[]> {
   const repoIndex = await getOrRebuildIndex();
   const config = await getCachedConfig();
   return assembleSystemBlocks({
@@ -398,6 +423,7 @@ async function buildSystemBlocks(): Promise<Anthropic.TextBlockParam[]> {
     feedback: await getFeedbackAsMarkdown(),
     repoIndex,
     pathAnnotations: Object.keys(config.paths).length > 0 ? config : null,
+    participants,
   });
 }
 
@@ -490,6 +516,7 @@ export async function runAgent(
   conversationHistory?: ConversationTurn[],
   rlog?: LogFn,
   onTextDelta?: TextDeltaCallback,
+  participants?: Participant[],
 ): Promise<AgentResult> {
   // Use request-scoped logger if provided, fall back to bare log. Typed
   // as LogFn because runAgent itself only calls the logger (the route
@@ -513,7 +540,7 @@ export async function runAgent(
   let issueProposal: IssueProposal | undefined;
   const allReferences: Reference[] = [];
   const startTime = Date.now();
-  const systemBlocks = await buildSystemBlocks();
+  const systemBlocks = await buildSystemBlocks(participants);
   const promptLength = systemBlocks.reduce((n, b) => n + b.text.length, 0);
 
   _log("agent_start", {

--- a/src/lib/slack-users.test.ts
+++ b/src/lib/slack-users.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ThreadMessage } from "./thread-filter";
+
+// Mock the KV client first so our slack-users module picks up the mock.
+// Defaults to Promise-returning so fire-and-forget `kv.set(...).catch()`
+// calls in the module don't trip on undefined. Individual tests can
+// override behavior via .mockImplementation.
+const kvGet = vi.fn().mockResolvedValue(null);
+const kvSet = vi.fn().mockResolvedValue("OK");
+vi.mock("@vercel/kv", () => ({
+  kv: {
+    get: (...args: unknown[]) => kvGet(...args),
+    set: (...args: unknown[]) => kvSet(...args),
+  },
+}));
+
+// Mock the slack client's users.info — we control its behavior per test.
+const usersInfo = vi.fn();
+vi.mock("./slack", () => ({
+  slack: {
+    users: {
+      info: (...args: unknown[]) => usersInfo(...args),
+    },
+  },
+}));
+
+// Import AFTER mocks are registered so the module resolves against them.
+import {
+  extractParticipantIds,
+  resolveParticipants,
+  PARTICIPANT_CACHE_TTL_SECONDS,
+} from "./slack-users";
+
+const BOT_ID = "U_BOT";
+
+describe("extractParticipantIds", () => {
+  it("returns unique user IDs from message authors", () => {
+    const msgs: ThreadMessage[] = [
+      { user: "U1", text: "hi" },
+      { user: "U2", text: "hello" },
+      { user: "U1", text: "again" }, // duplicate author
+    ];
+    expect(extractParticipantIds(msgs, BOT_ID).sort()).toEqual(["U1", "U2"]);
+  });
+
+  it("excludes the bot's own user ID", () => {
+    const msgs: ThreadMessage[] = [
+      { user: "U1", text: "@bm help" },
+      { user: BOT_ID, text: "bot reply", bot_id: "B001" },
+    ];
+    expect(extractParticipantIds(msgs, BOT_ID)).toEqual(["U1"]);
+  });
+
+  it("also extracts user IDs from <@U...> mention tokens in text", () => {
+    // A thread where the user asks about someone who hasn't posted yet —
+    // we still want that ID resolvable so the bot can @-mention them.
+    const msgs: ThreadMessage[] = [
+      { user: "U1", text: "can you ping <@U99> about this?" },
+    ];
+    expect(extractParticipantIds(msgs, BOT_ID).sort()).toEqual(["U1", "U99"]);
+  });
+
+  it("excludes the bot's ID even when it appears in text as a mention", () => {
+    const msgs: ThreadMessage[] = [
+      { user: "U1", text: `<@${BOT_ID}> what does this do?` },
+    ];
+    expect(extractParticipantIds(msgs, BOT_ID)).toEqual(["U1"]);
+  });
+
+  it("returns empty array for empty thread", () => {
+    expect(extractParticipantIds([], BOT_ID)).toEqual([]);
+  });
+
+  it("returns empty array when bot is sole author", () => {
+    const msgs: ThreadMessage[] = [
+      { user: BOT_ID, text: "bot solo", bot_id: "B001" },
+    ];
+    expect(extractParticipantIds(msgs, BOT_ID)).toEqual([]);
+  });
+
+  it("works when botUserId is undefined (no-op filter)", () => {
+    // If we can't determine the bot's ID, don't filter anything.
+    const msgs: ThreadMessage[] = [{ user: "U1", text: "<@U2>" }];
+    expect(extractParticipantIds(msgs, undefined).sort()).toEqual(["U1", "U2"]);
+  });
+
+  it("skips messages with no user field", () => {
+    const msgs: ThreadMessage[] = [
+      { text: "system message" },
+      { user: "U1", text: "real user" },
+    ];
+    expect(extractParticipantIds(msgs, BOT_ID)).toEqual(["U1"]);
+  });
+});
+
+describe("resolveParticipants", () => {
+  beforeEach(() => {
+    // Clear call history but re-establish Promise-returning defaults so
+    // `kv.set(...).catch()` in production code doesn't trip on undefined.
+    kvGet.mockReset().mockResolvedValue(null);
+    kvSet.mockReset().mockResolvedValue("OK");
+    usersInfo.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns cached display names without calling slack.users.info", async () => {
+    kvGet.mockImplementation(async (key: string) => {
+      if (key === "slack_user:U1") return "Vlad";
+      if (key === "slack_user:U2") return "Cole";
+      return null;
+    });
+
+    const result = await resolveParticipants(["U1", "U2"]);
+
+    expect(result).toEqual([
+      { id: "U1", displayName: "Vlad" },
+      { id: "U2", displayName: "Cole" },
+    ]);
+    expect(usersInfo).not.toHaveBeenCalled();
+  });
+
+  it("falls through to slack.users.info on cache miss and stores result", async () => {
+    kvGet.mockResolvedValue(null);
+    usersInfo.mockResolvedValue({
+      ok: true,
+      user: { id: "U1", name: "vlad", real_name: "Vlad Kostanjsek", profile: {} },
+    });
+
+    const result = await resolveParticipants(["U1"]);
+
+    expect(result).toEqual([{ id: "U1", displayName: "Vlad Kostanjsek" }]);
+    expect(usersInfo).toHaveBeenCalledWith({ user: "U1" });
+    expect(kvSet).toHaveBeenCalledWith(
+      "slack_user:U1",
+      "Vlad Kostanjsek",
+      { ex: PARTICIPANT_CACHE_TTL_SECONDS },
+    );
+  });
+
+  it("prefers display_name over real_name when available", async () => {
+    kvGet.mockResolvedValue(null);
+    usersInfo.mockResolvedValue({
+      ok: true,
+      user: {
+        id: "U1",
+        real_name: "Vlad Kostanjsek",
+        profile: { display_name: "vjk" },
+      },
+    });
+
+    const result = await resolveParticipants(["U1"]);
+    expect(result[0].displayName).toBe("vjk");
+  });
+
+  it("falls back to the user ID when users.info returns an error", async () => {
+    kvGet.mockResolvedValue(null);
+    usersInfo.mockResolvedValue({ ok: false, error: "user_not_found" });
+
+    const result = await resolveParticipants(["U_DELETED"]);
+
+    expect(result).toEqual([{ id: "U_DELETED", displayName: "U_DELETED" }]);
+    // Still cache the fallback so we don't retry every turn.
+    expect(kvSet).toHaveBeenCalledWith(
+      "slack_user:U_DELETED",
+      "U_DELETED",
+      { ex: PARTICIPANT_CACHE_TTL_SECONDS },
+    );
+  });
+
+  it("falls back to the user ID when users.info throws", async () => {
+    kvGet.mockResolvedValue(null);
+    usersInfo.mockRejectedValue(new Error("rate_limited"));
+
+    const result = await resolveParticipants(["U1"]);
+    expect(result).toEqual([{ id: "U1", displayName: "U1" }]);
+  });
+
+  it("handles a mix of cached and uncached users", async () => {
+    kvGet.mockImplementation(async (key: string) => {
+      if (key === "slack_user:U1") return "Vlad";
+      return null; // U2 uncached
+    });
+    usersInfo.mockResolvedValue({
+      ok: true,
+      user: { id: "U2", real_name: "Cole", profile: {} },
+    });
+
+    const result = await resolveParticipants(["U1", "U2"]);
+
+    expect(result).toEqual([
+      { id: "U1", displayName: "Vlad" },
+      { id: "U2", displayName: "Cole" },
+    ]);
+    // users.info called only for the uncached one.
+    expect(usersInfo).toHaveBeenCalledOnce();
+    expect(usersInfo).toHaveBeenCalledWith({ user: "U2" });
+  });
+
+  it("returns empty array for empty input (no api calls)", async () => {
+    const result = await resolveParticipants([]);
+    expect(result).toEqual([]);
+    expect(kvGet).not.toHaveBeenCalled();
+    expect(usersInfo).not.toHaveBeenCalled();
+  });
+
+  it("preserves the caller's input order", async () => {
+    kvGet.mockResolvedValue(null);
+    usersInfo.mockImplementation(async ({ user }: { user: string }) => ({
+      ok: true,
+      user: { id: user, real_name: user.toLowerCase(), profile: {} },
+    }));
+
+    const result = await resolveParticipants(["U3", "U1", "U2"]);
+    expect(result.map((p) => p.id)).toEqual(["U3", "U1", "U2"]);
+  });
+});
+
+describe("constants", () => {
+  it("PARTICIPANT_CACHE_TTL_SECONDS is 1 hour per #80", () => {
+    expect(PARTICIPANT_CACHE_TTL_SECONDS).toBe(3600);
+  });
+});

--- a/src/lib/slack-users.ts
+++ b/src/lib/slack-users.ts
@@ -1,0 +1,119 @@
+/**
+ * Slack user ID → display name resolution with KV caching.
+ *
+ * Junior's pattern (see #80): pre-resolve every Slack user in a thread and
+ * inject their IDs into the system prompt as `<@USERID>` tokens so the
+ * model can @-mention teammates correctly without a separate tool call.
+ *
+ * `users.info` is rate-limited (Tier 4: ~50/min) and the display name for
+ * a given user rarely changes. Cache results in Vercel KV with a 1-hour
+ * TTL — cheap enough to keep, fresh enough that renames propagate within
+ * an hour, forgiving enough that a cold thread doesn't burst the rate
+ * limit on the first turn.
+ *
+ * Fail-safe: if `users.info` errors (user deactivated, token scope issue,
+ * rate limit), fall back to the raw user ID as the display name. The
+ * agent still gets a usable `<@USERID>` mention token; only the human
+ * label is less friendly.
+ */
+
+import { kv } from "@vercel/kv";
+import { slack } from "./slack";
+import type { ThreadMessage } from "./thread-filter";
+
+export interface Participant {
+  id: string;
+  displayName: string;
+}
+
+export const PARTICIPANT_CACHE_TTL_SECONDS = 3600;
+
+const MENTION_RE = /<@([A-Z0-9]+)>/g;
+const KV_PREFIX = "slack_user:";
+
+/**
+ * Extract unique user IDs from a thread, pulling from BOTH:
+ *   - each message's `user` field (authors)
+ *   - any `<@U...>` mention tokens in message text (referenced users)
+ *
+ * The bot's own ID is excluded so we don't render "@bm" in the prompt.
+ * Returns in first-seen order so downstream rendering is deterministic.
+ */
+export function extractParticipantIds(
+  messages: ThreadMessage[],
+  botUserId: string | undefined,
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const add = (id: string) => {
+    if (!id) return;
+    if (botUserId && id === botUserId) return;
+    if (seen.has(id)) return;
+    seen.add(id);
+    out.push(id);
+  };
+  for (const m of messages) {
+    if (m.user) add(m.user);
+    const text = m.text ?? "";
+    for (const match of text.matchAll(MENTION_RE)) {
+      add(match[1]);
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve a list of user IDs to `{ id, displayName }` records. Preserves
+ * the input order. Hits KV first; falls through to `slack.users.info` for
+ * uncached IDs, caches the result for `PARTICIPANT_CACHE_TTL_SECONDS`.
+ *
+ * Display name preference:
+ *   1. `profile.display_name` (user-chosen nickname)
+ *   2. `real_name`
+ *   3. the raw user ID (fallback when users.info errors or both above are empty)
+ *
+ * Never throws. A failed `users.info` call caches the fallback so we don't
+ * retry every turn (rate-limit friendly; names resync when TTL expires).
+ */
+export async function resolveParticipants(
+  userIds: string[],
+): Promise<Participant[]> {
+  if (userIds.length === 0) return [];
+
+  const results = await Promise.all(
+    userIds.map(async (id) => {
+      const cached = await kv.get<string>(`${KV_PREFIX}${id}`);
+      if (cached) return { id, displayName: cached };
+
+      let displayName = id; // default fallback
+      try {
+        const resp = await slack.users.info({ user: id });
+        if (resp.ok && resp.user) {
+          const user = resp.user as {
+            profile?: { display_name?: string };
+            real_name?: string;
+          };
+          const chosen =
+            user.profile?.display_name?.trim() ||
+            user.real_name?.trim() ||
+            "";
+          if (chosen) displayName = chosen;
+        }
+      } catch {
+        // Swallow — we'll cache the ID-as-display fallback to avoid
+        // retrying on every turn.
+      }
+
+      // Fire-and-forget cache write; don't let KV slowness block us.
+      kv.set(`${KV_PREFIX}${id}`, displayName, {
+        ex: PARTICIPANT_CACHE_TTL_SECONDS,
+      }).catch(() => {
+        // KV transient failure must not abort the agent turn.
+      });
+
+      return { id, displayName };
+    }),
+  );
+
+  return results;
+}


### PR DESCRIPTION
## Summary

Pre-resolves Slack user IDs for thread participants and injects them into the system prompt so the agent can @-mention teammates correctly without a separate tool call. Mirrors junior's pattern.

## What lands

- **New `src/lib/slack-users.ts`:**
  - `Participant` interface (`{ id, displayName }`).
  - `extractParticipantIds(messages, botUserId)` — pulls unique IDs from BOTH message authors AND `<@U...>` mention tokens in text, so users referenced but not posting also resolve. Excludes the bot.
  - `resolveParticipants(ids)` — KV-cached (`slack_user:<ID>`, 1-hour TTL), falls through to `slack.users.info` on miss. Prefers `profile.display_name` > `real_name` > raw ID fallback. Never throws.
- **`src/lib/claude.ts`:**
  - `PromptInputs` gains optional `participants`.
  - New `buildParticipantsSection()` renders a volatile-zone `## Thread Participants` block listing `- Name (<@ID>)` per line plus an inline rule: *use the exact `<@USERID>` token, never `@name` (only the angle-bracket form renders as a live Slack mention)*.
  - `runAgent` gains optional `participants` param threaded through to `buildSystemBlocks`.
- **`src/app/api/slack/route.ts`:**
  - Mention flow: resolves participants for both thread mentions (full thread authors + mention tokens) AND fresh top-level mentions (invoking user + anyone `<@...>` they mentioned).
  - Thread follow-up flow: mirrors the pattern with the thread's full participant set.

## Test plan

- [x] 17 new tests in `slack-users.test.ts` covering extraction edge cases, cache hit/miss, API error fallback, thrown rejection fallback, display_name preference, empty input, input-order preservation, TTL constant.
- [x] 3 new tests in `claude.test.ts` for the participants block (appears with guidance; omitted when undefined or empty).
- [x] 374/374 pass (+20 new). Typecheck clean.
- [ ] Post-merge smoke: ask the bot something like *"@bm can you summarize this thread for @<teammate>"* in a multi-participant thread. Answer should include a live `<@...>` mention of the teammate (visible as a blue highlighted username) rather than a bare `@name`.

## Notes

- **Deprecation warning:** `@vercel/kv` is flagged for migration to `@upstash/redis`. Staying on `@vercel/kv` here for consistency with the rest of the codebase (`repo-index.ts`, `knowledge.ts`, `feedback.ts`). Storage-layer migration should be a dedicated cross-cutting PR.
- **Rate limit:** `users.info` is Tier-4 (~50/min). The 1-hour KV cache keeps cold-thread bursts bounded; worst-case first turn in a new thread hits it once per unique participant, then nothing until TTL expires.

Closes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)