### PR TITLE
feat: Documentation Index in system prompt (closes #82, option A)

### DIFF
--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -116,6 +116,31 @@ describe("assembleSystemPrompt", () => {
       expect(prompt).toContain("Feedback");
     });
 
+    it("includes doc catalog section when provided (#82)", () => {
+      const prompt = assembleSystemPrompt({
+        ...baseArgs,
+        docCatalog: [
+          { path: "docs/architecture.md", title: "Architecture" },
+          { path: "docs/setup.md", title: "Setup Guide" },
+        ],
+      });
+      expect(prompt).toContain("Documentation Index");
+      expect(prompt).toContain("`docs/architecture.md` — Architecture");
+      expect(prompt).toContain("`docs/setup.md` — Setup Guide");
+      // Guidance must mention the tool the agent uses to pull a doc.
+      expect(prompt).toContain("read_file");
+    });
+
+    it("omits doc catalog section when undefined", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      expect(prompt).not.toContain("Documentation Index");
+    });
+
+    it("omits doc catalog section when empty array", () => {
+      const prompt = assembleSystemPrompt({ ...baseArgs, docCatalog: [] });
+      expect(prompt).not.toContain("Documentation Index");
+    });
+
     it("includes thread participants block when provided (#80)", () => {
       const prompt = assembleSystemPrompt({
         ...baseArgs,

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -4,7 +4,13 @@ import type { IssueProposal } from "@/tools/create-issue";
 import { readFile } from "@/lib/github";
 import { getKnowledgeAsMarkdown } from "@/lib/knowledge";
 import { getFeedbackAsMarkdown } from "@/lib/feedback";
-import { getOrRebuildIndex, getCachedConfig } from "@/lib/repo-index";
+import {
+  getOrRebuildIndex,
+  getCachedConfig,
+  getDocCatalog,
+  buildDocCatalogSection,
+  type DocEntry,
+} from "@/lib/repo-index";
 import { log, type LogFn, type RequestLogger } from "@/lib/logger";
 import { classifyApiError, userErrorMessage } from "@/lib/api-error";
 import { shouldWarnBudget, shouldForceStop } from "@/lib/time-budget";
@@ -147,6 +153,12 @@ export interface PromptInputs {
    * pass an empty array to skip the block entirely. See #80.
    */
   participants?: Participant[];
+  /**
+   * Catalog of `docs/**` markdown files with one-line titles. Rendered
+   * as a discoverability section so the agent knows which docs exist
+   * and can pull the relevant one via `read_file`. See #82.
+   */
+  docCatalog?: DocEntry[];
 }
 
 function buildAnnotationsSection(config: BattleMageConfig | null): string {
@@ -368,7 +380,7 @@ function buildParticipantsSection(participants: Participant[] | undefined): stri
 }
 
 function buildVolatileZone(inputs: PromptInputs): string {
-  const { owner, repo, claudeMd, knowledge, feedback, repoIndex, pathAnnotations, participants } = inputs;
+  const { owner, repo, claudeMd, knowledge, feedback, repoIndex, pathAnnotations, participants, docCatalog } = inputs;
   const contextSection = claudeMd
     ? `\n## Project Context (from CLAUDE.md)\n\n${claudeMd}\n`
     : "";
@@ -383,8 +395,9 @@ function buildVolatileZone(inputs: PromptInputs): string {
     : "";
   const annotationsSection = buildAnnotationsSection(pathAnnotations);
   const participantsSection = buildParticipantsSection(participants);
+  const docCatalogSection = buildDocCatalogSection(docCatalog ?? []);
 
-  return `\n\n${buildRepoContextSection(owner, repo)}\n${contextSection}${repoIndexSection}${annotationsSection}${knowledgeSection}${feedbackSection}${participantsSection}`;
+  return `\n\n${buildRepoContextSection(owner, repo)}\n${contextSection}${repoIndexSection}${docCatalogSection}${annotationsSection}${knowledgeSection}${feedbackSection}${participantsSection}`;
 }
 
 export function assembleSystemPrompt(inputs: PromptInputs): string {
@@ -413,8 +426,18 @@ export function assembleSystemBlocks(inputs: PromptInputs): Anthropic.TextBlockP
 async function buildSystemBlocks(
   participants?: Participant[],
 ): Promise<Anthropic.TextBlockParam[]> {
-  const repoIndex = await getOrRebuildIndex();
-  const config = await getCachedConfig();
+  // Fetch index + doc catalog in parallel. Both are KV-reads on the warm
+  // path; rebuild on cold path is already time-bounded inside
+  // getOrRebuildIndex. getDocCatalog is KV-only and never triggers a
+  // rebuild — the catalog is populated by getOrRebuildIndex as a side
+  // effect, so the order of these two calls here doesn't matter for
+  // correctness (cold-start will either get an empty catalog or the
+  // just-built one depending on timing; both are safe).
+  const [repoIndex, config, docCatalog] = await Promise.all([
+    getOrRebuildIndex(),
+    getCachedConfig(),
+    getDocCatalog(),
+  ]);
   return assembleSystemBlocks({
     owner: process.env.GITHUB_OWNER,
     repo: process.env.GITHUB_REPO,
@@ -424,6 +447,7 @@ async function buildSystemBlocks(
     repoIndex,
     pathAnnotations: Object.keys(config.paths).length > 0 ? config : null,
     participants,
+    docCatalog,
   });
 }
 

--- a/src/lib/repo-index.test.ts
+++ b/src/lib/repo-index.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { classifyTopics, isIndexStale, buildIndexSummary } from "./repo-index";
+import {
+  classifyTopics,
+  isIndexStale,
+  buildIndexSummary,
+  extractDocTitle,
+  filterDocPaths,
+  buildDocCatalogSection,
+} from "./repo-index";
 
 describe("classifyTopics", () => {
   it("classifies auth-related files", () => {
@@ -230,5 +237,131 @@ describe("buildIndexSummary", () => {
     const lines = summary.split("\n");
     expect(lines[0]).toContain("authentication");
     expect(lines[1]).toContain("historic");
+  });
+});
+
+describe("extractDocTitle", () => {
+  it("returns the first H1 line, trimmed and without the # prefix", () => {
+    const content = "# Architecture\n\nHow the internals work.";
+    expect(extractDocTitle(content, "docs/architecture.md")).toBe("Architecture");
+  });
+
+  it("handles leading whitespace/blank lines before the H1", () => {
+    const content = "\n\n\n# Setup Guide\n\nGetting started.";
+    expect(extractDocTitle(content, "docs/setup.md")).toBe("Setup Guide");
+  });
+
+  it("ignores H2/H3 lines and picks only the first H1", () => {
+    const content = "## Subsection\n# Real Title\n### Sub-sub\n";
+    expect(extractDocTitle(content, "docs/x.md")).toBe("Real Title");
+  });
+
+  it("falls back to the path basename (no extension) when no H1 is present", () => {
+    const content = "No heading here.\n\nJust a paragraph.";
+    expect(extractDocTitle(content, "docs/features/repo-index.md")).toBe("repo-index");
+  });
+
+  it("falls back to the basename for empty content", () => {
+    expect(extractDocTitle("", "docs/setup.md")).toBe("setup");
+  });
+
+  it("strips surrounding whitespace and markdown markers from the H1 text", () => {
+    const content = "#   Knowledge  Base   \n\n...";
+    expect(extractDocTitle(content, "docs/kb.md")).toBe("Knowledge  Base");
+  });
+
+  it("uses the first '# ' line regardless of code-fence context (simple heuristic)", () => {
+    // Intentional simplicity: the extractor doesn't parse Markdown AST.
+    // It takes the first line starting with `# `, even inside code fences.
+    // In real docs, the H1 almost always precedes any fenced block, so
+    // this edge case is rare and the cost of AST parsing isn't justified.
+    const content = "```\n# not a heading\n```\n# Real Title\n";
+    expect(extractDocTitle(content, "docs/x.md")).toBe("not a heading");
+  });
+});
+
+describe("filterDocPaths", () => {
+  it("keeps docs/**/*.md and excludes other paths", () => {
+    const paths = [
+      "docs/setup.md",
+      "docs/features/kb.md",
+      "src/auth.ts",
+      "README.md",
+      "docs/architecture.md",
+    ];
+    const result = filterDocPaths(paths);
+    expect(result).toEqual([
+      "docs/setup.md",
+      "docs/features/kb.md",
+      "docs/architecture.md",
+    ]);
+  });
+
+  it("also accepts uppercase .MD (Markdown case-insensitivity)", () => {
+    const paths = ["docs/README.MD", "docs/setup.md"];
+    const result = filterDocPaths(paths);
+    expect(result).toContain("docs/README.MD");
+    expect(result).toContain("docs/setup.md");
+  });
+
+  it("returns empty array when no docs exist", () => {
+    expect(filterDocPaths(["src/auth.ts", "README.md"])).toEqual([]);
+  });
+
+  it("respects config excluded paths", () => {
+    // BattleMageConfig.paths is Record<prefix, PathAnnotation> — the
+    // annotation is the VALUE, not `{ annotation: ... }`. See config.ts.
+    const config = { paths: { "docs/internal/": "excluded" as const } };
+    const paths = ["docs/setup.md", "docs/internal/secret.md"];
+    expect(filterDocPaths(paths, config)).toEqual(["docs/setup.md"]);
+  });
+
+  it("respects config historic paths", () => {
+    const config = { paths: { "docs/archive/": "historic" as const } };
+    const paths = ["docs/setup.md", "docs/archive/old.md"];
+    expect(filterDocPaths(paths, config)).toEqual(["docs/setup.md"]);
+  });
+
+  it("does not match CLAUDE.md (kept inline, not in docs/)", () => {
+    const paths = ["CLAUDE.md", "docs/setup.md"];
+    expect(filterDocPaths(paths)).toEqual(["docs/setup.md"]);
+  });
+});
+
+describe("buildDocCatalogSection", () => {
+  it("renders a markdown section listing each entry", () => {
+    const entries = [
+      { path: "docs/architecture.md", title: "Architecture" },
+      { path: "docs/setup.md", title: "Setup Guide" },
+    ];
+    const section = buildDocCatalogSection(entries);
+    expect(section).toContain("## Documentation Index");
+    expect(section).toContain("- `docs/architecture.md` — Architecture");
+    expect(section).toContain("- `docs/setup.md` — Setup Guide");
+  });
+
+  it("includes guidance about how to load docs", () => {
+    const entries = [{ path: "docs/x.md", title: "X" }];
+    const section = buildDocCatalogSection(entries);
+    // Must tell the model to pull content via read_file when needed.
+    expect(section).toContain("read_file");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(buildDocCatalogSection([])).toBe("");
+  });
+
+  it("preserves entry order", () => {
+    const entries = [
+      { path: "docs/b.md", title: "B doc" },
+      { path: "docs/a.md", title: "A doc" },
+      { path: "docs/c.md", title: "C doc" },
+    ];
+    const section = buildDocCatalogSection(entries);
+    const bIdx = section.indexOf("docs/b.md");
+    const aIdx = section.indexOf("docs/a.md");
+    const cIdx = section.indexOf("docs/c.md");
+    expect(bIdx).toBeLessThan(aIdx);
+    expect(aIdx).toBeLessThan(cIdx);
   });
 });

--- a/src/lib/repo-index.ts
+++ b/src/lib/repo-index.ts
@@ -105,10 +105,78 @@ export function buildIndexSummary(topics: TopicMap): string {
     .join("\n");
 }
 
+// ── Documentation catalog (see #82) ──────────────────────────────────
+// Surfaces every `docs/**/*.md` to the model as a catalog with one-line
+// descriptions, so the agent can decide which doc to pull via `read_file`
+// without stuffing every doc body into the prompt. Cached alongside the
+// topic map, invalidated on HEAD SHA change.
+
+export interface DocEntry {
+  path: string;
+  title: string;
+}
+
+const H1_LINE_RE = /^#\s+(.+?)\s*$/m;
+
+/**
+ * Extract a one-line title from a Markdown doc. Takes the first H1 line
+ * (`# Title`) as the title; falls back to the path basename without
+ * extension when no H1 is found (or content is empty). The H1 heuristic
+ * is intentionally simple (no AST parsing): first line matching `^# ` in
+ * the document. Code fences start with ` ``` ` not `# `, so they don't
+ * trip the regex naturally.
+ */
+export function extractDocTitle(content: string, path: string): string {
+  const match = content.match(H1_LINE_RE);
+  if (match && match[1].trim().length > 0) {
+    return match[1].trim();
+  }
+  // Fallback: basename without .md/.MD extension.
+  const base = path.split("/").pop() ?? path;
+  return base.replace(/\.md$/i, "");
+}
+
+const DOC_PATH_RE = /^docs\/.+\.md$/i;
+
+/**
+ * Keep only Markdown files under the `docs/` tree, honoring the
+ * battle-mage config's `excluded` and `historic` annotations so
+ * internal/archive docs don't bloat the catalog.
+ */
+export function filterDocPaths(
+  paths: string[],
+  config?: BattleMageConfig,
+): string[] {
+  return paths.filter((p) => {
+    if (!DOC_PATH_RE.test(p)) return false;
+    if (!config) return true;
+    const annotation = getAnnotation(p, config);
+    return annotation !== "excluded" && annotation !== "historic";
+  });
+}
+
+/**
+ * Render the doc catalog as a Markdown section for the system prompt.
+ * Empty string for empty input so the caller can concatenate without
+ * worrying about blank sections.
+ */
+export function buildDocCatalogSection(entries: DocEntry[]): string {
+  if (entries.length === 0) return "";
+  const lines = entries
+    .map((e) => `- \`${e.path}\` — ${e.title}`)
+    .join("\n");
+  return (
+    `\n## Documentation Index\n\n` +
+    `These project docs are available via the \`read_file\` tool — use the title hint to pick which to pull when a question warrants deep context. Don't pull a doc speculatively; only when it's likely to answer the current question.\n\n` +
+    `${lines}\n`
+  );
+}
+
 // ── KV keys ──────────────────────────────────────────────────────────
 const INDEX_SHA_KEY = "index:sha";
 const INDEX_TOPICS_KEY = "index:topics";
 const INDEX_SUMMARY_KEY = "index:summary";
+const INDEX_DOC_CATALOG_KEY = "index:doc_catalog";
 const INDEX_BUILT_AT_KEY = "index:built_at";
 
 // ── GitHub helpers (import from github.ts at runtime) ────────────────
@@ -169,19 +237,78 @@ export async function getOrRebuildIndex(): Promise<string> {
     const topics = classifyTopics(paths, config);
     const summary = buildIndexSummary(topics);
 
+    // Build doc catalog in parallel with the rest — fetches content for
+    // every docs/**/*.md to extract H1 titles. Cold-path only; cached on
+    // same SHA-keyed invalidation as the topic map. See #82.
+    const docCatalog = await fetchDocCatalog(paths, config);
+
     // Write to KV
     await kv.set(INDEX_SHA_KEY, currentSha);
     await kv.set(INDEX_TOPICS_KEY, JSON.stringify(topics));
     await kv.set(INDEX_SUMMARY_KEY, summary);
+    await kv.set(INDEX_DOC_CATALOG_KEY, JSON.stringify(docCatalog));
     await kv.set(INDEX_CONFIG_KEY, JSON.stringify(config));
     await kv.set(INDEX_BUILT_AT_KEY, new Date().toISOString());
 
-    log("index_rebuilt", { sha: currentSha, topicCount: Object.keys(topics).length, fileCount: paths.length, duration_ms: Date.now() - startTime });
+    log("index_rebuilt", {
+      sha: currentSha,
+      topicCount: Object.keys(topics).length,
+      fileCount: paths.length,
+      docCount: docCatalog.length,
+      duration_ms: Date.now() - startTime,
+    });
     return summary;
   } catch (err) {
     log("index_build_error", { message: err instanceof Error ? err.message : String(err) });
     return "";
   }
+}
+
+/**
+ * Fetch the cached doc catalog (built alongside the topic index). Returns
+ * an empty array if the index has never been built or the key is missing.
+ * Non-throwing — treats KV errors as "no catalog yet", keeping the agent
+ * loop resilient to storage flakes. See #82.
+ */
+export async function getDocCatalog(): Promise<DocEntry[]> {
+  try {
+    const raw = await kv.get<string>(INDEX_DOC_CATALOG_KEY);
+    if (!raw) return [];
+    const parsed = typeof raw === "string" ? JSON.parse(raw) : (raw as DocEntry[]);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+// Parallel fetch + H1 extraction for every doc path. Individual file
+// failures degrade gracefully to the basename fallback — one broken doc
+// shouldn't deprive the agent of the rest of the catalog.
+async function fetchDocCatalog(
+  paths: string[],
+  config: BattleMageConfig,
+): Promise<DocEntry[]> {
+  const docPaths = filterDocPaths(paths, config);
+  if (docPaths.length === 0) return [];
+
+  const { readFile } = await import("@/lib/github");
+  const entries = await Promise.all(
+    docPaths.map(async (path): Promise<DocEntry> => {
+      try {
+        const result = await readFile(path);
+        const content =
+          "content" in result && typeof result.content === "string"
+            ? result.content
+            : "";
+        return { path, title: extractDocTitle(content, path) };
+      } catch {
+        // Per-file failure: fall back to basename-as-title. The catalog
+        // still surfaces the path so the agent can try read_file later.
+        return { path, title: extractDocTitle("", path) };
+      }
+    }),
+  );
+  return entries;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a new `## Documentation Index` section to the system prompt listing every `docs/**/*.md` file with its one-line title (extracted from the first H1 line). The agent now discovers which docs exist without prior knowledge and pulls content via the existing `read_file` tool when a question warrants deep context.

## Scope decision (Option A)

Per today's back-and-forth: the original #82 AC proposed a dedicated `load_doc` tool and moving feature docs BEHIND a lazy-load pattern. Reviewing what battle-mage actually does today — it *doesn't* inline feature docs; they're already loaded on demand via `read_file` — the real gap was **discoverability**, not tool granularity. Shipping the smaller "option A" (catalog only, no new tool) delivers the 80% win for ~100 lines. If the agent later shows it's struggling to pick the right doc, a dedicated tool can layer on without rework.

## Implementation

- **`src/lib/repo-index.ts`** — three pure helpers + one fetch/storage path, SHA-keyed on the existing index invalidation:
  - `extractDocTitle(content, path)` — first H1 line; falls back to path basename on empty / no heading.
  - `filterDocPaths(paths, config)` — keeps `docs/**/*.md`, honors `excluded` + `historic` annotations from `BattleMageConfig`.
  - `buildDocCatalogSection(entries)` — renders the Markdown section with one-line-per-doc plus usage guidance; empty string for empty input.
  - `fetchDocCatalog(paths, config)` (internal) — parallel `readFile` per doc; per-file failures fall back to the basename so one broken doc doesn't deprive the agent of the rest.
  - `getDocCatalog()` — KV-only reader; non-throwing.
  - New KV key `index:doc_catalog` populated as a side-effect of `getOrRebuildIndex()`.
- **`src/lib/claude.ts`** — `PromptInputs` gains optional `docCatalog`; volatile-zone placement is right after the repository map (both are repo-discovery context). `buildSystemBlocks()` now does the KV reads in parallel.

## Test plan

- [x] 17 new tests in `repo-index.test.ts` (H1 extraction edge cases, filter with/without config, section renderer format + order + empty handling).
- [x] 3 new tests in `claude.test.ts` for the catalog section (appears with guidance, omitted when undefined/empty).
- [x] 394/394 total pass (+20 new). Typecheck clean.
- [ ] Post-merge smoke: after an index rebuild triggers (push any commit), the next `@bm` question sees a `## Documentation Index` section in the prompt. Verify by asking something like *"what doc explains the agent loop?"* — the bot should find `docs/architecture.md` directly without needing to `search_code` for it first.

## Cold-start caveat

`getOrRebuildIndex()` and `getDocCatalog()` run in parallel inside `buildSystemBlocks`. On a cold start where the index hasn't been built yet, the reader may fire before the rebuild's KV write completes — the first turn after a cold rebuild sees an empty catalog; subsequent turns see it. Documented in the code; acceptable trade-off vs. sequencing the calls (which would cost warm-path latency on every turn).

## Out of scope

- Dedicated `load_doc` tool (option B). Can be layered on later.
- Full Markdown-AST parsing for title extraction. Simple heuristic is adequate for our doc shapes.
- `@vercel/kv` → `@upstash/redis` migration. Pre-existing deprecation warning; belongs in a dedicated cross-cutting PR.

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)