### PR TITLE
fix: Cap Slack messages at 40K chars — the REAL msg_too_long cause (closes #100)

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -18,11 +18,8 @@ import { formatReferences, rankReferences } from "@/lib/references";
 import { getAllKnowledge } from "@/lib/knowledge";
 import { buildCorrectionActions } from "@/lib/auto-correct";
 import { toSlackMrkdwn } from "@/lib/mrkdwn";
-
-// Initial acknowledgment posted as the thinking message. One-shot per
-// turn — under the minimize-API-calls model (#108) this is the first
-// of exactly two Slack calls per turn (ack + final answer).
-const THINKING_HEADER = "🧠 Battle Mage is working... _(this may take a minute, go grab some tea)_";
+import { buildThinkingMessage, THINKING_HEADER } from "@/lib/progress";
+import { createThrottledUpdater } from "@/lib/slack-throttle";
 import { formatReplyFooter, isReplyFooterEnabled } from "@/lib/reply-footer";
 import {
   extractParticipantIds,
@@ -137,18 +134,30 @@ export async function POST(request: NextRequest) {
           rlog("topic_hints_injected", { topics: topicMatches.map((m) => m.topic), fileCount: topicMatches.reduce((s, m) => s + m.paths.length, 0) });
         }
 
-        // Minimize Slack API calls per turn to 2: one "Thinking…" on ack
-        // (posted above via replyInThread → thinkingTs) and one final
-        // updateMessage below with the answer. No mid-flight progress
-        // updates, no streaming text deltas — see #108 for the rationale.
-        // The agent_tool_call events still fire to Sentry via the agent
-        // loop's logger, so per-round observability is unaffected.
+        // Tool-progress updater. Per #110 review: the streaming flood
+        // from #109 was character-level text deltas, NOT tool-progress
+        // messages. Tool progress at ~1 call per tool round (debounced
+        // to coalesce parallel bursts) is 5-7 calls per turn — well
+        // under Slack's 30/min Tier 2 limit and genuinely informative
+        // for the user. Re-introducing it WITHOUT streaming.
+        const progressThrottle = createThrottledUpdater(async (text) => {
+          if (thinkingTs) {
+            await updateMessage(channel, thinkingTs, text);
+          }
+        }, 1200);
+
         const result = await runAgent(
           augmentedMessage,
           mentionHistory,
           rlog,
           mentionParticipants,
+          (toolName, input) => {
+            progressThrottle.update(buildThinkingMessage(toolName, input));
+          },
         );
+        // Drain any pending progress update before the final write so a
+        // stale progress message can't land on top of the final answer.
+        await progressThrottle.flush();
         // `agent_complete` is already emitted by runAgent with rounds,
         // token usage, and cache metrics — don't duplicate at route level.
 
@@ -321,15 +330,24 @@ export async function POST(request: NextRequest) {
         const followupMatches = matchTopicsToQuestion(cleanMessage, followupTopics);
         const followupMessage = buildQuestionHints(cleanMessage, followupMatches);
 
-        // Minimize Slack API calls per turn — see mention flow above
-        // and #108 for full rationale. Single "Thinking…" post above +
-        // single final updateMessage below; nothing in between.
+        // Mirror of the mention-flow progress updater — see comment
+        // there + #110 for rationale.
+        const followupProgress = createThrottledUpdater(async (text) => {
+          if (thinkTs) {
+            await updateMessage(channel, thinkTs, text);
+          }
+        }, 1200);
+
         const result = await runAgent(
           followupMessage,
           history,
           rlog,
           followupParticipants,
+          (toolName, input) => {
+            followupProgress.update(buildThinkingMessage(toolName, input));
+          },
         );
+        await followupProgress.flush();
 
         const text = toSlackMrkdwn(result.text);
         const rankedRefs = rankReferences(result.references, result.text);

--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -9,6 +9,8 @@ import {
   MAX_TOOL_ROUNDS,
   TOOL_RESULT_MAX_CHARS,
   MESSAGES_SAFE_BUDGET_TOKENS,
+  ANSWER_BUDGET_CHARS,
+  ISSUE_PROPOSAL_BODY_BUDGET_CHARS,
 } from "./claude";
 import type Anthropic from "@anthropic-ai/sdk";
 
@@ -193,6 +195,48 @@ describe("assembleSystemPrompt", () => {
       const prompt = assembleSystemPrompt(baseArgs);
       expect(prompt).toContain("acme");
       expect(prompt).toContain("backend");
+    });
+  });
+
+  describe("Slack message budget (output contract, #110)", () => {
+    // Primary guard against msg_too_long is prompt-level: tell the model
+    // about Slack's 40K-char ceiling and give it a conservative answer
+    // budget. The slack.ts cap is a rare safety net; these tests pin
+    // the prompt guidance so a future refactor can't silently weaken it.
+
+    it("tells the model about Slack's 40,000-char message ceiling", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      expect(prompt).toContain("40,000");
+      // Must frame it as something that causes the user to see an error,
+      // not just a soft guideline.
+      expect(prompt).toMatch(/reject|error/i);
+    });
+
+    it("states an explicit char budget for the answer itself", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      // The formatted constant must appear — pin the exact number so
+      // callers can't drift the constant without updating the prompt.
+      expect(prompt).toContain(ANSWER_BUDGET_CHARS.toLocaleString());
+    });
+
+    it("states an explicit char budget for issue proposal bodies", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      expect(prompt).toContain(ISSUE_PROPOSAL_BODY_BUDGET_CHARS.toLocaleString());
+      expect(prompt).toMatch(/create_issue|proposal/i);
+    });
+
+    it("directs the model toward references instead of long inline content", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      // Core UX principle: concise answer + references > essay inline.
+      expect(prompt).toMatch(/point.*user.*references|references.*detail|follow.up/i);
+    });
+
+    it("mentions comparative/summarize questions explicitly as NOT an exception", () => {
+      const prompt = assembleSystemPrompt(baseArgs);
+      // Long-form questions are where the model most often over-writes.
+      // Call that class out by name so the model can't hide behind
+      // "but this question requires depth".
+      expect(prompt).toMatch(/compar|summari/i);
     });
   });
 

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -34,6 +34,16 @@ export const MAX_TOOL_ROUNDS = 15;
 // Output contract knobs
 export const MAX_ANSWER_LINES = 15;
 export const RECENCY_WINDOW_DAYS = 30;
+// Target character budget for the agent's TEXT answer alone. Composed
+// messages also carry references + optional issue proposal body +
+// optional reply footer; all of that must fit under Slack's 40K hard
+// cap. Telling the model "~6000 chars for the answer" leaves comfortable
+// room for the other components. See `buildOutputContractSection`.
+export const ANSWER_BUDGET_CHARS = 6_000;
+// Target character budget for an issue proposal body when the agent
+// uses `create_issue`. A focused issue doesn't need 15K chars — title
+// + goal + acceptance criteria + the 1–2 key files is enough.
+export const ISSUE_PROPOSAL_BODY_BUDGET_CHARS = 5_000;
 
 // Hard cap on any single tool_result before it is appended to the agent's
 // messages array. Prevents broad research prompts (list_issues, list_prs,
@@ -331,6 +341,14 @@ Prefer a single result-focused reply after tool work completes. Don't pre-announ
 - Skip sections like "Development Maturity Indicators" or "Why This Is Impressive" — the user didn't ask for a pitch.
 - Be direct and technical — this is an engineering team.
 - If the user wants more detail, they'll ask a follow-up.
+
+*Slack message budget — hard limit:*
+- Slack caps a single message at **40,000 characters**. Your answer, plus the reference footer, plus (when applicable) an issue proposal body, are composed into ONE Slack message. If the total exceeds 40K, Slack rejects it and the user sees an error — not your answer.
+- Keep your answer text itself under **~${ANSWER_BUDGET_CHARS.toLocaleString()} characters** (≈150 lines). Comparative or "summarize our X" questions are NOT an exception — condense aggressively.
+- When you'd want to go long: DON'T. Summarize the 3–5 key points, then point the user at specific files/PRs/issues via references. They can ask a narrower follow-up for detail on any one of them.
+- DO NOT quote or paraphrase tool results verbatim. Don't inline whole files. Don't write an essay comparing two systems when a bulleted contrast list + references will do.
+- When using \`create_issue\`, keep the proposal body under **~${ISSUE_PROPOSAL_BODY_BUDGET_CHARS.toLocaleString()} characters**: title, clear goal, 3–6 acceptance-criteria bullets, and the 1–2 most relevant file paths. Don't paste context dumps.
+- Your goal is a clear answer a human can absorb in ~30 seconds, with references they can follow for anything deeper. Not an essay.
 
 *Recency (today is ${today}):*
 - Prefer the most recent activity first. When asked about "recent developments", "status", or "what's new", focus on the last ${RECENCY_WINDOW_DAYS} days.

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -37,13 +37,16 @@ export const RECENCY_WINDOW_DAYS = 30;
 // Target character budget for the agent's TEXT answer alone. Composed
 // messages also carry references + optional issue proposal body +
 // optional reply footer; all of that must fit under Slack's 40K hard
-// cap. Telling the model "~6000 chars for the answer" leaves comfortable
-// room for the other components. See `buildOutputContractSection`.
-export const ANSWER_BUDGET_CHARS = 6_000;
+// cap. Math: 20K answer + ~3K refs + ~8K proposal (worst case) + 100
+// footer = ~31K, comfortable under 40K. 20K gives the agent room for
+// structured answers on comparative / analytical questions without
+// encouraging novel-length essays (other prompt guidance — "15 lines
+// typical", "brevity" — steers the common case short).
+export const ANSWER_BUDGET_CHARS = 20_000;
 // Target character budget for an issue proposal body when the agent
-// uses `create_issue`. A focused issue doesn't need 15K chars — title
-// + goal + acceptance criteria + the 1–2 key files is enough.
-export const ISSUE_PROPOSAL_BODY_BUDGET_CHARS = 5_000;
+// uses `create_issue`. Title + goal + acceptance criteria + context +
+// 1-2 key files comfortably fit. Not a tight cap.
+export const ISSUE_PROPOSAL_BODY_BUDGET_CHARS = 8_000;
 
 // Hard cap on any single tool_result before it is appended to the agent's
 // messages array. Prevents broad research prompts (list_issues, list_prs,
@@ -489,6 +492,18 @@ export interface ConversationTurn {
   content: string;
 }
 
+/**
+ * Progress callback invoked once per tool_use block, before the tool
+ * executes. The route passes a throttled Slack updater that renders
+ * "🔍 Searching for X…" / "📖 Reading foo.ts…" style status messages.
+ * Fire-and-forget at the callsite; errors are swallowed inside the
+ * dispatcher so a flaky UX hook can't break agent execution.
+ */
+export type ProgressCallback = (
+  toolName: string,
+  input: Record<string, unknown>,
+) => void | Promise<void>;
+
 // Non-streaming Anthropic call. Previously used `messages.stream` +
 // `finalMessage()` to enable live text-delta forwarding to Slack. With
 // the API-minimization refactor (#108) we no longer stream text to
@@ -511,6 +526,7 @@ export async function runAgent(
   conversationHistory?: ConversationTurn[],
   rlog?: LogFn,
   participants?: Participant[],
+  onProgress?: ProgressCallback,
 ): Promise<AgentResult> {
   // Use request-scoped logger if provided, fall back to bare log. Typed
   // as LogFn because runAgent itself only calls the logger (the route
@@ -689,7 +705,7 @@ export async function runAgent(
     // with no cost impact. See #77.
     const parallelOutcome = await executeToolsInParallel(
       toolUseBlocks.filter((b): b is Anthropic.ToolUseBlock => b.type === "tool_use"),
-      { round, log: _log },
+      { round, log: _log, onProgress },
     );
     const toolResults: Anthropic.ToolResultBlockParam[] = parallelOutcome.toolResults;
     allReferences.push(...parallelOutcome.references);
@@ -761,6 +777,12 @@ export async function runAgent(
 export interface ParallelToolsContext {
   round: number;
   log: LogFn;
+  /**
+   * UX hook fired once per tool_use block (fire-and-forget, errors
+   * swallowed). The route uses this to push debounced progress
+   * messages into the thinking message. See #110.
+   */
+  onProgress?: ProgressCallback;
   executor?: (name: string, input: Record<string, unknown>) => Promise<ToolResult>;
 }
 
@@ -778,9 +800,9 @@ export async function executeToolsInParallel(
 
   // Fire all tools concurrently. Each task emits its agent_tool_call log
   // synchronously at the top (so the full set of intended calls is
-  // visible in Sentry before any tool finishes), then awaits its
-  // executor. With the API-minimization refactor (#108) there's no UI
-  // progress callback to coordinate with; Sentry is the sole observer.
+  // visible in Sentry before any tool finishes), invokes the UX progress
+  // hook if present (fire-and-forget — a flaky updater cannot serialize
+  // tool dispatch), then awaits its executor.
   const outcomes = await Promise.all(
     blocks.map(async (block) => {
       ctx.log("agent_tool_call", {
@@ -788,6 +810,13 @@ export async function executeToolsInParallel(
         round: ctx.round,
         input: JSON.stringify(block.input).slice(0, 200),
       });
+      if (ctx.onProgress) {
+        Promise.resolve()
+          .then(() => ctx.onProgress!(block.name, block.input as Record<string, unknown>))
+          .catch(() => {
+            // Progress is UX-only; swallow to protect the agent loop.
+          });
+      }
       try {
         const result = await exec(block.name, block.input as Record<string, unknown>);
         return { block, result, error: null as string | null };

--- a/src/lib/progress.test.ts
+++ b/src/lib/progress.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { formatProgressMessage, buildThinkingMessage, THINKING_HEADER } from "./progress";
+
+describe("formatProgressMessage", () => {
+  it("formats initial thinking step", () => {
+    const msg = formatProgressMessage("thinking", {});
+    expect(msg).toContain("🧠");
+    expect(msg).toMatch(/_.*thinking/i);
+  });
+
+  it("formats index check step", () => {
+    const msg = formatProgressMessage("index", {});
+    expect(msg).toContain("🗂️");
+    expect(msg).toMatch(/_.*index/i);
+  });
+
+  it("formats search_code with query", () => {
+    const msg = formatProgressMessage("search_code", { query: "authentication middleware" });
+    expect(msg).toContain("🔍");
+    expect(msg).toContain("authentication middleware");
+  });
+
+  it("formats read_file with path", () => {
+    const msg = formatProgressMessage("read_file", { path: "app/Services/Auth/LoginService.php" });
+    expect(msg).toContain("👓");
+    expect(msg).toContain("app/Services/Auth/LoginService.php");
+  });
+
+  it("formats list_issues", () => {
+    const msg = formatProgressMessage("list_issues", {});
+    expect(msg).toContain("🎫");
+  });
+
+  it("formats save_knowledge", () => {
+    const msg = formatProgressMessage("save_knowledge", {});
+    expect(msg).toContain("💾");
+  });
+
+  it("formats create_issue", () => {
+    const msg = formatProgressMessage("create_issue", {});
+    expect(msg).toContain("📝");
+  });
+
+  it("formats composing step", () => {
+    const msg = formatProgressMessage("composing", {});
+    expect(msg).toContain("✏️");
+    expect(msg).toMatch(/_.*composing/i);
+  });
+
+  it("all messages are italic (wrapped in underscores)", () => {
+    const steps = ["thinking", "index", "search_code", "read_file", "composing"];
+    for (const step of steps) {
+      const msg = formatProgressMessage(step, {});
+      // Slack italics: starts with _ and ends with _
+      expect(msg).toMatch(/^.+_.*_$/);
+    }
+  });
+
+  it("handles unknown tool name gracefully", () => {
+    const msg = formatProgressMessage("unknown_tool", {});
+    expect(msg).toContain("🧠");
+    expect(msg).toMatch(/_/); // still italic
+  });
+
+  it("truncates long file paths", () => {
+    const msg = formatProgressMessage("read_file", {
+      path: "very/deeply/nested/directory/structure/that/goes/on/forever/file.php",
+    });
+    expect(msg.length).toBeLessThan(120);
+  });
+});
+
+describe("buildThinkingMessage", () => {
+  it("includes the fixed header on every message", () => {
+    const msg = buildThinkingMessage("search_code", { query: "auth" });
+    expect(msg).toContain(THINKING_HEADER);
+  });
+
+  it("includes the status line below the header", () => {
+    const msg = buildThinkingMessage("search_code", { query: "auth" });
+    const lines = msg.split("\n");
+    expect(lines[0]).toBe(THINKING_HEADER);
+    expect(lines[1]).toContain("🔍");
+    expect(lines[1]).toContain("auth");
+  });
+
+  it("header stays the same regardless of tool", () => {
+    const msg1 = buildThinkingMessage("search_code", { query: "x" });
+    const msg2 = buildThinkingMessage("read_file", { path: "y" });
+    const header1 = msg1.split("\n")[0];
+    const header2 = msg2.split("\n")[0];
+    expect(header1).toBe(header2);
+  });
+});

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -1,0 +1,58 @@
+/**
+ * Progress Message Formatter — maps tool calls to user-friendly status messages.
+ * All status lines use italic text (Slack _underscores_) to visually distinguish
+ * from the actual answer.
+ */
+
+const MAX_PATH_LENGTH = 60;
+
+function truncatePath(path: string): string {
+  if (path.length <= MAX_PATH_LENGTH) return path;
+  return "..." + path.slice(-(MAX_PATH_LENGTH - 3));
+}
+
+type ToolInput = Record<string, unknown>;
+
+const HEADER = "🧠 Battle Mage is working... _(this may take a minute, go grab some tea)_";
+
+const TOOL_FORMATS: Record<string, (input: ToolInput) => string> = {
+  thinking: () => "🧠 _Thinking about your question..._",
+  index: () => "🗂️ _Checking repo index..._",
+  search_code: (input) => {
+    const query = (input.query as string) || "code";
+    return `🔍 _Searching for "${query}"..._`;
+  },
+  read_file: (input) => {
+    const path = truncatePath((input.path as string) || "file");
+    return `👓 _Reading ${path}..._`;
+  },
+  list_issues: () => "🎫 _Looking up issues..._",
+  list_commits: () => "📜 _Checking recent commits..._",
+  list_prs: () => "🔀 _Checking recent PRs..._",
+  create_issue: () => "📝 _Drafting issue proposal..._",
+  save_knowledge: () => "💾 _Saving to knowledge base..._",
+  composing: () => "✏️ _Composing answer..._",
+};
+
+export function formatProgressMessage(
+  toolName: string,
+  input: ToolInput,
+): string {
+  const formatter = TOOL_FORMATS[toolName];
+  if (formatter) return formatter(input);
+  return `🧠 _Working on it..._`;
+}
+
+/**
+ * Build the full thinking message: fixed header + current status line.
+ * The header stays constant, only the status line changes on each update.
+ */
+export function buildThinkingMessage(
+  toolName: string,
+  input: ToolInput,
+): string {
+  const status = formatProgressMessage(toolName, input);
+  return `${HEADER}\n${status}`;
+}
+
+export { HEADER as THINKING_HEADER };

--- a/src/lib/slack-throttle.test.ts
+++ b/src/lib/slack-throttle.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createThrottledUpdater } from "./slack-throttle";
+
+describe("createThrottledUpdater", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires the first update immediately", async () => {
+    const fn = vi.fn(async (_text: string) => {});
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    throttle.update("first");
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fn).toHaveBeenCalledOnce();
+    expect(fn).toHaveBeenCalledWith("first");
+  });
+
+  it("coalesces rapid updates within the min interval into one deferred call with the latest text", async () => {
+    const fn = vi.fn(async (_text: string) => {});
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    throttle.update("a"); // immediate
+    await vi.advanceTimersByTimeAsync(0);
+    throttle.update("b"); // deferred
+    throttle.update("c"); // deferred, replaces b
+    throttle.update("d"); // deferred, replaces c
+
+    // Before the interval elapses, still only 1 call
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // After interval: the deferred flush fires with the LATEST text
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(2, "d");
+  });
+
+  it("fires immediately if enough time has elapsed since the last flush", async () => {
+    const fn = vi.fn(async (_text: string) => {});
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    throttle.update("a");
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1500); // well past interval
+    throttle.update("b");
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(2, "b");
+  });
+
+  it("flush() forces the pending update immediately and clears the timer", async () => {
+    const fn = vi.fn(async (_text: string) => {});
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    throttle.update("first"); // fires immediately
+    await vi.advanceTimersByTimeAsync(0);
+    throttle.update("second"); // deferred
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await throttle.flush();
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(2, "second");
+
+    // After flush, a later update that's within the interval still defers correctly
+    throttle.update("third");
+    expect(fn).toHaveBeenCalledTimes(2); // not yet
+  });
+
+  it("flush() is a no-op when nothing is pending", async () => {
+    const fn = vi.fn(async (_text: string) => {});
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    await throttle.flush();
+    expect(fn).not.toHaveBeenCalled();
+
+    throttle.update("x");
+    await vi.advanceTimersByTimeAsync(0);
+    await throttle.flush();
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it("swallows errors from the update function without breaking throttling", async () => {
+    const fn = vi.fn(async (_text: string) => {
+      throw new Error("slack rate limit");
+    });
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    throttle.update("boom");
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Subsequent update should still be accepted
+    await vi.advanceTimersByTimeAsync(1500);
+    throttle.update("after");
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("serializes fn() — never runs concurrently even when fn is slower than the interval", async () => {
+    let inflight = 0;
+    let maxInflight = 0;
+    const fn = vi.fn(async (_text: string) => {
+      inflight++;
+      maxInflight = Math.max(maxInflight, inflight);
+      await new Promise((r) => setTimeout(r, 2000)); // slow fn
+      inflight--;
+    });
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    // t=0: fires immediately, fn("a") starts a 2000ms call
+    throttle.update("a");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(inflight).toBe(1);
+
+    // t=1500: interval has elapsed but "a" is still in flight — must NOT start "b"
+    await vi.advanceTimersByTimeAsync(1500);
+    throttle.update("b");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(
+      maxInflight,
+      "second fn() call started before first finished — concurrent writes",
+    ).toBe(1);
+
+    // Let "a" finish; "b" may then start (serialized)
+    await vi.advanceTimersByTimeAsync(2500);
+    expect(maxInflight).toBe(1);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("flush() awaits an in-flight fn() before returning", async () => {
+    let completed = false;
+    const fn = vi.fn(async (_text: string) => {
+      await new Promise((r) => setTimeout(r, 2000));
+      completed = true;
+    });
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    throttle.update("x");
+    await vi.advanceTimersByTimeAsync(0); // fn starts
+    expect(completed).toBe(false);
+
+    const flushDone = vi.fn();
+    const flushPromise = throttle.flush().then(flushDone);
+
+    // Before fn finishes: flush should NOT have resolved
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(completed).toBe(false);
+    expect(flushDone).not.toHaveBeenCalled();
+
+    // Let fn finish
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushPromise;
+    expect(completed).toBe(true);
+    expect(flushDone).toHaveBeenCalled();
+  });
+
+  it("cancel() drops pending text and clears the timer — no further fn() calls", async () => {
+    const fn = vi.fn(async (_text: string) => {});
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    // First update fires immediately
+    throttle.update("first");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Queue a deferred update, then cancel — the timer must not fire
+    throttle.update("pending");
+    await throttle.cancel();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fn).toHaveBeenCalledTimes(1); // still just "first"
+
+    // After cancel, update() still works for fresh calls
+    throttle.update("after-cancel");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(2, "after-cancel");
+  });
+
+  it("cancel() awaits an in-flight fn() — no stale writes can land after it resolves", async () => {
+    // Scenario: a slow streaming edit is still running when onProgress fires
+    // and calls cancel() before writing an emoji update. cancel() must block
+    // until the streamed write is done, otherwise the emoji could be
+    // overwritten by the delayed Slack response.
+    let completed = false;
+    const fn = vi.fn(async (_text: string) => {
+      await new Promise((r) => setTimeout(r, 2000));
+      completed = true;
+    });
+    const throttle = createThrottledUpdater(fn, 1000);
+
+    throttle.update("streamed"); // starts fn, takes 2000ms
+    await vi.advanceTimersByTimeAsync(0);
+    expect(completed).toBe(false);
+
+    // cancel() must NOT resolve before fn completes
+    const cancelDone = vi.fn();
+    const cancelPromise = throttle.cancel().then(cancelDone);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(completed).toBe(false);
+    expect(cancelDone).not.toHaveBeenCalled();
+
+    // Let fn finish
+    await vi.advanceTimersByTimeAsync(1000);
+    await cancelPromise;
+    expect(completed).toBe(true);
+    expect(cancelDone).toHaveBeenCalled();
+  });
+});

--- a/src/lib/slack-throttle.ts
+++ b/src/lib/slack-throttle.ts
@@ -1,0 +1,111 @@
+export interface ThrottledUpdater {
+  update(text: string): void;
+  flush(): Promise<void>;
+  cancel(): Promise<void>;
+}
+
+// Coalesces rapid update() calls into at most one flush per minIntervalMs,
+// and serializes flushes so fn() never runs concurrently — important when
+// fn is an async Slack chat.update that can exceed the interval under rate
+// limiting.
+//
+// - First update fires immediately (if not busy).
+// - Subsequent updates within the interval collapse to the LATEST text.
+// - If fn takes longer than the interval, further updates wait for it;
+//   the next fn() call is scheduled onto the in-flight chain.
+// - flush() awaits any in-flight fn() AND any pending text, returning only
+//   when Slack has observed the final state.
+// - cancel() drops pending text and clears the timer without firing —
+//   used by the route when emoji progress takes over from streamed text.
+export function createThrottledUpdater(
+  fn: (text: string) => Promise<void>,
+  minIntervalMs: number,
+  now: () => number = Date.now,
+): ThrottledUpdater {
+  let lastFlushAt = -Infinity;
+  let pendingText: string | null = null;
+  let inFlight: Promise<void> = Promise.resolve();
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let busy = false;
+
+  function fireNow(): void {
+    if (pendingText === null || busy) return;
+    const text = pendingText;
+    pendingText = null;
+    busy = true;
+    inFlight = (async () => {
+      try {
+        await fn(text);
+      } catch {
+        // Swallow — transient Slack errors (rate limit, deleted message)
+        // must not break the agent loop.
+      }
+      busy = false;
+      lastFlushAt = now();
+      // A later update() may have arrived while fn() was running;
+      // re-check schedule so it gets picked up.
+      maybeSchedule();
+    })();
+  }
+
+  function maybeSchedule(): void {
+    if (pendingText === null || busy || timer) return;
+    const elapsed = now() - lastFlushAt;
+    if (elapsed >= minIntervalMs) {
+      fireNow();
+      return;
+    }
+    const delay = Math.max(0, minIntervalMs - elapsed);
+    timer = setTimeout(() => {
+      timer = null;
+      fireNow();
+    }, delay);
+  }
+
+  return {
+    update(text: string): void {
+      pendingText = text;
+      maybeSchedule();
+    },
+    async flush(): Promise<void> {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      // Drain any currently running fn() call first.
+      await inFlight.catch(() => {});
+      // If the above finalizer scheduled another fireNow, drain that too.
+      while (busy || pendingText !== null) {
+        if (pendingText !== null && !busy) {
+          const text = pendingText;
+          pendingText = null;
+          busy = true;
+          try {
+            await fn(text);
+          } catch {
+            // swallow
+          }
+          busy = false;
+          lastFlushAt = now();
+        } else if (busy) {
+          await inFlight.catch(() => {});
+        }
+      }
+    },
+    async cancel(): Promise<void> {
+      // Drop the deferred timer and any pending text immediately.
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      pendingText = null;
+      // If a fn() call is already running, await it so the caller can be
+      // sure no throttled Slack write will land after cancel() resolves —
+      // important for the route to avoid stale streamed text overwriting
+      // a fresh emoji progress update on the same message.
+      if (busy) {
+        await inFlight.catch(() => {});
+      }
+    },
+  };
+}

--- a/src/lib/slack.test.ts
+++ b/src/lib/slack.test.ts
@@ -17,9 +17,10 @@ describe("capSlackMessage", () => {
     const result = capSlackMessage(text);
     // Final length must fit under the hard cap.
     expect(result.length).toBeLessThanOrEqual(SLACK_MESSAGE_HARD_CAP);
-    // Must carry a truncation note so the user knows they got a partial.
-    expect(result).toMatch(/truncated/);
+    // Must carry a user-facing note so they know to ask a narrower follow-up.
+    expect(result).toMatch(/cut off|truncated/i);
     expect(result).toContain("Slack");
+    expect(result).toMatch(/follow.up|narrower/i);
   });
 
   it("preserves the start of the content (truncates from the end)", () => {
@@ -35,7 +36,7 @@ describe("capSlackMessage", () => {
     const text = "a".repeat(SLACK_MESSAGE_HARD_CAP + 1);
     const result = capSlackMessage(text);
     expect(result.length).toBeLessThanOrEqual(SLACK_MESSAGE_HARD_CAP);
-    expect(result).toMatch(/truncated/);
+    expect(result).toMatch(/cut off|truncated/i);
   });
 
   it("handles very-oversized messages without allocating uncontrollably", () => {

--- a/src/lib/slack.test.ts
+++ b/src/lib/slack.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { capSlackMessage, SLACK_MESSAGE_HARD_CAP } from "./slack";
+
+describe("capSlackMessage", () => {
+  it("passes through messages under the cap unchanged", () => {
+    const text = "hello world";
+    expect(capSlackMessage(text)).toBe(text);
+  });
+
+  it("passes through messages exactly at the cap unchanged", () => {
+    const text = "a".repeat(SLACK_MESSAGE_HARD_CAP);
+    expect(capSlackMessage(text)).toBe(text);
+  });
+
+  it("truncates and appends a note when over the cap", () => {
+    const text = "a".repeat(SLACK_MESSAGE_HARD_CAP + 5_000);
+    const result = capSlackMessage(text);
+    // Final length must fit under the hard cap.
+    expect(result.length).toBeLessThanOrEqual(SLACK_MESSAGE_HARD_CAP);
+    // Must carry a truncation note so the user knows they got a partial.
+    expect(result).toMatch(/truncated/);
+    expect(result).toContain("Slack");
+  });
+
+  it("preserves the start of the content (truncates from the end)", () => {
+    const head = "IMPORTANT: The agent's analysis begins here.\n\n";
+    const filler = "x".repeat(SLACK_MESSAGE_HARD_CAP + 5_000);
+    const text = head + filler;
+
+    const result = capSlackMessage(text);
+    expect(result.startsWith(head)).toBe(true);
+  });
+
+  it("handles messages only slightly over the cap", () => {
+    const text = "a".repeat(SLACK_MESSAGE_HARD_CAP + 1);
+    const result = capSlackMessage(text);
+    expect(result.length).toBeLessThanOrEqual(SLACK_MESSAGE_HARD_CAP);
+    expect(result).toMatch(/truncated/);
+  });
+
+  it("handles very-oversized messages without allocating uncontrollably", () => {
+    // 1 MB body — bigger than anything the agent could realistically produce,
+    // but if it happens we must still return a sane capped result, not hang.
+    const text = "x".repeat(1_000_000);
+    const result = capSlackMessage(text);
+    expect(result.length).toBeLessThanOrEqual(SLACK_MESSAGE_HARD_CAP);
+  });
+
+  it("SLACK_MESSAGE_HARD_CAP leaves headroom under Slack's 40k limit", () => {
+    // Slack's documented limit for `text` on chat.postMessage / chat.update
+    // is 40_000. We stay under with margin so the truncation note itself
+    // can't push us over.
+    expect(SLACK_MESSAGE_HARD_CAP).toBeLessThan(40_000);
+    expect(SLACK_MESSAGE_HARD_CAP).toBeGreaterThan(35_000);
+  });
+});

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -42,23 +42,29 @@ export function verifySlackSignature(
   return crypto.timingSafeEqual(expectedBuf, signatureBuf);
 }
 
-// ── Slack message length guard ────────────────────────────────────────
+// ── Slack message length guard (safety net) ──────────────────────────
 // Slack's `chat.postMessage` / `chat.update` cap `text` at 40,000 chars.
 // Exceeding this throws `An API error occurred: msg_too_long` — the
 // error that haunted us through #100, mis-attributed to Anthropic's
-// context-window limit. Actual root cause: Slack's message cap. We leave
-// ~500 chars of headroom under the hard limit so the truncation note
-// itself can't push us over.
+// context-window limit.
+//
+// PRIMARY fix for oversized replies lives in the prompt (see
+// `buildOutputContractSection` — ANSWER_BUDGET_CHARS etc.): we tell the
+// model about the 40K ceiling and give it a conservative answer budget.
+// This function is a last-line-of-defense safety net for the rare case
+// where the model ignores the budget. When it fires, that's a signal
+// the prompt guidance needs tuning for that class of question — not a
+// routine outcome the user should expect to see.
 export const SLACK_MESSAGE_HARD_CAP = 39_500;
 
 const TRUNCATION_NOTE =
-  "\n\n_…(response truncated — exceeded Slack's 40K-character message limit. Ask a narrower follow-up for full detail.)_";
+  "\n\n_…(answer cut off to fit Slack's 40K-character message limit — ask a narrower follow-up for detail on any specific area.)_";
 
 /**
  * Cap a message body at Slack's max length. Passes short messages
- * through unchanged; for oversized messages, takes the first N chars
- * (leaving room for the note) and appends a truncation note so the
- * user knows they got a partial response. Pure function; no I/O.
+ * through unchanged; for the rare oversized case, takes the first N
+ * chars (leaving room for the note) and appends a short explanation
+ * so the user knows to ask a narrower follow-up. Pure function; no I/O.
  */
 export function capSlackMessage(text: string): string {
   if (text.length <= SLACK_MESSAGE_HARD_CAP) return text;

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -42,6 +42,30 @@ export function verifySlackSignature(
   return crypto.timingSafeEqual(expectedBuf, signatureBuf);
 }
 
+// ── Slack message length guard ────────────────────────────────────────
+// Slack's `chat.postMessage` / `chat.update` cap `text` at 40,000 chars.
+// Exceeding this throws `An API error occurred: msg_too_long` — the
+// error that haunted us through #100, mis-attributed to Anthropic's
+// context-window limit. Actual root cause: Slack's message cap. We leave
+// ~500 chars of headroom under the hard limit so the truncation note
+// itself can't push us over.
+export const SLACK_MESSAGE_HARD_CAP = 39_500;
+
+const TRUNCATION_NOTE =
+  "\n\n_…(response truncated — exceeded Slack's 40K-character message limit. Ask a narrower follow-up for full detail.)_";
+
+/**
+ * Cap a message body at Slack's max length. Passes short messages
+ * through unchanged; for oversized messages, takes the first N chars
+ * (leaving room for the note) and appends a truncation note so the
+ * user knows they got a partial response. Pure function; no I/O.
+ */
+export function capSlackMessage(text: string): string {
+  if (text.length <= SLACK_MESSAGE_HARD_CAP) return text;
+  const budget = SLACK_MESSAGE_HARD_CAP - TRUNCATION_NOTE.length;
+  return text.slice(0, budget) + TRUNCATION_NOTE;
+}
+
 // ── Thread reply helper ───────────────────────────────────────────────
 export async function replyInThread(
   channel: string,
@@ -51,7 +75,7 @@ export async function replyInThread(
   const result = await slack.chat.postMessage({
     channel,
     thread_ts: threadTs,
-    text,
+    text: capSlackMessage(text),
   });
   return result.ts; // message timestamp — used to track Q&A context for feedback
 }
@@ -62,7 +86,7 @@ export async function updateMessage(
   ts: string,
   text: string,
 ): Promise<void> {
-  await slack.chat.update({ channel, ts, text });
+  await slack.chat.update({ channel, ts, text: capSlackMessage(text) });
 }
 
 // ── Delete a message ──────────────────────────────────────────────────


### PR DESCRIPTION
## Correction of a mis-diagnosis

Through #100, #103, #106, #108, and #109, I attributed the \`"An API error occurred: msg_too_long"\` error to **Anthropic's 200K token context-window limit**. That was wrong. Re-reading the stack trace on the 3rd occurrence (against #109's deployment, commit \`ce06ef9\`):

\`\`\`
app:///_next/server/app/api/slack/route.js:4:150715 (H.apiCall)
app:///_next/server/app/api/slack/route.js:2:354992 (b.platformErrorFromResult)
\`\`\`

\`H.apiCall\` + \`platformErrorFromResult\` are **\`@slack/web-api\` WebClient internals**. The Slack SDK throws errors formatted as \`"An API error occurred: <error_code>"\`. Slack has its own \`msg_too_long\` error code for messages that exceed **40,000 characters** on \`chat.postMessage\` / \`chat.update\` — a completely different beast from Anthropic's token ceiling.

**Corroborating evidence:**
- \`agent_complete\` fires successfully before every occurrence (latest: \`input_tokens: 30_280\` — nowhere near Anthropic's 200K).
- Error lands ~48ms AFTER \`agent_complete\`, during the route's \`updateMessage\` call on the final body.
- Top frame of the stack is \`route.js:198\` — the issue-proposal body assembly block. On a verbose comparative question, \`text + divider + proposal title + labels + proposal body + confirmation prompt + refs + replyFooter\` easily crosses 40K chars.

The catalog-cap + streaming-removal in #109 addressed real API fan-out problems, but it didn't touch the actual root cause — hence the same error after that PR.

## Fix

- **\`SLACK_MESSAGE_HARD_CAP = 39_500\`** (500-char margin under Slack's 40K).
- **\`capSlackMessage(text)\`** pure utility: truncates at the cap, appends a *\"response truncated — Slack limit; ask a narrower follow-up\"* note so the user knows they got a partial.
- **Applied at the slack.ts layer** — inside both \`replyInThread\` and \`updateMessage\`, so every caller is protected by default. No way for a route-level assembly accident to slip a >40K body past the guard.

## Test plan

- [x] 7 new unit tests in \`slack.test.ts\` (under-cap, at-cap, over-cap truncation, head preservation, slightly-over edge, 1 MB defensive case, cap bounds sanity).
- [x] 355/355 total pass. Typecheck clean.
- [ ] Post-merge: same comparative SCC question that triggered BATTLE-MAGE-2 should now succeed. If the agent produces a >40K response, the user sees it truncated with a note instead of \`"Something went wrong"\`.

## Lessons

1. Read the full stack trace, not just the error message. \`H.apiCall\` / \`platformErrorFromResult\` was the clue all along.
2. Error message shape (\`"An API error occurred: ..."\`) can look identical between SDKs. Never assume the SDK from the string alone.
3. The other work from this investigation still has value: \`Sentry.captureException\` in the route catch (#103) is exactly what finally gave us the stack trace; the API-minimization refactor in #108/#109 addressed real trace-visible fan-out anti-patterns. None of it was wasted — but none of it fixed this bug.

Closes #100. Refs #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)