### PR TITLE
fix: Slack cap must be byte-based, not char-based (msg_too_long, #100)

### DIFF
--- a/src/lib/slack.test.ts
+++ b/src/lib/slack.test.ts
@@ -1,57 +1,94 @@
 import { describe, it, expect } from "vitest";
-import { capSlackMessage, SLACK_MESSAGE_HARD_CAP } from "./slack";
+import { capSlackMessage, SLACK_MESSAGE_BYTE_CAP } from "./slack";
 
-describe("capSlackMessage", () => {
-  it("passes through messages under the cap unchanged", () => {
+// Helper — UTF-8 byte length of a string.
+function bytes(s: string): number {
+  return new TextEncoder().encode(s).length;
+}
+
+describe("capSlackMessage (byte-based)", () => {
+  it("passes through short ASCII messages unchanged", () => {
     const text = "hello world";
     expect(capSlackMessage(text)).toBe(text);
   });
 
-  it("passes through messages exactly at the cap unchanged", () => {
-    const text = "a".repeat(SLACK_MESSAGE_HARD_CAP);
+  it("passes through messages exactly at the byte cap unchanged", () => {
+    const text = "a".repeat(SLACK_MESSAGE_BYTE_CAP);
+    expect(bytes(text)).toBe(SLACK_MESSAGE_BYTE_CAP);
     expect(capSlackMessage(text)).toBe(text);
   });
 
-  it("truncates and appends a note when over the cap", () => {
-    const text = "a".repeat(SLACK_MESSAGE_HARD_CAP + 5_000);
+  it("truncates when over the byte cap and appends a user-facing note", () => {
+    const text = "a".repeat(SLACK_MESSAGE_BYTE_CAP + 5_000);
     const result = capSlackMessage(text);
-    // Final length must fit under the hard cap.
-    expect(result.length).toBeLessThanOrEqual(SLACK_MESSAGE_HARD_CAP);
-    // Must carry a user-facing note so they know to ask a narrower follow-up.
+    expect(bytes(result)).toBeLessThanOrEqual(SLACK_MESSAGE_BYTE_CAP);
     expect(result).toMatch(/cut off|truncated/i);
     expect(result).toContain("Slack");
     expect(result).toMatch(/follow.up|narrower/i);
   });
 
+  it("enforces byte budget on unicode-heavy content (the real-world bug)", () => {
+    // An em-dash `—` is 3 bytes in UTF-8. 20_000 em-dashes = 60_000 bytes
+    // but only 20_000 JavaScript chars — the failure mode that the old
+    // char-based cap missed (#110 post-merge reproduction). The byte cap
+    // must enforce byte count.
+    const text = "—".repeat(20_000);
+    expect(bytes(text)).toBe(60_000);
+    expect(text.length).toBe(20_000);
+
+    const result = capSlackMessage(text);
+    expect(bytes(result)).toBeLessThanOrEqual(SLACK_MESSAGE_BYTE_CAP);
+    expect(result).toMatch(/cut off|truncated/i);
+  });
+
   it("preserves the start of the content (truncates from the end)", () => {
-    const head = "IMPORTANT: The agent's analysis begins here.\n\n";
-    const filler = "x".repeat(SLACK_MESSAGE_HARD_CAP + 5_000);
+    const head = "IMPORTANT: the agent's analysis begins here.\n\n";
+    const filler = "x".repeat(SLACK_MESSAGE_BYTE_CAP + 5_000);
     const text = head + filler;
 
     const result = capSlackMessage(text);
     expect(result.startsWith(head)).toBe(true);
   });
 
-  it("handles messages only slightly over the cap", () => {
-    const text = "a".repeat(SLACK_MESSAGE_HARD_CAP + 1);
+  it("handles emoji-heavy content (4 bytes per emoji) correctly", () => {
+    // 🧠 is U+1F9E0, encoded as 4 UTF-8 bytes. 10_000 of them = 40_000 bytes
+    // (over the 36K cap) but only 20_000 UTF-16 code units (JS length).
+    const text = "🧠".repeat(10_000);
+    expect(bytes(text)).toBe(40_000);
+
     const result = capSlackMessage(text);
-    expect(result.length).toBeLessThanOrEqual(SLACK_MESSAGE_HARD_CAP);
+    expect(bytes(result)).toBeLessThanOrEqual(SLACK_MESSAGE_BYTE_CAP);
     expect(result).toMatch(/cut off|truncated/i);
   });
 
-  it("handles very-oversized messages without allocating uncontrollably", () => {
-    // 1 MB body — bigger than anything the agent could realistically produce,
-    // but if it happens we must still return a sane capped result, not hang.
-    const text = "x".repeat(1_000_000);
+  it("never corrupts the output when the cut falls inside a multi-byte char", () => {
+    // Construct a string whose byte length right at the budget boundary
+    // falls mid-character. TextDecoder with fatal:false handles this by
+    // substituting U+FFFD for the partial sequence, so the result is
+    // always valid UTF-8 (no half-chars, no throw).
+    const prefix = "a".repeat(SLACK_MESSAGE_BYTE_CAP - 100);
+    // Append a run of 3-byte em-dashes whose middle falls past the cut.
+    const text = prefix + "—".repeat(200);
     const result = capSlackMessage(text);
-    expect(result.length).toBeLessThanOrEqual(SLACK_MESSAGE_HARD_CAP);
+
+    // Must be valid UTF-8; no partial sequence should survive.
+    // Re-encoding the result should not throw and should match expected bytes.
+    expect(() => new TextEncoder().encode(result)).not.toThrow();
+    expect(bytes(result)).toBeLessThanOrEqual(SLACK_MESSAGE_BYTE_CAP);
   });
 
-  it("SLACK_MESSAGE_HARD_CAP leaves headroom under Slack's 40k limit", () => {
-    // Slack's documented limit for `text` on chat.postMessage / chat.update
-    // is 40_000. We stay under with margin so the truncation note itself
-    // can't push us over.
-    expect(SLACK_MESSAGE_HARD_CAP).toBeLessThan(40_000);
-    expect(SLACK_MESSAGE_HARD_CAP).toBeGreaterThan(35_000);
+  it("handles messages only slightly over the cap", () => {
+    const text = "a".repeat(SLACK_MESSAGE_BYTE_CAP + 1);
+    const result = capSlackMessage(text);
+    expect(bytes(result)).toBeLessThanOrEqual(SLACK_MESSAGE_BYTE_CAP);
+    expect(result).toMatch(/cut off|truncated/i);
+  });
+
+  it("SLACK_MESSAGE_BYTE_CAP leaves headroom under Slack's 40k limit", () => {
+    // Slack's documented limit for `text` is 40_000; we stay well under so
+    // the JSON envelope (channel, thread_ts, token header, message
+    // metadata) has room and unicode expansion can't cross the cliff.
+    expect(SLACK_MESSAGE_BYTE_CAP).toBeLessThan(40_000);
+    expect(SLACK_MESSAGE_BYTE_CAP).toBeGreaterThan(25_000);
   });
 });

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -43,33 +43,61 @@ export function verifySlackSignature(
 }
 
 // ── Slack message length guard (safety net) ──────────────────────────
-// Slack's `chat.postMessage` / `chat.update` cap `text` at 40,000 chars.
-// Exceeding this throws `An API error occurred: msg_too_long` — the
-// error that haunted us through #100, mis-attributed to Anthropic's
-// context-window limit.
+// Slack's `chat.postMessage` / `chat.update` cap `text` at 40,000 —
+// measured in BYTES, not characters (the docs say "characters" but
+// empirical behavior on msg_too_long rejects aligns with byte count).
+// Unicode content blows this up fast: em-dash `—` = 3 bytes, emoji = 4,
+// divider `─` = 3. A 39K-char answer with moderate unicode density
+// easily crosses 42-45K BYTES, which Slack refuses.
 //
-// PRIMARY fix for oversized replies lives in the prompt (see
-// `buildOutputContractSection` — ANSWER_BUDGET_CHARS etc.): we tell the
-// model about the 40K ceiling and give it a conservative answer budget.
-// This function is a last-line-of-defense safety net for the rare case
-// where the model ignores the budget. When it fires, that's a signal
-// the prompt guidance needs tuning for that class of question — not a
-// routine outcome the user should expect to see.
-export const SLACK_MESSAGE_HARD_CAP = 39_500;
+// First shipped a char-based cap in #110 — still saw msg_too_long on
+// unicode-heavy answers. Moving to byte-based cap here. See #108.
+//
+// PRIMARY fix for oversized replies still lives in the prompt
+// (ANSWER_BUDGET_CHARS in claude.ts — 20K char target). This function
+// is a last-line-of-defense safety net; when it fires, that's a signal
+// the prompt guidance needs tuning for a class of question.
+export const SLACK_MESSAGE_BYTE_CAP = 36_000;
 
 const TRUNCATION_NOTE =
-  "\n\n_…(answer cut off to fit Slack's 40K-character message limit — ask a narrower follow-up for detail on any specific area.)_";
+  "\n\n_…(answer cut off to fit Slack's message size limit — ask a narrower follow-up for detail on any specific area.)_";
+
+const textEncoder = new TextEncoder();
+// `fatal: false` so a mid-multi-byte-char cut at the budget boundary is
+// gracefully replaced with U+FFFD rather than throwing. `ignoreBOM: true`
+// because Slack messages never need a BOM.
+const textDecoder = new TextDecoder("utf-8", { fatal: false, ignoreBOM: true });
 
 /**
- * Cap a message body at Slack's max length. Passes short messages
- * through unchanged; for the rare oversized case, takes the first N
- * chars (leaving room for the note) and appends a short explanation
- * so the user knows to ask a narrower follow-up. Pure function; no I/O.
+ * Cap a Slack message body at `SLACK_MESSAGE_BYTE_CAP` BYTES (UTF-8).
+ * Short messages pass through unchanged; oversized ones are sliced at
+ * a byte-aligned boundary with the partial multi-byte sequence at the
+ * cut handled by TextDecoder's replacement behavior, then the
+ * truncation note is appended. Result's byte length is guaranteed
+ * ≤ SLACK_MESSAGE_BYTE_CAP (the note's bytes are reserved in the
+ * initial budget).
+ *
+ * Pure function; no I/O.
  */
 export function capSlackMessage(text: string): string {
-  if (text.length <= SLACK_MESSAGE_HARD_CAP) return text;
-  const budget = SLACK_MESSAGE_HARD_CAP - TRUNCATION_NOTE.length;
-  return text.slice(0, budget) + TRUNCATION_NOTE;
+  const textBytes = textEncoder.encode(text);
+  if (textBytes.length <= SLACK_MESSAGE_BYTE_CAP) return text;
+
+  const noteBytes = textEncoder.encode(TRUNCATION_NOTE).length;
+  // When the slice lands inside a multi-byte char, TextDecoder substitutes
+  // U+FFFD (3 UTF-8 bytes) for the partial sequence. That can make the
+  // re-encoded result 2–3 bytes larger than the byte slice itself, so we
+  // pre-reserve 3 bytes for that overhead.
+  const REPLACEMENT_OVERHEAD = 3;
+  const budget = SLACK_MESSAGE_BYTE_CAP - noteBytes - REPLACEMENT_OVERHEAD;
+  let head = textDecoder.decode(textBytes.slice(0, budget));
+  // Defensive trim: in case a pathological input still spills past the cap
+  // (e.g. grapheme clusters across multiple code points), shave chars until
+  // we fit. Finite loop bounded by head.length.
+  while (textEncoder.encode(head + TRUNCATION_NOTE).length > SLACK_MESSAGE_BYTE_CAP) {
+    head = head.slice(0, -1);
+  }
+  return head + TRUNCATION_NOTE;
 }
 
 // ── Thread reply helper ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Post-merge of #110 we still hit \`msg_too_long\` on a comparative query. Root cause: Slack's 40K limit on \`chat.postMessage\`/\`chat.update\` is measured in **bytes**, not characters. The docs say "characters" but empirical rejections align with byte count. Unicode content (em-dashes, box-drawing chars, emoji) blows the budget fast:

- em-dash \`—\` → 3 bytes
- emoji 🧠 → 4 bytes

A 39,500-char reply with moderate unicode density easily crosses 42–45K **bytes** → Slack rejects.

## What changed

- \`capSlackMessage\` is now byte-based via \`TextEncoder\`/\`TextDecoder\`
- Slice at byte boundary; \`TextDecoder(fatal:false)\` substitutes U+FFFD for partial multi-byte sequences (no throws, no half-chars)
- Reserve 3 bytes for replacement-char overhead + defensive trim loop
- Renamed \`SLACK_MESSAGE_HARD_CAP\` → \`SLACK_MESSAGE_BYTE_CAP\`, lowered 39,500 → **36,000** for JSON envelope headroom
- Softened truncation note ("40K-character" → "message size")

## Context

This is a safety net. The **primary fix** for oversized replies remains \`ANSWER_BUDGET_CHARS = 20_000\` in the prompt (shipped in #110). When this cap fires, treat it as a signal to tune the prompt for that class of question.

## Test plan

- [x] 9 new byte-based tests in \`slack.test.ts\` — unicode-heavy (20K em-dashes = 60K bytes), emoji-heavy (10K × 🧠 = 40K bytes), mid-multi-byte-cut, slightly-over-cap, head-preservation
- [x] Full suite: 386/386 passing
- [x] \`tsc --noEmit\` clean
- [ ] Post-merge: re-run the SCC comparative query that reproduced \`msg_too_long\`

Refs #100, #108. Follow-up to #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)