### PR TITLE
fix: Split long Slack replies instead of truncating (msg_too_long root fix)

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -9,6 +9,7 @@ import {
   fetchThreadMessages,
   updateMessage,
   deleteMessage,
+  postReplyInChunks,
 } from "@/lib/slack";
 import { runAgent } from "@/lib/claude";
 import { createIssue } from "@/lib/github";
@@ -187,29 +188,30 @@ export async function POST(request: NextRequest) {
             "React with :white_check_mark: to create this issue, or ignore to cancel.",
           ].join("\n") + refsFooter + replyFooter;
 
-          if (thinkingTs) {
-            // Reuse the thinking/streamed message as the final answer.
-            await updateMessage(channel, thinkingTs, finalBody);
-            thinkingTs = undefined; // Mark as finalized — prevent finally-cleanup.
-          } else {
-            await replyInThread(channel, threadTs, finalBody);
-          }
-          rlog("answer_posted", { channel, threadTs });
+          const posted = await postReplyInChunks({
+            channel,
+            threadTs,
+            thinkingTs,
+            text: finalBody,
+          });
+          // Only mark as finalized when we actually posted. A 0-chunk
+          // result (empty body) falls through to the finally cleanup.
+          if (posted.chunks > 0) thinkingTs = undefined;
+          rlog("answer_posted", { channel, threadTs, chunks: posted.chunks, kind: "proposal" });
         } else {
           const finalBody = text + refsFooter + replyFooter;
-          let replyTs: string | undefined;
-          if (thinkingTs) {
-            await updateMessage(channel, thinkingTs, finalBody);
-            replyTs = thinkingTs;
-            thinkingTs = undefined; // Mark as finalized.
-          } else {
-            replyTs = await replyInThread(channel, threadTs, finalBody);
-          }
-          rlog("answer_posted", { channel, threadTs });
+          const posted = await postReplyInChunks({
+            channel,
+            threadTs,
+            thinkingTs,
+            text: finalBody,
+          });
+          if (posted.chunks > 0) thinkingTs = undefined;
+          rlog("answer_posted", { channel, threadTs, chunks: posted.chunks });
 
           // Store Q&A context so 👍/👎 reactions can reference it
-          if (replyTs) {
-            await storeQAContext(channel, replyTs, {
+          if (posted.firstTs) {
+            await storeQAContext(channel, posted.firstTs, {
               question: cleanMessage,
               answer: result.text.slice(0, 500),
               references: result.references.map((r) => r.label),
@@ -374,25 +376,27 @@ export async function POST(request: NextRequest) {
             "React with :white_check_mark: to create this issue, or ignore to cancel.",
           ].join("\n") + refsFooter + replyFooter;
 
-          if (thinkTs) {
-            await updateMessage(channel, thinkTs, finalBody);
-            thinkTs = undefined;
-          } else {
-            await replyInThread(channel, threadTs, finalBody);
-          }
+          const posted = await postReplyInChunks({
+            channel,
+            threadTs,
+            thinkingTs: thinkTs,
+            text: finalBody,
+          });
+          if (posted.chunks > 0) thinkTs = undefined;
+          rlog("answer_posted", { channel, threadTs, chunks: posted.chunks, kind: "proposal" });
         } else {
           const finalBody = text + refsFooter + replyFooter;
-          let replyTs: string | undefined;
-          if (thinkTs) {
-            await updateMessage(channel, thinkTs, finalBody);
-            replyTs = thinkTs;
-            thinkTs = undefined;
-          } else {
-            replyTs = await replyInThread(channel, threadTs, finalBody);
-          }
+          const posted = await postReplyInChunks({
+            channel,
+            threadTs,
+            thinkingTs: thinkTs,
+            text: finalBody,
+          });
+          if (posted.chunks > 0) thinkTs = undefined;
+          rlog("answer_posted", { channel, threadTs, chunks: posted.chunks });
 
-          if (replyTs) {
-            await storeQAContext(channel, replyTs, {
+          if (posted.firstTs) {
+            await storeQAContext(channel, posted.firstTs, {
               question: cleanMessage,
               answer: result.text.slice(0, 500),
               references: result.references.map((r) => r.label),

--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -198,18 +198,16 @@ describe("assembleSystemPrompt", () => {
     });
   });
 
-  describe("Slack message budget (output contract, #110)", () => {
-    // Primary guard against msg_too_long is prompt-level: tell the model
-    // about Slack's 40K-char ceiling and give it a conservative answer
-    // budget. The slack.ts cap is a rare safety net; these tests pin
-    // the prompt guidance so a future refactor can't silently weaken it.
+  describe("Slack message budget (output contract, #112)", () => {
+    // Primary lever against msg_too_long is prompt-level: tell the model
+    // to prefer one compact reply, and warn that longer answers WILL be
+    // split. The splitter + fail-loud boundary guard (see slack.ts,
+    // split-reply.ts) back-stop anything the prompt doesn't catch. These
+    // tests pin the guidance so a future refactor can't silently weaken it.
 
-    it("tells the model about Slack's 40,000-char message ceiling", () => {
+    it("tells the model that oversized answers will be split into multiple replies", () => {
       const prompt = assembleSystemPrompt(baseArgs);
-      expect(prompt).toContain("40,000");
-      // Must frame it as something that causes the user to see an error,
-      // not just a soft guideline.
-      expect(prompt).toMatch(/reject|error/i);
+      expect(prompt).toMatch(/split.*multiple|multiple.*replies|continued/i);
     });
 
     it("states an explicit char budget for the answer itself", () => {

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -37,16 +37,18 @@ export const RECENCY_WINDOW_DAYS = 30;
 // Target character budget for the agent's TEXT answer alone. Composed
 // messages also carry references + optional issue proposal body +
 // optional reply footer; all of that must fit under Slack's 40K hard
-// cap. Math: 20K answer + ~3K refs + ~8K proposal (worst case) + 100
-// footer = ~31K, comfortable under 40K. 20K gives the agent room for
-// structured answers on comparative / analytical questions without
-// encouraging novel-length essays (other prompt guidance — "15 lines
-// typical", "brevity" — steers the common case short).
-export const ANSWER_BUDGET_CHARS = 20_000;
+// Primary lever against msg_too_long: keep any single Slack post well
+// below the 40K limit. 3,000 chars reads as ~60 lines — a scannable
+// Slack answer. Longer answers are split into multiple thread replies
+// by `postReplyInChunks` (see src/lib/slack.ts). The prompt tells the
+// model this happens so it prefers concision over relying on the splitter.
+// See #112.
+export const ANSWER_BUDGET_CHARS = 3_000;
 // Target character budget for an issue proposal body when the agent
-// uses `create_issue`. Title + goal + acceptance criteria + context +
-// 1-2 key files comfortably fit. Not a tight cap.
-export const ISSUE_PROPOSAL_BODY_BUDGET_CHARS = 8_000;
+// uses `create_issue`. Title + goal + acceptance criteria + 1-2 key
+// file paths fit comfortably. Tighter than before (#112) to keep the
+// combined answer+proposal body compact.
+export const ISSUE_PROPOSAL_BODY_BUDGET_CHARS = 4_000;
 
 // Hard cap on any single tool_result before it is appended to the agent's
 // messages array. Prevents broad research prompts (list_issues, list_prs,
@@ -345,9 +347,9 @@ Prefer a single result-focused reply after tool work completes. Don't pre-announ
 - Be direct and technical — this is an engineering team.
 - If the user wants more detail, they'll ask a follow-up.
 
-*Slack message budget — hard limit:*
-- Slack caps a single message at **40,000 characters**. Your answer, plus the reference footer, plus (when applicable) an issue proposal body, are composed into ONE Slack message. If the total exceeds 40K, Slack rejects it and the user sees an error — not your answer.
-- Keep your answer text itself under **~${ANSWER_BUDGET_CHARS.toLocaleString()} characters** (≈150 lines). Comparative or "summarize our X" questions are NOT an exception — condense aggressively.
+*Slack message budget — target one compact reply:*
+- Target **~${ANSWER_BUDGET_CHARS.toLocaleString()} characters** (≈60 lines) for your answer. Comparative or "summarize our X" questions are NOT an exception — condense aggressively.
+- Answers longer than the budget WILL be split across multiple thread replies automatically. That works, but a user absorbs one compact post much better than three long ones. Prefer concision.
 - When you'd want to go long: DON'T. Summarize the 3–5 key points, then point the user at specific files/PRs/issues via references. They can ask a narrower follow-up for detail on any one of them.
 - DO NOT quote or paraphrase tool results verbatim. Don't inline whole files. Don't write an essay comparing two systems when a bulleted contrast list + references will do.
 - When using \`create_issue\`, keep the proposal body under **~${ISSUE_PROPOSAL_BODY_BUDGET_CHARS.toLocaleString()} characters**: title, clear goal, 3–6 acceptance-criteria bullets, and the 1–2 most relevant file paths. Don't paste context dumps.

--- a/src/lib/slack.test.ts
+++ b/src/lib/slack.test.ts
@@ -1,94 +1,68 @@
 import { describe, it, expect } from "vitest";
-import { capSlackMessage, SLACK_MESSAGE_BYTE_CAP } from "./slack";
+import {
+  requireSlackMessageText,
+  SLACK_MESSAGE_CHAR_LIMIT,
+  SlackMessageOversizeError,
+} from "./slack";
 
-// Helper — UTF-8 byte length of a string.
-function bytes(s: string): number {
-  return new TextEncoder().encode(s).length;
-}
-
-describe("capSlackMessage (byte-based)", () => {
-  it("passes through short ASCII messages unchanged", () => {
+describe("requireSlackMessageText (fail-loud boundary guard)", () => {
+  it("returns the text unchanged when under the limit", () => {
     const text = "hello world";
-    expect(capSlackMessage(text)).toBe(text);
+    expect(requireSlackMessageText(text, "chat.postMessage")).toBe(text);
   });
 
-  it("passes through messages exactly at the byte cap unchanged", () => {
-    const text = "a".repeat(SLACK_MESSAGE_BYTE_CAP);
-    expect(bytes(text)).toBe(SLACK_MESSAGE_BYTE_CAP);
-    expect(capSlackMessage(text)).toBe(text);
+  it("returns the text unchanged when exactly at the limit", () => {
+    const text = "a".repeat(SLACK_MESSAGE_CHAR_LIMIT);
+    expect(requireSlackMessageText(text, "chat.postMessage")).toBe(text);
   });
 
-  it("truncates when over the byte cap and appends a user-facing note", () => {
-    const text = "a".repeat(SLACK_MESSAGE_BYTE_CAP + 5_000);
-    const result = capSlackMessage(text);
-    expect(bytes(result)).toBeLessThanOrEqual(SLACK_MESSAGE_BYTE_CAP);
-    expect(result).toMatch(/cut off|truncated/i);
-    expect(result).toContain("Slack");
-    expect(result).toMatch(/follow.up|narrower/i);
+  it("throws SlackMessageOversizeError when over the limit", () => {
+    const text = "a".repeat(SLACK_MESSAGE_CHAR_LIMIT + 1);
+    expect(() => requireSlackMessageText(text, "chat.update")).toThrow(
+      SlackMessageOversizeError,
+    );
   });
 
-  it("enforces byte budget on unicode-heavy content (the real-world bug)", () => {
-    // An em-dash `—` is 3 bytes in UTF-8. 20_000 em-dashes = 60_000 bytes
-    // but only 20_000 JavaScript chars — the failure mode that the old
-    // char-based cap missed (#110 post-merge reproduction). The byte cap
-    // must enforce byte count.
+  it("error message names the action and the actual length", () => {
+    const text = "x".repeat(SLACK_MESSAGE_CHAR_LIMIT + 500);
+    try {
+      requireSlackMessageText(text, "chat.postMessage");
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(SlackMessageOversizeError);
+      const msg = (e as Error).message;
+      expect(msg).toContain("chat.postMessage");
+      expect(msg).toContain(String(SLACK_MESSAGE_CHAR_LIMIT + 500));
+      expect(msg).toContain("40000");
+    }
+  });
+
+  it("SLACK_MESSAGE_CHAR_LIMIT matches Slack's documented 40_000 limit", () => {
+    // Anchor value — changing this should be a conscious decision that
+    // surfaces in code review, not a silent drift.
+    expect(SLACK_MESSAGE_CHAR_LIMIT).toBe(40_000);
+  });
+
+  it("unicode content counts as characters, not bytes (matches Slack's count)", () => {
+    // 20K em-dashes = 20,000 chars but 60,000 UTF-8 bytes. Should PASS
+    // the guard (chars-based), whereas the old byte-based cap would
+    // have truncated it.
     const text = "—".repeat(20_000);
-    expect(bytes(text)).toBe(60_000);
     expect(text.length).toBe(20_000);
-
-    const result = capSlackMessage(text);
-    expect(bytes(result)).toBeLessThanOrEqual(SLACK_MESSAGE_BYTE_CAP);
-    expect(result).toMatch(/cut off|truncated/i);
+    expect(() => requireSlackMessageText(text, "chat.postMessage")).not.toThrow();
   });
 
-  it("preserves the start of the content (truncates from the end)", () => {
-    const head = "IMPORTANT: the agent's analysis begins here.\n\n";
-    const filler = "x".repeat(SLACK_MESSAGE_BYTE_CAP + 5_000);
-    const text = head + filler;
-
-    const result = capSlackMessage(text);
-    expect(result.startsWith(head)).toBe(true);
-  });
-
-  it("handles emoji-heavy content (4 bytes per emoji) correctly", () => {
-    // 🧠 is U+1F9E0, encoded as 4 UTF-8 bytes. 10_000 of them = 40_000 bytes
-    // (over the 36K cap) but only 20_000 UTF-16 code units (JS length).
-    const text = "🧠".repeat(10_000);
-    expect(bytes(text)).toBe(40_000);
-
-    const result = capSlackMessage(text);
-    expect(bytes(result)).toBeLessThanOrEqual(SLACK_MESSAGE_BYTE_CAP);
-    expect(result).toMatch(/cut off|truncated/i);
-  });
-
-  it("never corrupts the output when the cut falls inside a multi-byte char", () => {
-    // Construct a string whose byte length right at the budget boundary
-    // falls mid-character. TextDecoder with fatal:false handles this by
-    // substituting U+FFFD for the partial sequence, so the result is
-    // always valid UTF-8 (no half-chars, no throw).
-    const prefix = "a".repeat(SLACK_MESSAGE_BYTE_CAP - 100);
-    // Append a run of 3-byte em-dashes whose middle falls past the cut.
-    const text = prefix + "—".repeat(200);
-    const result = capSlackMessage(text);
-
-    // Must be valid UTF-8; no partial sequence should survive.
-    // Re-encoding the result should not throw and should match expected bytes.
-    expect(() => new TextEncoder().encode(result)).not.toThrow();
-    expect(bytes(result)).toBeLessThanOrEqual(SLACK_MESSAGE_BYTE_CAP);
-  });
-
-  it("handles messages only slightly over the cap", () => {
-    const text = "a".repeat(SLACK_MESSAGE_BYTE_CAP + 1);
-    const result = capSlackMessage(text);
-    expect(bytes(result)).toBeLessThanOrEqual(SLACK_MESSAGE_BYTE_CAP);
-    expect(result).toMatch(/cut off|truncated/i);
-  });
-
-  it("SLACK_MESSAGE_BYTE_CAP leaves headroom under Slack's 40k limit", () => {
-    // Slack's documented limit for `text` is 40_000; we stay well under so
-    // the JSON envelope (channel, thread_ts, token header, message
-    // metadata) has room and unicode expansion can't cross the cliff.
-    expect(SLACK_MESSAGE_BYTE_CAP).toBeLessThan(40_000);
-    expect(SLACK_MESSAGE_BYTE_CAP).toBeGreaterThan(25_000);
+  it("emoji (surrogate pairs) count each pair as 2 chars (UTF-16 length)", () => {
+    // 🧠 is one grapheme but 2 UTF-16 code units. 20K emoji = 40_000 chars.
+    // Slack's limit is applied via `.length` which counts code units, so
+    // this should be exactly at the limit.
+    const text = "🧠".repeat(20_000);
+    expect(text.length).toBe(40_000);
+    expect(() => requireSlackMessageText(text, "chat.postMessage")).not.toThrow();
+    // One more character pushes us over.
+    const overText = text + "x";
+    expect(() => requireSlackMessageText(overText, "chat.postMessage")).toThrow(
+      SlackMessageOversizeError,
+    );
   });
 });

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -1,5 +1,6 @@
 import crypto from "crypto";
 import { WebClient } from "@slack/web-api";
+import { splitSlackReplyText } from "./split-reply";
 
 // ── Slack client ──────────────────────────────────────────────────────
 const slack = new WebClient(process.env.SLACK_BOT_TOKEN);
@@ -42,62 +43,40 @@ export function verifySlackSignature(
   return crypto.timingSafeEqual(expectedBuf, signatureBuf);
 }
 
-// ── Slack message length guard (safety net) ──────────────────────────
-// Slack's `chat.postMessage` / `chat.update` cap `text` at 40,000 —
-// measured in BYTES, not characters (the docs say "characters" but
-// empirical behavior on msg_too_long rejects aligns with byte count).
-// Unicode content blows this up fast: em-dash `—` = 3 bytes, emoji = 4,
-// divider `─` = 3. A 39K-char answer with moderate unicode density
-// easily crosses 42-45K BYTES, which Slack refuses.
+// ── Slack message length guard (fail-loud boundary) ──────────────────
+// Slack rejects `chat.postMessage` / `chat.update` calls whose `text`
+// exceeds 40,000 with `msg_too_long`. The primary defense against that
+// is the splitter (src/lib/split-reply.ts) which chops long answers
+// into multiple thread posts, each well under the limit. This guard
+// is the last line of defense: if anything ever reaches the wire
+// oversized, we throw so Sentry gets a loud stack with our own frame
+// (rather than a minified Slack SDK frame) and the user sees a clear
+// error rather than silently losing part of their answer.
 //
-// First shipped a char-based cap in #110 — still saw msg_too_long on
-// unicode-heavy answers. Moving to byte-based cap here. See #108.
-//
-// PRIMARY fix for oversized replies still lives in the prompt
-// (ANSWER_BUDGET_CHARS in claude.ts — 20K char target). This function
-// is a last-line-of-defense safety net; when it fires, that's a signal
-// the prompt guidance needs tuning for a class of question.
-export const SLACK_MESSAGE_BYTE_CAP = 36_000;
+// See #112 for the architectural rationale.
+export const SLACK_MESSAGE_CHAR_LIMIT = 40_000;
 
-const TRUNCATION_NOTE =
-  "\n\n_…(answer cut off to fit Slack's message size limit — ask a narrower follow-up for detail on any specific area.)_";
-
-const textEncoder = new TextEncoder();
-// `fatal: false` so a mid-multi-byte-char cut at the budget boundary is
-// gracefully replaced with U+FFFD rather than throwing. `ignoreBOM: true`
-// because Slack messages never need a BOM.
-const textDecoder = new TextDecoder("utf-8", { fatal: false, ignoreBOM: true });
+export class SlackMessageOversizeError extends Error {
+  constructor(action: string, length: number) {
+    super(
+      `${action} text is ${length} chars, exceeds Slack's ${SLACK_MESSAGE_CHAR_LIMIT}-char limit — splitter bug`,
+    );
+    this.name = "SlackMessageOversizeError";
+  }
+}
 
 /**
- * Cap a Slack message body at `SLACK_MESSAGE_BYTE_CAP` BYTES (UTF-8).
- * Short messages pass through unchanged; oversized ones are sliced at
- * a byte-aligned boundary with the partial multi-byte sequence at the
- * cut handled by TextDecoder's replacement behavior, then the
- * truncation note is appended. Result's byte length is guaranteed
- * ≤ SLACK_MESSAGE_BYTE_CAP (the note's bytes are reserved in the
- * initial budget).
+ * Throws SlackMessageOversizeError if `text` would trip Slack's
+ * msg_too_long. The splitter is expected to keep us well under this
+ * bound — anything reaching the guard oversized is a bug worth surfacing.
  *
  * Pure function; no I/O.
  */
-export function capSlackMessage(text: string): string {
-  const textBytes = textEncoder.encode(text);
-  if (textBytes.length <= SLACK_MESSAGE_BYTE_CAP) return text;
-
-  const noteBytes = textEncoder.encode(TRUNCATION_NOTE).length;
-  // When the slice lands inside a multi-byte char, TextDecoder substitutes
-  // U+FFFD (3 UTF-8 bytes) for the partial sequence. That can make the
-  // re-encoded result 2–3 bytes larger than the byte slice itself, so we
-  // pre-reserve 3 bytes for that overhead.
-  const REPLACEMENT_OVERHEAD = 3;
-  const budget = SLACK_MESSAGE_BYTE_CAP - noteBytes - REPLACEMENT_OVERHEAD;
-  let head = textDecoder.decode(textBytes.slice(0, budget));
-  // Defensive trim: in case a pathological input still spills past the cap
-  // (e.g. grapheme clusters across multiple code points), shave chars until
-  // we fit. Finite loop bounded by head.length.
-  while (textEncoder.encode(head + TRUNCATION_NOTE).length > SLACK_MESSAGE_BYTE_CAP) {
-    head = head.slice(0, -1);
+export function requireSlackMessageText(text: string, action: string): string {
+  if (text.length > SLACK_MESSAGE_CHAR_LIMIT) {
+    throw new SlackMessageOversizeError(action, text.length);
   }
-  return head + TRUNCATION_NOTE;
+  return text;
 }
 
 // ── Thread reply helper ───────────────────────────────────────────────
@@ -109,7 +88,7 @@ export async function replyInThread(
   const result = await slack.chat.postMessage({
     channel,
     thread_ts: threadTs,
-    text: capSlackMessage(text),
+    text: requireSlackMessageText(text, "chat.postMessage"),
   });
   return result.ts; // message timestamp — used to track Q&A context for feedback
 }
@@ -120,7 +99,55 @@ export async function updateMessage(
   ts: string,
   text: string,
 ): Promise<void> {
-  await slack.chat.update({ channel, ts, text: capSlackMessage(text) });
+  await slack.chat.update({
+    channel,
+    ts,
+    text: requireSlackMessageText(text, "chat.update"),
+  });
+}
+
+// ── Multi-post delivery (splits long bodies into N thread replies) ───
+// Primary entry point for any final-answer post. Splits `text` into
+// chunks via `splitSlackReplyText`; edits the thinking message with
+// chunk 0 (if `thinkingTs` given) or posts it fresh, then posts the
+// remaining chunks as new thread replies. Returns the TS of chunk 0
+// (for Q&A-context storage).
+//
+// Short answers (the common case) produce one chunk → same UX as before.
+// Long answers produce 2-4 chunks → still one logical answer, split at
+// paragraph boundaries with a "[continued ↓]" hint on intermediate posts.
+export interface PostReplyInChunksInput {
+  channel: string;
+  threadTs: string;
+  thinkingTs?: string;
+  text: string;
+}
+
+export async function postReplyInChunks(
+  input: PostReplyInChunksInput,
+): Promise<{ firstTs: string | undefined; chunks: number }> {
+  const chunks = splitSlackReplyText(input.text);
+  if (chunks.length === 0) {
+    return { firstTs: undefined, chunks: 0 };
+  }
+
+  const first = chunks[0] ?? "";
+  let firstTs: string | undefined;
+  if (input.thinkingTs) {
+    // Edit the thinking message in place — it becomes the first chunk.
+    await updateMessage(input.channel, input.thinkingTs, first);
+    firstTs = input.thinkingTs;
+  } else {
+    firstTs = await replyInThread(input.channel, input.threadTs, first);
+  }
+
+  // Remaining chunks post as fresh thread replies in order.
+  for (let i = 1; i < chunks.length; i++) {
+    const chunk = chunks[i] ?? "";
+    await replyInThread(input.channel, input.threadTs, chunk);
+  }
+
+  return { firstTs, chunks: chunks.length };
 }
 
 // ── Delete a message ──────────────────────────────────────────────────

--- a/src/lib/split-reply.test.ts
+++ b/src/lib/split-reply.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from "vitest";
+import {
+  splitSlackReplyText,
+  DEFAULT_MAX_CHARS,
+  DEFAULT_MAX_LINES,
+  CONTINUATION_MARKER,
+} from "./split-reply";
+
+describe("splitSlackReplyText", () => {
+  describe("pass-through (no split needed)", () => {
+    it("returns single chunk for short text", () => {
+      const text = "hello world";
+      expect(splitSlackReplyText(text)).toEqual([text]);
+    });
+
+    it("returns single chunk exactly at maxChars", () => {
+      const text = "a".repeat(DEFAULT_MAX_CHARS);
+      const chunks = splitSlackReplyText(text);
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]).toBe(text);
+    });
+
+    it("returns single chunk exactly at maxLines", () => {
+      const lines = Array.from({ length: DEFAULT_MAX_LINES }, (_, i) => `line ${i}`);
+      const text = lines.join("\n");
+      const chunks = splitSlackReplyText(text);
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]).toBe(text);
+    });
+
+    it("returns empty array for empty input", () => {
+      expect(splitSlackReplyText("")).toEqual([]);
+    });
+
+    it("returns empty array for whitespace-only input", () => {
+      expect(splitSlackReplyText("   \n\n  ")).toEqual([]);
+    });
+  });
+
+  describe("split boundaries (priority order)", () => {
+    it("prefers paragraph boundary (\\n\\n) over line boundary", () => {
+      // Build text with both paragraph and line breaks; cut must land on paragraph
+      const paragraph1 = "Short intro paragraph.";
+      const paragraph2 = "a".repeat(120) + "\n" + "b".repeat(120);
+      const paragraph3 = "Conclusion.";
+      const text = `${paragraph1}\n\n${paragraph2}\n\n${paragraph3}`;
+
+      const chunks = splitSlackReplyText(text, { maxChars: 200 });
+      expect(chunks.length).toBeGreaterThan(1);
+      // First chunk (stripped of continuation marker) must end at a
+      // paragraph boundary — not mid-line.
+      const firstContent = (chunks[0] ?? "").replace(CONTINUATION_MARKER, "").trimEnd();
+      expect(firstContent.endsWith(paragraph1)).toBe(true);
+    });
+
+    it("falls back to line boundary (\\n) when no paragraph fits", () => {
+      const line1 = "a".repeat(80);
+      const line2 = "b".repeat(80);
+      const line3 = "c".repeat(80);
+      // No \n\n at all, just \n — one long paragraph split into three lines
+      const text = `${line1}\n${line2}\n${line3}`;
+
+      const chunks = splitSlackReplyText(text, { maxChars: 150 });
+      expect(chunks.length).toBeGreaterThan(1);
+      // First chunk (stripped of continuation marker) must end with
+      // line1 content (line boundary split).
+      const firstContent = (chunks[0] ?? "").replace(CONTINUATION_MARKER, "").trimEnd();
+      expect(firstContent.endsWith(line1)).toBe(true);
+    });
+
+    it("falls back to word boundary when no line break fits in budget", () => {
+      // One long run of words, no newlines — cut on a space
+      const words = Array.from({ length: 100 }, (_, i) => `word${i}`).join(" ");
+      const chunks = splitSlackReplyText(words, { maxChars: 60 });
+
+      expect(chunks.length).toBeGreaterThan(1);
+      // No chunk should end mid-word (except the final chunk by coincidence)
+      for (let i = 0; i < chunks.length - 1; i++) {
+        const chunk = chunks[i] ?? "";
+        // Strip the continuation marker for this check
+        const stripped = chunk.replace(CONTINUATION_MARKER, "").trimEnd();
+        // The chunk content should end with a complete word (not a partial)
+        expect(stripped).toMatch(/word\d+$/);
+      }
+    });
+
+    it("hard-cuts when a single token exceeds budget", () => {
+      const megaword = "a".repeat(5_000);
+      const chunks = splitSlackReplyText(megaword, { maxChars: 1_000 });
+      expect(chunks.length).toBeGreaterThanOrEqual(5);
+      // Every chunk must be within budget
+      for (const chunk of chunks) {
+        expect(chunk.length).toBeLessThanOrEqual(1_000);
+      }
+    });
+  });
+
+  describe("continuation marker behavior", () => {
+    it("appends marker to non-final chunks when >= 3 chunks", () => {
+      const text = "x".repeat(9_000);
+      const chunks = splitSlackReplyText(text, { maxChars: 3_000 });
+      expect(chunks.length).toBeGreaterThanOrEqual(3);
+      for (let i = 0; i < chunks.length - 1; i++) {
+        expect(chunks[i]).toMatch(/continued|continue|↓/i);
+      }
+      // Final chunk must NOT carry the marker
+      expect(chunks.at(-1)).not.toMatch(/continued|↓/i);
+    });
+
+    it("drops the continuation marker on the 2-chunk case (cleaner UX)", () => {
+      // Just over maxChars → exactly 2 chunks → marker dropped
+      const text = "a".repeat(3_500);
+      const chunks = splitSlackReplyText(text, { maxChars: 3_000 });
+      expect(chunks).toHaveLength(2);
+      // Neither chunk should contain the marker text
+      for (const chunk of chunks) {
+        expect(chunk).not.toMatch(/\[continued/i);
+      }
+    });
+
+    it("every chunk fits within maxChars INCLUDING the marker", () => {
+      const text = "x".repeat(9_000);
+      const chunks = splitSlackReplyText(text, { maxChars: 3_000 });
+      for (const chunk of chunks) {
+        expect(chunk.length).toBeLessThanOrEqual(3_000);
+      }
+    });
+  });
+
+  describe("code fence continuation", () => {
+    it("closes and reopens an unmatched fence across a split", () => {
+      // Build a long code block that MUST split
+      const codeBody = Array.from({ length: 80 }, (_, i) => `  line ${i}: ${"x".repeat(30)}`).join("\n");
+      const text = `Here's the code:\n\n\`\`\`typescript\n${codeBody}\n\`\`\`\n\nThat's all.`;
+
+      const chunks = splitSlackReplyText(text, { maxChars: 800 });
+      expect(chunks.length).toBeGreaterThan(1);
+
+      // Count fences per chunk — each chunk must have balanced fences
+      for (const chunk of chunks) {
+        const fenceCount = (chunk.match(/```/g) ?? []).length;
+        expect(fenceCount % 2).toBe(0);
+      }
+    });
+
+    it("preserves the language tag when reopening a fence", () => {
+      const codeBody = "x".repeat(2_000);
+      const text = `\`\`\`python\n${codeBody}\n\`\`\``;
+
+      const chunks = splitSlackReplyText(text, { maxChars: 800 });
+      expect(chunks.length).toBeGreaterThan(1);
+      // Chunk 2+ should re-open with ```python
+      // (not just ```)
+      for (let i = 1; i < chunks.length; i++) {
+        expect(chunks[i]).toMatch(/^```python/);
+      }
+    });
+
+    it("tilde fences (~~~) are treated the same as backticks", () => {
+      const codeBody = "y".repeat(2_000);
+      const text = `~~~\n${codeBody}\n~~~`;
+      const chunks = splitSlackReplyText(text, { maxChars: 800 });
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        const tildeCount = (chunk.match(/~~~/g) ?? []).length;
+        expect(tildeCount % 2).toBe(0);
+      }
+    });
+  });
+
+  describe("line budget", () => {
+    it("splits on line count even when char budget has room", () => {
+      const lines = Array.from({ length: 100 }, (_, i) => `short line ${i}`);
+      const text = lines.join("\n");
+      // Plenty of chars available, but line budget should force split
+      const chunks = splitSlackReplyText(text, { maxChars: 10_000, maxLines: 30 });
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        const lineCount = chunk.split("\n").length;
+        expect(lineCount).toBeLessThanOrEqual(30);
+      }
+    });
+  });
+
+  describe("unicode and real-world content", () => {
+    it("handles em-dash heavy content (no byte/char confusion)", () => {
+      // This was the #111 regression — em-dashes are 3 bytes but 1 char.
+      // Splitter works in CHARS, matching Slack's reported limit.
+      const text = "—".repeat(10_000);
+      const chunks = splitSlackReplyText(text, { maxChars: 3_000 });
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        expect(chunk.length).toBeLessThanOrEqual(3_000);
+      }
+    });
+
+    it("handles emoji content (surrogate pairs not mid-split)", () => {
+      const text = "🧠".repeat(4_000);
+      const chunks = splitSlackReplyText(text, { maxChars: 3_000 });
+      expect(chunks.length).toBeGreaterThan(1);
+      // No chunk should contain a lone high surrogate (broken emoji)
+      for (const chunk of chunks) {
+        // A lone high surrogate is D800-DBFF without a following low surrogate.
+        // This regex matches one if present — test asserts none are.
+        expect(chunk).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+        expect(chunk).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+      }
+    });
+  });
+
+  describe("invariants (mutation testing)", () => {
+    it("concatenating non-marker content yields the original (lossless for long runs)", () => {
+      // Splitter may strip continuation markers and trailing whitespace, but
+      // the original SEMANTIC content must be preserved.
+      const original = "a".repeat(500) + "\n\n" + "b".repeat(500) + "\n\n" + "c".repeat(500);
+      const chunks = splitSlackReplyText(original, { maxChars: 600 });
+
+      // Strip the continuation marker from each chunk and rejoin
+      const stripped = chunks
+        .map((c) => c.replace(CONTINUATION_MARKER, "").trimEnd())
+        .join("\n\n");
+
+      // Key characters should all be present
+      expect(stripped).toContain("a".repeat(500));
+      expect(stripped).toContain("b".repeat(500));
+      expect(stripped).toContain("c".repeat(500));
+    });
+
+    it("never returns an empty string chunk", () => {
+      const text = "x\n\n\n\n" + "y".repeat(5_000) + "\n\n\n\n" + "z";
+      const chunks = splitSlackReplyText(text, { maxChars: 1_000 });
+      for (const chunk of chunks) {
+        expect(chunk.trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    it("returns at least one chunk for non-empty input", () => {
+      const text = "x";
+      const chunks = splitSlackReplyText(text);
+      expect(chunks.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("DEFAULT_MAX_CHARS stays well under Slack's 40,000 limit", () => {
+      expect(DEFAULT_MAX_CHARS).toBeLessThan(10_000);
+      expect(DEFAULT_MAX_CHARS).toBeGreaterThan(1_000);
+    });
+  });
+});

--- a/src/lib/split-reply.ts
+++ b/src/lib/split-reply.ts
@@ -1,0 +1,211 @@
+// ── Slack reply splitter ──────────────────────────────────────────────
+// Long answers are split into multiple thread replies rather than
+// truncated at a character cap. Truncation silently eats content
+// (including the user's call-to-action in issue-proposal messages)
+// and still trips Slack's msg_too_long because the "40K limit" is not
+// the only constraint in play. Splitting removes the limit entirely
+// from the happy path.
+//
+// Priority order when picking a cut point: paragraph (\n\n) > line (\n)
+// > word (space) > hard-cut. Code fences are tracked and re-opened on
+// the next chunk so ``` blocks stay valid.
+//
+// Pure function, no I/O. Colocated tests in split-reply.test.ts.
+
+export const DEFAULT_MAX_CHARS = 3_000;
+export const DEFAULT_MAX_LINES = 60;
+export const CONTINUATION_MARKER = "\n\n_[continued ↓]_";
+
+export interface SplitOptions {
+  maxChars?: number;
+  maxLines?: number;
+}
+
+interface FenceState {
+  // Language tag (e.g. "python", "typescript") or "" for fence with no tag.
+  // undefined means no fence currently open.
+  openLang: string | undefined;
+  // The fence marker (``` or ~~~) currently open.
+  openMarker: "```" | "~~~" | undefined;
+}
+
+const FENCE_RE = /^(```|~~~)([\w+-]*)\s*$/;
+
+// Walk every line; toggle fence state on opening/closing markers.
+// Returns the fence state at the END of the given text.
+function trackFenceState(text: string, initial: FenceState): FenceState {
+  let state = { ...initial };
+  for (const line of text.split("\n")) {
+    const match = FENCE_RE.exec(line);
+    if (!match) continue;
+    const marker = match[1] as "```" | "~~~";
+    const lang = match[2] ?? "";
+    if (state.openMarker === undefined) {
+      state = { openMarker: marker, openLang: lang };
+    } else if (state.openMarker === marker) {
+      state = { openMarker: undefined, openLang: undefined };
+    }
+    // Mismatched close (e.g. ~~~ inside a ``` block) — ignore as text.
+  }
+  return state;
+}
+
+// Find the best cut point in `text` at or before `limit` characters.
+// Returns the index AT which to cut (exclusive): text.slice(0, cut) is
+// the chunk; text.slice(cut) is the remainder. Whitespace at the boundary
+// is consumed into the cut point.
+function findCutIndex(text: string, limit: number): number {
+  if (text.length <= limit) return text.length;
+
+  // 1. Paragraph boundary
+  const paragraphCut = text.lastIndexOf("\n\n", limit);
+  if (paragraphCut > 0) return paragraphCut;
+
+  // 2. Line boundary
+  const lineCut = text.lastIndexOf("\n", limit);
+  if (lineCut > 0) return lineCut;
+
+  // 3. Word boundary (space)
+  const spaceCut = text.lastIndexOf(" ", limit);
+  if (spaceCut > 0) return spaceCut;
+
+  // 4. Hard cut — but be careful about surrogate pairs. If `limit` lands
+  // on the low half of a surrogate pair, back up one so the emoji stays
+  // whole on the earlier chunk.
+  const codeUnit = text.charCodeAt(limit - 1);
+  if (codeUnit >= 0xD800 && codeUnit <= 0xDBFF) {
+    return limit - 1;
+  }
+  return limit;
+}
+
+// Enforce the line budget BEFORE the char budget: if `text` has more
+// than `maxLines` lines, truncate to that many lines first, then let
+// the char-budget cut further if needed.
+function applyLineBudget(text: string, maxLines: number): string {
+  const lines = text.split("\n");
+  if (lines.length <= maxLines) return text;
+  return lines.slice(0, maxLines).join("\n");
+}
+
+export function splitSlackReplyText(
+  text: string,
+  options?: SplitOptions,
+): string[] {
+  const maxChars = options?.maxChars ?? DEFAULT_MAX_CHARS;
+  const maxLines = options?.maxLines ?? DEFAULT_MAX_LINES;
+
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return [];
+
+  // Fast path: whole message fits both budgets.
+  const fitsChars = trimmed.length <= maxChars;
+  const fitsLines = trimmed.split("\n").length <= maxLines;
+  if (fitsChars && fitsLines) return [trimmed];
+
+  // Reserve room for the continuation marker on intermediate chunks so
+  // appending it can't push the chunk back over budget — both in chars
+  // and in lines. The marker is `\n\n_[continued ↓]_` → 2 extra newlines.
+  const markerLen = CONTINUATION_MARKER.length;
+  const markerLines = (CONTINUATION_MARKER.match(/\n/g) ?? []).length;
+  const chunkBudget = Math.max(1, maxChars - markerLen);
+  // Also reserve 1 line for a potential fence-close ("```") on a split
+  // that lands inside a code block.
+  const intermediateLineBudget = Math.max(1, maxLines - markerLines - 1);
+
+  const chunks: string[] = [];
+  let remaining = trimmed;
+  let fenceState: FenceState = { openMarker: undefined, openLang: undefined };
+
+  // Safety bound: we'll never produce more than `text.length` chunks,
+  // and each iteration strictly shrinks `remaining`.
+  const maxIterations = Math.max(10, Math.ceil(trimmed.length / Math.max(1, chunkBudget)) + 4);
+  let iter = 0;
+
+  while (remaining.length > 0) {
+    if (iter++ > maxIterations) {
+      // Hard backstop — should be unreachable given the cut-advances-invariant.
+      chunks.push(remaining);
+      break;
+    }
+
+    // Does the remainder fit as the final chunk (no marker needed)?
+    const finalFitsChars = remaining.length <= maxChars;
+    const finalFitsLines = remaining.split("\n").length <= maxLines;
+    if (finalFitsChars && finalFitsLines) {
+      // Re-open any inherited fence so the final chunk is self-contained.
+      const prefixed = fenceState.openMarker !== undefined
+        ? `${fenceState.openMarker}${fenceState.openLang}\n${remaining}`
+        : remaining;
+      chunks.push(prefixed);
+      break;
+    }
+
+    // Apply line budget first (cheaper), then char budget.
+    // Use the intermediate line budget since this chunk will get a marker
+    // (and possibly a fence-close) appended.
+    const lineBudgeted = applyLineBudget(remaining, intermediateLineBudget);
+    const cut = findCutIndex(lineBudgeted, chunkBudget);
+    if (cut <= 0) {
+      // Degenerate — force progress with a hard cut at the chunk budget.
+      const forced = Math.min(chunkBudget, remaining.length);
+      const rawChunk = remaining.slice(0, forced);
+      remaining = remaining.slice(forced).replace(/^\s+/, "");
+      const finalized = finalizeChunk(rawChunk, fenceState, /*hasMore=*/ remaining.length > 0);
+      chunks.push(finalized.text);
+      fenceState = finalized.fenceState;
+      continue;
+    }
+
+    const rawChunk = remaining.slice(0, cut);
+    remaining = remaining.slice(cut).replace(/^\s+/, "");
+    const finalized = finalizeChunk(rawChunk, fenceState, /*hasMore=*/ remaining.length > 0);
+    chunks.push(finalized.text);
+    fenceState = finalized.fenceState;
+  }
+
+  // Visual-polish: drop the continuation marker in the exact 2-chunk case.
+  if (chunks.length === 2) {
+    chunks[0] = (chunks[0] ?? "").replace(CONTINUATION_MARKER, "").trimEnd();
+  }
+
+  return chunks.filter((c) => c.trim().length > 0);
+}
+
+// Given a raw chunk + the fence state coming IN, produce:
+// - the finalized chunk text (prefixed with fence re-open if needed,
+//   suffixed with fence close + continuation marker if needed)
+// - the fence state to carry into the NEXT chunk
+function finalizeChunk(
+  rawChunk: string,
+  incomingFence: FenceState,
+  hasMore: boolean,
+): { text: string; fenceState: FenceState } {
+  // Prefix with fence re-open if we're inheriting one from a prior chunk.
+  let text = incomingFence.openMarker !== undefined
+    ? `${incomingFence.openMarker}${incomingFence.openLang}\n${rawChunk}`
+    : rawChunk;
+
+  // Track fence state ACROSS the prefixed text (the re-opened fence might
+  // close within this chunk, in which case we don't need to carry state).
+  const outgoing = trackFenceState(text, { openMarker: undefined, openLang: undefined });
+
+  // If a fence is still open at end-of-chunk AND there's more content to
+  // come, close the fence here and the next chunk will re-open it.
+  if (outgoing.openMarker !== undefined && hasMore) {
+    text = `${text.trimEnd()}\n${outgoing.openMarker}`;
+  }
+
+  // Continuation marker on non-final chunks.
+  if (hasMore) {
+    text = text + CONTINUATION_MARKER;
+  }
+
+  // Carry the fence state forward only if this chunk ends with an open fence
+  // and there's more content.
+  const carry: FenceState = hasMore && outgoing.openMarker !== undefined
+    ? outgoing
+    : { openMarker: undefined, openLang: undefined };
+
+  return { text, fenceState: carry };
+}


### PR DESCRIPTION
Closes #112. Supersedes the truncation approach from #93/#110/#111.

## Why

Truncation was the wrong primitive. Sentry BATTLE-MAGE-3 shows the byte cap from #111 (release \`1a1f534\`) still hit \`msg_too_long\` twice within 2 hours of deploy. And truncation silently eats the tail of the user's answer — including the \":white_check_mark: to approve\" call-to-action in issue-proposal messages.

## What

New invariant: **40K is only meaningful at the guard; everything upstream keeps us 10-20× below it.**

### Layer 1 — Prompt output contract
\`ANSWER_BUDGET_CHARS\` 20K → 3K, \`ISSUE_PROPOSAL_BODY_BUDGET_CHARS\` 8K → 4K. Contract reframed: longer answers WILL be split; prefer concision.

### Layer 2 — Pure splitter (\`src/lib/split-reply.ts\`, new)
\`splitSlackReplyText(text)\` → \`string[]\`. Cut priority: paragraph (\`\\n\\n\`) > line (\`\\n\`) > word > hard-cut. Code-fence aware (closes + reopens with language tag). Reserves budget for \`[continued ↓]\` marker; drops it in the 2-chunk case.

### Layer 3 — Fail-loud boundary guard
Removed silent \`capSlackMessage\`. Added \`requireSlackMessageText\` that **throws** on >40K so Sentry gets a stack with our own frame + action label (not minified Slack SDK internals).

### Layer 4 — Multi-post delivery
\`postReplyInChunks({ channel, threadTs, thinkingTs?, text })\` — edits thinking msg with chunk 0, posts chunks 1..N as new thread replies, returns TS of chunk 0.

### Layer 5 — Route wiring
4 inline \`updateMessage\`/\`replyInThread\` branches collapsed into 4 \`postReplyInChunks\` calls. \`answer_posted\` log gains \`chunks: N\` for prod visibility.

## UX

| Case | Before | After |
|---|---|---|
| Short answer (common) | 1 post | 1 post |
| Long comparative answer | 1 post truncated, tail (incl. CTA) eaten | 2-4 thread replies with \`[continued ↓]\` hints |
| Code block spanning split | Often broken | Fence closes + re-opens with language preserved |
| Over-40K edge | Silent truncate → user confused | Sentry captures clear stack |

## Test plan

- [x] 22 new tests in \`split-reply.test.ts\` — boundaries, fence continuation, unicode, emoji surrogates, empty-chunk safety, mutation invariants
- [x] 7 rewritten tests in \`slack.test.ts\` — guard passes/throws/counts chars-not-bytes
- [x] Existing 378 tests still pass (406/406 total)
- [x] \`tsc --noEmit\` clean
- [ ] Post-merge: reproduce the SCC comparison query → expect 2-3 thread replies with continuation markers instead of the error

## Rate limits
Slack Tier 2 is 30/min. 4 posts per turn is fine.

Refs #100, #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)