### PR TITLE
docs: Message-splitting architecture + troubleshooting entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ src/
     mrkdwn.ts             — Markdown → Slack mrkdwn converter
     logger.ts             — Structured JSON logging with request correlation IDs
     references.ts         — Typed references: ranking, dedup, emoji formatting
+    split-reply.ts        — Pure splitter for long Slack replies (paragraph/line/word/fence-aware)
   tools/
     index.ts              — Tool registry and executor
     search-code.ts        — GitHub code search tool
@@ -77,6 +78,7 @@ docs/
     source-hierarchy.md   — Source-of-truth hierarchy (5 levels)
     auto-correction.md    — Auto-correction on 👎 reactions
     progress-ux.md        — Live progress updates (emoji + status)
+    message-splitting.md  — Long-reply chunking architecture (split-reply + boundary guard)
 ```
 
 ## Testing (TDD Required)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,14 +18,16 @@ POST /api/slack (Next.js API route)
         ├── Post thinking message ("Battle Mage is working...")
         ├── Run agent loop (Claude + tools)
         │     ├── Tool round 1: search_code("auth middleware")
-        │     │   └── Update thinking message: "Searching for auth middleware..."
+        │     │   └── Update thinking message: "🔍 Searching for auth middleware..."
         │     ├── Tool round 2: read_file("src/middleware/auth.ts")
-        │     │   └── Update thinking message: "Reading src/middleware/auth.ts..."
+        │     │   └── Update thinking message: "📖 Reading src/middleware/auth.ts..."
         │     └── ... up to 15 rounds
-        ├── Delete thinking message
         ├── Convert markdown to Slack mrkdwn
         ├── Format reference links
-        └── Post final answer in thread
+        └── Post final answer via `postReplyInChunks`
+              ├── Split body into chunks (≤3K chars each)
+              ├── Chunk 0: edit thinking message in place
+              └── Chunks 1..N: post as new thread replies with "[continued ↓]"
 ```
 
 ## The Ack-Then-Process Pattern
@@ -165,19 +167,17 @@ A warm thread should see `cache_read_tokens` dominate after the first turn. A co
 
 ## The Agent Loop
 
-The agent loop is a streaming Claude tool-use loop with a hard cap of 15 rounds:
+The agent loop is a Claude tool-use loop with a hard cap of 15 rounds. It is **non-streaming** — each round is a single `messages.create` call that returns the complete response before any tools run (see [Message Splitting](./features/message-splitting.md) for why streaming was removed):
 
 ```
 for round in 0..MAX_TOOL_ROUNDS:
-    stream = claude.messages.stream(system, tools, messages)
-    stream.on("text", (_delta, snapshot) => onTextDelta(snapshot))   // Slack streaming
-    response = await stream.finalMessage()
+    response = await anthropic.messages.create(system, tools, messages)
 
     if response.stop_reason == "end_turn":
         return text + references
 
     for each tool_use block in response:
-        fire onProgress callback (updates thinking message)
+        fire onProgress callback (updates thinking message with tool status)
         result = executeTool(name, input)
         collect references from result
 
@@ -187,9 +187,7 @@ if loop exhausted:
     return "hit maximum tool calls" message
 ```
 
-Every round uses `anthropic.messages.stream()` and subscribes to `text` events. On the final round — where Claude produces only text (no `tool_use`) — deltas flow through to Slack in near-real-time. On tool-use rounds, the text event typically doesn't fire (the model emits only tool_use blocks under the output contract), so progress emoji owns the message.
-
-On any streaming error (SDK transport blip), `runAgent` falls back transparently to `anthropic.messages.create()` for that round — the turn keeps going, just without live deltas.
+Progress updates run via `onProgress(toolName, input)` → `progressThrottle.update(...)` (`createThrottledUpdater` in `src/lib/slack-throttle.ts`). The throttle coalesces bursts of parallel tool progress into ~1 Slack edit every 1.2 seconds, well under Slack's rate limit. A final `progressThrottle.flush()` drains any pending update before the final answer is posted, preventing a stale progress message from overwriting the answer.
 
 ### Model tiering — main vs fast (see #75)
 
@@ -214,28 +212,26 @@ Long threads (Slack Q&A with the bot accumulating over many follow-ups) used to 
 
 Integration point: `runAgent` in `src/lib/claude.ts`. Single check at the top of the function, before the round loop. Covers both mention-follow-up and thread-follow-up flows because both path through `runAgent`.
 
-### Streaming into Slack
+### Answer delivery — split, don't truncate
 
-Text deltas are coalesced by `createThrottledUpdater` in `src/lib/slack-throttle.ts`:
+The final answer flows through `postReplyInChunks` in `src/lib/slack.ts`, which splits long bodies into multiple thread replies instead of truncating them to fit Slack's 40K-char limit. Each chunk is a complete, valid Slack message well under the limit; users see the same logical answer across 1-4 posts depending on length. See [Message Splitting](./features/message-splitting.md) for the full design.
 
-- First update fires immediately.
-- Rapid subsequent updates within 1200 ms are coalesced and fire once with the latest accumulated snapshot — safely below Slack's ~1 edit/sec per-message rate limit.
-- `flush()` drains any pending edit before the final-answer write, preventing a race.
+### One-answer lifecycle
 
-Slack mrkdwn conversion (`toSlackMrkdwn`) runs on every streamed edit as a safety net — with the output contract in place, the model emits single-asterisk bold natively so conversion is near-idempotent.
+The thinking message is created once and **reused as chunk 0** of the final answer — no delete-and-repost flicker on short answers. Sequence:
 
-### One-message lifecycle
+1. Post thinking message: "🧠 Battle Mage is working…"
+2. Tool rounds: emoji + status via `onProgress` → throttled `updateMessage(thinkingTs, ...)`
+3. `runAgent` returns; `progressThrottle.flush()` drains pending progress edits
+4. Build final body: formatted text + references footer (and proposal block if present)
+5. `postReplyInChunks({ channel, threadTs, thinkingTs, text: finalBody })`:
+   - Splits `finalBody` into N chunks at paragraph boundaries (see [Message Splitting](./features/message-splitting.md))
+   - Chunk 0: `updateMessage(thinkingTs, chunks[0])` — edits the thinking message in place
+   - Chunks 1..N: `replyInThread(channel, threadTs, chunks[i])` — new thread posts
+   - Returns `{ firstTs, chunks }`
+6. Store Q&A context using `firstTs` (chunk 0's ts)
 
-The thinking message is created once and **reused as the final answer** — no delete-and-repost flicker. Sequence:
-
-1. Post thinking message: "Battle Mage is working…"
-2. Tool round: emoji + status via `onProgress` → `updateMessage(thinkingTs, ...)`
-3. Final round: text deltas via `onTextDelta` → throttled `updateMessage(thinkingTs, ...)`
-4. `runAgent` returns; `streamThrottle.flush()` drains pending edits
-5. Final edit: formatted text + references footer (and proposal block if present) → `updateMessage(thinkingTs, finalBody)`
-6. Store Q&A context using the former `thinkingTs` (now the answer `ts`)
-
-The `finally` block still deletes the thinking message as a safety net if the turn crashed mid-flight.
+The `finally` block still deletes the thinking message as a safety net if the turn crashed before any chunk posted (`thinkingTs` is only cleared once a chunk was successfully sent).
 
 ### Other key behaviors
 
@@ -333,7 +329,8 @@ This ensures users see the most authoritative sources first.
 | **15 tool round budget** | Hard cap prevents runaway tool loops. The system prompt instructs Claude to synthesize early rather than exhausting all rounds. |
 | **References from reads only** | Search results are discovery aids and do not appear in references. Only files the agent actually reads (via `read_file`) are cited. |
 | **KV for knowledge, not GitHub** | The knowledge base lives in Vercel KV, not in the GitHub repo. The GitHub PAT does not need Contents: Write permission. |
-| **Progress messages deleted** | The thinking message is deleted when the answer is ready, rather than edited in place. This keeps the thread clean with just the final answer. |
+| **Split long answers, don't truncate** | Answers over ~3K chars post as multiple thread replies (`[continued ↓]`) instead of being silently cut off. Makes Slack's `msg_too_long` architecturally unreachable on the happy path. See [Message Splitting](./features/message-splitting.md). |
+| **Thinking message reused as chunk 0** | The "🧠 Battle Mage is working…" message is edited in place with the first chunk of the answer — no delete-and-repost flicker. Subsequent chunks post as new thread replies. |
 
 ## Project Structure
 
@@ -354,6 +351,7 @@ src/
     progress.ts           -- Progress message formatter (tool name to emoji + status)
     mrkdwn.ts             -- Markdown to Slack mrkdwn converter
     references.ts         -- Reference deduplication, capping, and formatting
+    split-reply.ts        -- Pure splitter for long Slack replies (paragraph/line/word/fence-aware)
   tools/
     index.ts              -- Tool registry and executor
     search-code.ts        -- GitHub code search

--- a/docs/features/message-splitting.md
+++ b/docs/features/message-splitting.md
@@ -1,0 +1,108 @@
+# Message Splitting
+
+Slack's `chat.postMessage` and `chat.update` APIs reject any `text` above 40,000 characters with a `msg_too_long` error. Battle Mage answers long questions by **splitting the reply across multiple thread posts**, not by truncating a single message. This makes the limit architecturally unreachable on the happy path and, when anything does approach it, fails loudly with a Sentry-captured stack instead of silently eating the user's answer.
+
+## Invariant
+
+**40K is only meaningful at the outbound guard; everything upstream keeps us 10-20× below it.**
+
+The system has three layers that collaborate:
+
+| Layer | File | Purpose |
+|---|---|---|
+| 1. Prompt output contract | `src/lib/claude.ts` | Tell the model to target ~3K chars; warn longer answers WILL be split |
+| 2. Pure splitter | `src/lib/split-reply.ts` | Chop oversized replies at paragraph/line/word boundaries; fence-aware |
+| 3. Fail-loud boundary guard | `src/lib/slack.ts` | Throw `SlackMessageOversizeError` if any chunk reaches the wire >40K — would indicate a splitter bug |
+
+## Layer 1 — Output contract
+
+Constants in `src/lib/claude.ts`:
+
+- `ANSWER_BUDGET_CHARS = 3_000` — target for the main answer
+- `ISSUE_PROPOSAL_BODY_BUDGET_CHARS = 4_000` — target for `create_issue` proposals
+
+These numbers are stamped into the system prompt so the model steers toward compact replies:
+
+> Target ~3,000 characters (≈60 lines) for your answer. Answers longer than the budget WILL be split across multiple thread replies automatically. That works, but a user absorbs one compact post much better than three long ones. Prefer concision.
+
+Comparative / "summarize our X" questions are explicitly called out as **not an exception** — they are where the model most often over-writes. The contract also directs it to prefer references over inline content ("summarize the 3-5 key points, then point the user at specific files/PRs/issues").
+
+## Layer 2 — The splitter
+
+`splitSlackReplyText(text, { maxChars = 3000, maxLines = 60 }): string[]` in `src/lib/split-reply.ts`.
+
+Pure function. No I/O. Fully unit-tested (`split-reply.test.ts`, 22 cases).
+
+### Cut priority at each chunk boundary
+
+1. Paragraph boundary (`\n\n`) at or before the char budget
+2. Line boundary (`\n`)
+3. Word boundary (` `)
+4. Hard cut — with a surrogate-pair guard so a 4-byte emoji never gets split mid-code-point
+
+The splitter falls through the priority list until it finds a cut point; step 4 is a last resort that preserves valid UTF-16.
+
+### Continuation markers
+
+Intermediate (non-final) chunks are suffixed with `_[continued ↓]_` so the user knows more is coming. The marker's chars and newlines are **reserved from the budget** before the cut is picked — appending it can never push a chunk back over the limit.
+
+**Visual polish**: in the exact 2-chunk case the marker is dropped from chunk 0. A user scanning two replies in succession doesn't need the hint that chunk 1 exists right below.
+
+### Code fences
+
+If a cut lands inside a ` ``` ` or `~~~` code block, the splitter:
+
+1. Closes the fence at the end of chunk N (adds a matching ` ``` ` line)
+2. Re-opens the fence at the start of chunk N+1 with the same language tag
+
+So a 4,000-line Python file fragment splits cleanly into multiple chunks, each with a valid, syntax-highlightable ` ```python ` block. Tilde fences (`~~~`) are handled identically.
+
+### Line budget
+
+Independent of the char budget. If a chunk has more than 60 lines, it splits even if char budget has room. Short many-line content (tables, lists) would otherwise produce very tall single posts.
+
+## Layer 3 — Boundary guard
+
+`requireSlackMessageText(text, action)` in `src/lib/slack.ts` throws `SlackMessageOversizeError` if `text.length > SLACK_MESSAGE_CHAR_LIMIT` (40,000).
+
+Every outbound Slack call (`replyInThread`, `updateMessage`) runs this guard first. The expectation is that the splitter keeps us 10× below the limit; the guard's job is to make it loud if anything ever slips through. The thrown error carries a readable action label (e.g. `"chat.update"`) so Sentry captures a stack pointing at our frame, not a minified Slack SDK frame.
+
+**Silent truncation is forbidden.** Earlier iterations (#93, #110, #111) tried progressively fancier truncators. Each silently ate the tail of the user's answer — including, in the worst case, the `:white_check_mark: to approve` call-to-action on issue-proposal messages. The guard replaces that behavior with fail-loud + split.
+
+## Layer 4 — Multi-post delivery
+
+`postReplyInChunks({ channel, threadTs, thinkingTs?, text })` in `src/lib/slack.ts` is the single entry point the Slack route uses for final answers and issue proposals:
+
+1. Calls `splitSlackReplyText(text)` to produce `chunks`
+2. Chunk 0: edits the thinking message (`updateMessage(channel, thinkingTs, chunks[0])`) if a `thinkingTs` was provided, otherwise posts as a fresh thread reply
+3. Chunks 1..N-1: posts each as a new thread reply via `replyInThread`
+4. Returns `{ firstTs, chunks }`
+
+The caller uses `firstTs` to store Q&A context for reactions. `chunks` is logged in `answer_posted` so production visibility shows the split-rate distribution.
+
+**Empty-input safety:** if the agent produced no text at all (`text.trim() === ""`), `splitSlackReplyText` returns `[]` and `postReplyInChunks` returns `{ firstTs: undefined, chunks: 0 }`. The route only clears `thinkingTs` when `chunks > 0`, so the `finally` block still deletes the stuck "thinking…" message.
+
+## Tuning knobs
+
+All defaults live in `src/lib/claude.ts` (prompt) and `src/lib/split-reply.ts` (splitter). To change behavior:
+
+| Knob | Default | Effect |
+|---|---|---|
+| `ANSWER_BUDGET_CHARS` | 3,000 | Lower → more splits on borderline answers; raise → longer single posts |
+| `ISSUE_PROPOSAL_BODY_BUDGET_CHARS` | 4,000 | Same, for proposal bodies |
+| `DEFAULT_MAX_CHARS` | 3,000 | Splitter's chunk cap; should track `ANSWER_BUDGET_CHARS` |
+| `DEFAULT_MAX_LINES` | 60 | Line budget per chunk (protects tall lists/tables) |
+| `CONTINUATION_MARKER` | `\n\n_[continued ↓]_` | The intermediate-chunk marker text |
+| `SLACK_MESSAGE_CHAR_LIMIT` | 40,000 | Outbound guard; should match Slack's actual limit |
+
+## Observability
+
+- `answer_posted` log event includes `chunks: N` — in prod, you can bucket by chunk count to see the distribution. `chunks: 1` should dominate; `chunks: ≥5` is unusual and worth investigating (possibly a tool-result leak into the final answer).
+- `SlackMessageOversizeError` throws land in Sentry tagged `flow=mention` or `flow=thread_followup`. An occurrence means the splitter has a bug — widen the test matrix rather than raising the limit.
+
+## History
+
+- **#93** — first msg_too_long fix: capped tool-result sizes going INTO the agent (still in place, prevents the Anthropic-side context-window crash). Not related to outbound Slack posting.
+- **#110** — first outbound char cap (39,500 chars). Silent truncation. Still hit `msg_too_long` on unicode-heavy content.
+- **#111** — byte-based cap (36,000 UTF-8 bytes). Also silent. Still hit `msg_too_long` after merge — confirming truncation was the wrong primitive.
+- **#112 / #113** — this architecture. Shipped April 2026. Replaces truncation with splitting + fail-loud guard.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,6 +33,12 @@ Common issues and how to fix them.
 - **Rate limits**: Both GitHub and Anthropic APIs have rate limits. If you are hitting them, you will see errors in the Vercel function logs.
 - **Vercel function logs**: The error message is logged to console. Check Vercel dashboard > Logs for the specific error.
 
+### `msg_too_long` errors
+
+If the error message is `An API error occurred: msg_too_long`, Slack rejected an oversized `chat.postMessage` or `chat.update` call. With the split-reply architecture (see [Message Splitting](./features/message-splitting.md)), this should be architecturally unreachable on the happy path — a single message should never approach Slack's 40,000-char limit because the splitter chops long bodies into multiple thread replies first.
+
+If you see it anyway, Sentry will have a `SlackMessageOversizeError` with the offending length and action. That indicates a splitter bug, not a prompt-budget issue. Widen the splitter's test matrix rather than raising the limit.
+
 ## Bot Cannot Read the Repository
 
 **Symptom**: The bot says it cannot find files, or search returns no results.


### PR DESCRIPTION
## Summary

Captures the architecture shipped in #113 and brings the rest of the docs in sync.

- **New** \`docs/features/message-splitting.md\` — full design: prompt output contract, pure splitter (paragraph/line/word/fence-aware), fail-loud boundary guard, \`postReplyInChunks\` delivery, tuning knobs, observability signals, history.
- **Updated** \`docs/architecture.md\` — flow diagram now shows chunked delivery; agent-loop pseudocode matches the non-streaming \`messages.create\` path (streaming was removed in #109); \"One-message lifecycle\" → \"One-answer lifecycle\"; design-decisions table entries refreshed.
- **Updated** \`docs/troubleshooting.md\` — dedicated \`msg_too_long\` section pointing to the feature doc and clarifying that \`SlackMessageOversizeError\` in Sentry is a splitter bug, not a prompt-budget issue.
- **Updated** \`CLAUDE.md\` — project-structure block gains \`split-reply.ts\` and the new features doc.

## Test plan

- [x] Rendered docs read cleanly
- [x] Links to features doc resolve (\`./features/message-splitting.md\`)
- [x] No stale references to removed streaming / truncator code
- [x] No code changes — docs-only PR

Follows up #113. Related #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)