### PR TITLE
fix: Feedback reactions on non-first chunks + robust observability (closes #114)

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -69,16 +69,16 @@ Filter: requestId=a3f2b1c4
 | `mention_received` | @bm mentioned in a channel | channel, user, question |
 | `thread_followup` | Reply in thread where bot is participating | channel, threadTs |
 | `reaction_checkmark` | ✅ on a proposal message | channel, messageTs |
-| `reaction_thumbsup` | 👍 on a bot answer | channel, messageTs |
-| `reaction_thumbsdown` | 👎 on a bot answer | channel, messageTs |
+| `reaction_received` | **Any** `reaction_added` dispatched to the bot's handler (fires before validation) | reaction, reactingUser, targetTs, channel |
 
 ### Agent Events (claude.ts)
 
 | Event | When | Key data |
 |-------|------|----------|
-| `agent_start` | Agent loop begins | promptLength, question |
+| `agent_start` | Agent loop begins | promptLength, question, model |
 | `agent_tool_call` | Each tool execution | tool, round, input (truncated) |
 | `agent_complete` | Agent produces final answer | rounds, refCount, hasProposal, duration_ms |
+| `prompt_feedback_included` | System prompt assembled — fires **every** turn, even when no entries | positiveCount, negativeCount, totalEntries, promptZone |
 
 ### Index Events (repo-index.ts)
 
@@ -93,12 +93,32 @@ Filter: requestId=a3f2b1c4
 
 | Event | When | Key data |
 |-------|------|----------|
-| `answer_posted` | Bot's answer sent to Slack | channel, threadTs |
+| `answer_posted` | Bot's answer sent to Slack | channel, threadTs, chunks |
 | `issue_created` | GitHub issue created after ✅ | number |
-| `correction_saved` | User's correction saved to KB | entry (truncated) |
-| `feedback_positive` | 👍 feedback recorded | question (truncated) |
-| `feedback_negative` | 👎 analysis complete | kbFlagged, docsFlagged |
 | `followup_agent_start` | Thread follow-up triggering agent | channel, threadTs |
+
+### Feedback Events (route.ts) — #114
+
+Every reaction flows through this event funnel. `reaction_skipped` and `feedback_saved` are **mutually exclusive outcomes** of a given `reaction_received`. When diagnosing "my 👍 did nothing", filter for `reaction_skipped` with the user's `reactingUser` first — silent drops used to be invisible and are now fully logged.
+
+| Event | When | Key data |
+|-------|------|----------|
+| `reaction_skipped` | The handler decided to drop the reaction | reaction, reason (`non_message_item` / `bot_own_reaction` / `target_not_bot_message` / `no_qa_context`), targetTs, channel |
+| `feedback_saved` | A 👍 or 👎 passed validation and was recorded | type, answerTs, chunkIndex, chunkCount, latencyMs, referenceCount, referenceTypes, questionLength, answerLength, questionSample |
+| `feedback_ack_added` | The 🧠 ack reaction posted back to the user | reactionName, chunkTs |
+| `feedback_ack_failed` | The 🧠 ack was rejected by Slack | reason (`already_reacted` / `permission_denied` / `unknown`), chunkTs, errMsg |
+| `correction_pending` | 👎 created a pending-correction KV record; user prompted for the correction text | channel, threadTs, answerTs, flaggedKBCount, flaggedDocCount, ttlSec |
+| `correction_saved` | User replied with a correction; entry saved to KB and funnel closed | channel, threadTs, answerTs, correctionLength, timeSincePendingMs, flaggedKBCount, correctionSample |
+
+**The `answerTs` field** is the stable identifier for the whole answer — equal to chunk 0's TS regardless of which chunk the user reacted on. Use it to join reaction events across the same answer (e.g. to see if the user reacted on chunk 1 and also replied with a correction later).
+
+### Useful queries
+
+- **Silent-drop rate:** `count(reaction_skipped) / count(reaction_received)` — should be low in steady state; a spike in `no_qa_context` indicates either stale Q&A records (>7-day TTL) or a bug.
+- **Chunk-reaction distribution:** `feedback_saved.chunkIndex` bucketed — if users reliably react on chunk 1+, the compact-answer prompt isn't working; if they only react on chunk 0, the 2-chunk marker-drop heuristic is fine.
+- **👎 funnel completion:** `count(correction_saved) / count(correction_pending)` — low means users don't follow through; consider shortening the pending TTL or changing the prompt.
+- **Feedback feature value:** correlate `prompt_feedback_included.totalEntries > 0` turns with subsequent `feedback_saved.type = "positive"` rates — does having feedback in context correlate with higher-quality answers?
+- **Reaction latency:** bucket `feedback_saved.latencyMs` — immediate reactions (<30s) are higher signal than day-later reactions.
 
 ### Error Events (all flows)
 
@@ -126,7 +146,19 @@ If you see `index_cache_hit` on every request, the SHA hasn't changed since the 
 
 ### "Feedback not working"
 
-After a 👍/👎, look for `feedback_positive`/`feedback_negative` events. If missing, the Q&A context may have expired (7-day TTL) or the reacted-to message wasn't a bot answer.
+First check the reaction funnel — a feedback event that never resulted in action now always leaves a log:
+
+1. Search for `reaction_received` with the user's `reactingUser` and the approximate time.
+2. Look for a matching `feedback_saved` (success) or `reaction_skipped` (drop).
+   - `reason: "no_qa_context"` → the reacted-on message has no stored Q&A context. Either it's not an answer chunk, or the 7-day TTL expired. Post-#114, Q&A is stored against every chunk of a split answer.
+   - `reason: "bot_own_reaction"` → the bot reacted to itself; benign.
+   - `reason: "target_not_bot_message"` → the user reacted on a human message; benign.
+3. If `feedback_saved` fired but the user didn't see a 🧠 ack, look for `feedback_ack_failed` — usually `already_reacted`, which is benign.
+
+For the 👎 correction funnel specifically, expect `correction_pending` immediately after `feedback_saved` (type=negative), and `correction_saved` only if the user typed a reply within 24h.
+
+
+After a 👍/👎, look for a `feedback_saved` event with the matching `type`. If missing, look for `reaction_skipped` with the reason — the Q&A context may have expired (7-day TTL), the reacted-to message may not be a bot answer, or the bot reacted to its own message (`bot_own_reaction`). See the "Feedback Events" section above for the full funnel.
 
 ## Implementation
 

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -14,7 +14,7 @@ import {
 import { runAgent } from "@/lib/claude";
 import { createIssue } from "@/lib/github";
 import { parseProposalFromMessage } from "@/tools/create-issue";
-import { storeQAContext, getQAContext, saveFeedback } from "@/lib/feedback";
+import { storeQAContext, getQAContext, saveFeedback, deriveReferenceTypes } from "@/lib/feedback";
 import { formatReferences, rankReferences } from "@/lib/references";
 import { getAllKnowledge } from "@/lib/knowledge";
 import { buildCorrectionActions } from "@/lib/auto-correct";
@@ -209,13 +209,25 @@ export async function POST(request: NextRequest) {
           if (posted.chunks > 0) thinkingTs = undefined;
           rlog("answer_posted", { channel, threadTs, chunks: posted.chunks });
 
-          // Store Q&A context so 👍/👎 reactions can reference it
-          if (posted.firstTs) {
-            await storeQAContext(channel, posted.firstTs, {
-              question: cleanMessage,
-              answer: result.text.slice(0, 500),
-              references: result.references.map((r) => r.label),
-            });
+          // Store Q&A context for EVERY chunk ts (see #114). Reactions
+          // on any chunk resolve to the same question/answer pair.
+          if (posted.firstTs && posted.allTs.length > 0) {
+            const postedAt = Date.now();
+            const referenceTypes = deriveReferenceTypes(result.references);
+            await Promise.all(
+              posted.allTs.map((ts, chunkIndex) =>
+                storeQAContext(channel, ts, {
+                  question: cleanMessage,
+                  answer: result.text.slice(0, 500),
+                  references: result.references.map((r) => r.label),
+                  answerTs: posted.firstTs!,
+                  chunkIndex,
+                  chunkCount: posted.chunks,
+                  postedAt,
+                  referenceTypes,
+                }),
+              ),
+            );
           }
         }
       } catch (err) {
@@ -292,7 +304,20 @@ export async function POST(request: NextRequest) {
 
           // Clear the pending state
           await kv.del(pendingKey);
-          rlog("correction_saved", { entry: userMessage.slice(0, 100) });
+          // Close the 👎 → correction funnel with latency from the
+          // moment 👎 was registered. `pendingAt` was added to the KV
+          // record when the pending state was created (see reaction_thumbsdown
+          // handler); fall back to 0 for records written before that.
+          const pendingAt: number = typeof pending.pendingAt === "number" ? pending.pendingAt : 0;
+          rlog("correction_saved", {
+            channel,
+            threadTs,
+            answerTs: pending.answerTs ?? null,
+            correctionLength: userMessage.length,
+            timeSincePendingMs: pendingAt > 0 ? Date.now() - pendingAt : null,
+            flaggedKBCount: Array.isArray(pending.flaggedKB) ? pending.flaggedKB.length : 0,
+            correctionSample: userMessage.slice(0, 100),
+          });
 
           await replyInThread(
             channel,
@@ -395,12 +420,23 @@ export async function POST(request: NextRequest) {
           if (posted.chunks > 0) thinkTs = undefined;
           rlog("answer_posted", { channel, threadTs, chunks: posted.chunks });
 
-          if (posted.firstTs) {
-            await storeQAContext(channel, posted.firstTs, {
-              question: cleanMessage,
-              answer: result.text.slice(0, 500),
-              references: result.references.map((r) => r.label),
-            });
+          if (posted.firstTs && posted.allTs.length > 0) {
+            const postedAt = Date.now();
+            const referenceTypes = deriveReferenceTypes(result.references);
+            await Promise.all(
+              posted.allTs.map((ts, chunkIndex) =>
+                storeQAContext(channel, ts, {
+                  question: cleanMessage,
+                  answer: result.text.slice(0, 500),
+                  references: result.references.map((r) => r.label),
+                  answerTs: posted.firstTs!,
+                  chunkIndex,
+                  chunkCount: posted.chunks,
+                  postedAt,
+                  referenceTypes,
+                }),
+              ),
+            );
           }
         }
       } catch (err) {
@@ -494,23 +530,43 @@ export async function POST(request: NextRequest) {
   // ── Handle 👍 reaction → save positive feedback ─────────────────────
   if (event.type === "reaction_added" && event.reaction === "+1") {
     const item = event.item;
-    if (item?.type !== "message") return NextResponse.json({ ok: true });
-
-    const channel: string = item.channel;
-    const messageTs: string = item.ts;
-    rlog("reaction_thumbsup", { channel, messageTs });
+    const channel: string = item?.channel;
+    const messageTs: string = item?.ts;
+    rlog("reaction_received", {
+      reaction: "+1",
+      reactingUser: event.user,
+      targetTs: messageTs,
+      channel,
+    });
+    if (item?.type !== "message") {
+      rlog("reaction_skipped", {
+        reaction: "+1",
+        reason: "non_message_item",
+        targetTs: messageTs,
+        channel,
+      });
+      return NextResponse.json({ ok: true });
+    }
 
     after(async () => {
       try {
         const botId = await getBotUserId();
-        if (botId && event.user === botId) return;
+        if (botId && event.user === botId) {
+          rlog("reaction_skipped", { reaction: "+1", reason: "bot_own_reaction", targetTs: messageTs, channel });
+          return;
+        }
 
-        // Only act on bot messages
         const msg = await fetchMessage(channel, messageTs);
-        if (!msg || msg.user !== botId) return;
+        if (!msg || msg.user !== botId) {
+          rlog("reaction_skipped", { reaction: "+1", reason: "target_not_bot_message", targetTs: messageTs, channel });
+          return;
+        }
 
         const context = await getQAContext(channel, messageTs);
-        if (!context) return; // No Q&A context — probably not an answer message
+        if (!context) {
+          rlog("reaction_skipped", { reaction: "+1", reason: "no_qa_context", targetTs: messageTs, channel });
+          return;
+        }
 
         await saveFeedback({
           type: "positive",
@@ -518,13 +574,36 @@ export async function POST(request: NextRequest) {
           detail: `👍 for: "${context.question.slice(0, 80)}" — used: ${context.references.join(", ") || "general knowledge"}`,
           timestamp: new Date().toISOString().split("T")[0],
         });
-        rlog("feedback_positive", { question: context.question.slice(0, 80) });
+        rlog("feedback_saved", {
+          type: "positive",
+          answerTs: context.answerTs,
+          chunkIndex: context.chunkIndex,
+          chunkCount: context.chunkCount,
+          latencyMs: Date.now() - context.postedAt,
+          referenceCount: context.references.length,
+          referenceTypes: context.referenceTypes,
+          questionLength: context.question.length,
+          answerLength: context.answer.length,
+          questionSample: context.question.slice(0, 80),
+        });
 
-        // Silent acknowledgment — just add a checkmark reaction
+        // Reaction ack — emit success/failure so "already_reacted" and
+        // permission errors are no longer silent.
         try {
           const { slack } = await import("@/lib/slack");
           await slack.reactions.add({ channel, name: "brain", timestamp: messageTs });
-        } catch { /* already reacted or can't react — ignore */ }
+          rlog("feedback_ack_added", { reactionName: "brain", chunkTs: messageTs });
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          // Slack returns specific error codes via @slack/web-api — bucket
+          // them for metric-friendliness.
+          const reason = errMsg.includes("already_reacted")
+            ? "already_reacted"
+            : errMsg.includes("not_in_channel") || errMsg.includes("missing_scope")
+            ? "permission_denied"
+            : "unknown";
+          rlog("feedback_ack_failed", { reason, chunkTs: messageTs, errMsg: errMsg.slice(0, 120) });
+        }
       } catch (err) {
         rlog("error", { flow: "reaction_thumbsup", message: err instanceof Error ? err.message : String(err) });
         Sentry.captureException(err, { tags: { flow: "reaction_thumbsup" } });
@@ -539,54 +618,109 @@ export async function POST(request: NextRequest) {
   // ── Handle 👎 reaction → ask for correction, save negative feedback ─
   if (event.type === "reaction_added" && event.reaction === "-1") {
     const item = event.item;
-    if (item?.type !== "message") return NextResponse.json({ ok: true });
-
-    const channel: string = item.channel;
-    const messageTs: string = item.ts;
-    rlog("reaction_thumbsdown", { channel, messageTs });
+    const channel: string = item?.channel;
+    const messageTs: string = item?.ts;
+    rlog("reaction_received", {
+      reaction: "-1",
+      reactingUser: event.user,
+      targetTs: messageTs,
+      channel,
+    });
+    if (item?.type !== "message") {
+      rlog("reaction_skipped", {
+        reaction: "-1",
+        reason: "non_message_item",
+        targetTs: messageTs,
+        channel,
+      });
+      return NextResponse.json({ ok: true });
+    }
 
     after(async () => {
       try {
         const botId = await getBotUserId();
-        if (botId && event.user === botId) return;
+        if (botId && event.user === botId) {
+          rlog("reaction_skipped", { reaction: "-1", reason: "bot_own_reaction", targetTs: messageTs, channel });
+          return;
+        }
 
         const msg = await fetchMessage(channel, messageTs);
-        if (!msg || msg.user !== botId) return;
+        if (!msg || msg.user !== botId) {
+          rlog("reaction_skipped", { reaction: "-1", reason: "target_not_bot_message", targetTs: messageTs, channel });
+          return;
+        }
 
         const context = await getQAContext(channel, messageTs);
-        if (!context) return;
+        if (!context) {
+          rlog("reaction_skipped", { reaction: "-1", reason: "no_qa_context", targetTs: messageTs, channel });
+          return;
+        }
 
         const threadTs = msg.thread_ts || messageTs;
 
-        // Flag possibly related KB entries and docs (don't auto-remove)
+        // Flag possibly related KB entries and docs (don't auto-remove).
         const kbEntries = await getAllKnowledge();
         const actions = buildCorrectionActions(context.references, kbEntries);
-        rlog("feedback_negative", { kbFlagged: actions.kbEntriesToFlag.length, docsFlagged: actions.docsToProposeFix.length });
+
+        await saveFeedback({
+          type: "negative",
+          question: context.question,
+          detail: `👎 for: "${context.question.slice(0, 80)}" — flagged KB entries: ${actions.kbEntriesToFlag.length}, docs: ${actions.docsToProposeFix.length}`,
+          timestamp: new Date().toISOString().split("T")[0],
+        });
+        rlog("feedback_saved", {
+          type: "negative",
+          answerTs: context.answerTs,
+          chunkIndex: context.chunkIndex,
+          chunkCount: context.chunkCount,
+          latencyMs: Date.now() - context.postedAt,
+          referenceCount: context.references.length,
+          referenceTypes: context.referenceTypes,
+          questionLength: context.question.length,
+          answerLength: context.answer.length,
+          questionSample: context.question.slice(0, 80),
+        });
 
         const notes: string[] = [];
-
         if (actions.kbEntriesToFlag.length > 0) {
           notes.push("*Possibly related KB entries* (reply to confirm removal):");
           for (const entry of actions.kbEntriesToFlag) {
             notes.push(`  • _"${entry.entry}"_`);
           }
         }
-
         if (actions.docsToProposeFix.length > 0) {
           const docList = actions.docsToProposeFix.map((d) => `\`${d}\``).join(", ");
           notes.push(`*Docs referenced:* ${docList}`);
         }
-
         const flagText = notes.length > 0 ? `\n\n${notes.join("\n")}` : "";
 
-        // Store pending correction state so the next reply is saved as a KB correction
+        // Store pending correction state so the next reply is saved as a
+        // KB correction. Include a `pendingAt` timestamp so the
+        // correction_saved event can compute timeSincePendingMs when the
+        // user replies (closes the 👎 funnel).
         const pendingKey = `pending-correction:${channel}:${threadTs}`;
+        const pendingAt = Date.now();
+        const ttlSec = 86400;
         const { kv } = await import("@vercel/kv");
-        await kv.set(pendingKey, JSON.stringify({
-          question: context.question,
-          references: context.references,
-          flaggedKB: actions.kbEntriesToFlag.map((e) => e.entry),
-        }), { ex: 86400 }); // 24h TTL
+        await kv.set(
+          pendingKey,
+          JSON.stringify({
+            question: context.question,
+            references: context.references,
+            flaggedKB: actions.kbEntriesToFlag.map((e) => e.entry),
+            pendingAt,
+            answerTs: context.answerTs,
+          }),
+          { ex: ttlSec },
+        );
+        rlog("correction_pending", {
+          channel,
+          threadTs,
+          answerTs: context.answerTs,
+          flaggedKBCount: actions.kbEntriesToFlag.length,
+          flaggedDocCount: actions.docsToProposeFix.length,
+          ttlSec,
+        });
 
         await replyInThread(
           channel,

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -3,7 +3,7 @@ import { tools, executeTool, type ToolResult, type Reference } from "@/tools";
 import type { IssueProposal } from "@/tools/create-issue";
 import { readFile } from "@/lib/github";
 import { getKnowledgeAsMarkdown } from "@/lib/knowledge";
-import { getFeedbackAsMarkdown } from "@/lib/feedback";
+import { getFeedbackSummary } from "@/lib/feedback";
 import {
   getOrRebuildIndex,
   getCachedConfig,
@@ -448,7 +448,7 @@ export function assembleSystemBlocks(inputs: PromptInputs): Anthropic.TextBlockP
 // ── Async wrapper that fetches data then assembles ────────────────────
 async function buildSystemBlocks(
   participants?: Participant[],
-): Promise<Anthropic.TextBlockParam[]> {
+): Promise<{ blocks: Anthropic.TextBlockParam[]; feedbackMeta: { positiveCount: number; negativeCount: number; totalEntries: number } }> {
   // Fetch index + doc catalog in parallel. Both are KV-reads on the warm
   // path; rebuild on cold path is already time-bounded inside
   // getOrRebuildIndex. getDocCatalog is KV-only and never triggers a
@@ -456,22 +456,29 @@ async function buildSystemBlocks(
   // effect, so the order of these two calls here doesn't matter for
   // correctness (cold-start will either get an empty catalog or the
   // just-built one depending on timing; both are safe).
-  const [repoIndex, config, docCatalog] = await Promise.all([
+  const [repoIndex, config, docCatalog, feedbackSummary] = await Promise.all([
     getOrRebuildIndex(),
     getCachedConfig(),
     getDocCatalog(),
+    getFeedbackSummary(),
   ]);
-  return assembleSystemBlocks({
+  const blocks = assembleSystemBlocks({
     owner: process.env.GITHUB_OWNER,
     repo: process.env.GITHUB_REPO,
     claudeMd: await getClaudeMd(),
     knowledge: await getKnowledge(),
-    feedback: await getFeedbackAsMarkdown(),
+    feedback: feedbackSummary?.markdown ?? null,
     repoIndex,
     pathAnnotations: Object.keys(config.paths).length > 0 ? config : null,
     participants,
     docCatalog,
   });
+  const feedbackMeta = {
+    positiveCount: feedbackSummary?.positiveCount ?? 0,
+    negativeCount: feedbackSummary?.negativeCount ?? 0,
+    totalEntries: feedbackSummary?.totalEntries ?? 0,
+  };
+  return { blocks, feedbackMeta };
 }
 
 // ── Agent loop: message → tool calls → final answer ───────────────────
@@ -552,7 +559,7 @@ export async function runAgent(
   let issueProposal: IssueProposal | undefined;
   const allReferences: Reference[] = [];
   const startTime = Date.now();
-  const systemBlocks = await buildSystemBlocks(participants);
+  const { blocks: systemBlocks, feedbackMeta } = await buildSystemBlocks(participants);
   const promptLength = systemBlocks.reduce((n, b) => n + b.text.length, 0);
 
   _log("agent_start", {
@@ -560,6 +567,11 @@ export async function runAgent(
     question: userMessage.slice(0, 100),
     model: MODEL,
   });
+  // Observability (#114): emit how much feedback context the model saw
+  // this turn. Fires on every turn (even when totalEntries === 0) so we
+  // can compute "feedback-present" vs "feedback-absent" turn ratios
+  // when correlating with downstream reactions.
+  _log("prompt_feedback_included", { ...feedbackMeta, promptZone: "volatile" });
 
   let warned = false;
   let contextWarned = false;

--- a/src/lib/feedback.test.ts
+++ b/src/lib/feedback.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveReferenceTypes,
+  formatFeedbackSummary,
+  type FeedbackEntry,
+  type QAContext,
+} from "./feedback";
+import type { Reference } from "@/tools";
+
+describe("deriveReferenceTypes", () => {
+  it("returns empty array for empty input", () => {
+    expect(deriveReferenceTypes([])).toEqual([]);
+  });
+
+  it("returns unique types sorted alphabetically", () => {
+    const refs: Reference[] = [
+      { label: "src/a.ts", url: "u1", type: "file" },
+      { label: "docs/b.md", url: "u2", type: "doc" },
+      { label: "src/c.ts", url: "u3", type: "file" },
+      { label: "#42", url: "u4", type: "issue" },
+    ];
+    expect(deriveReferenceTypes(refs)).toEqual(["doc", "file", "issue"]);
+  });
+
+  it("dedupes across identical types", () => {
+    const refs: Reference[] = [
+      { label: "#1", url: "u1", type: "issue" },
+      { label: "#2", url: "u2", type: "issue" },
+      { label: "#3", url: "u3", type: "issue" },
+    ];
+    expect(deriveReferenceTypes(refs)).toEqual(["issue"]);
+  });
+
+  it("handles all five type values", () => {
+    const refs: Reference[] = [
+      { label: "a", url: "u", type: "file" },
+      { label: "b", url: "u", type: "doc" },
+      { label: "c", url: "u", type: "issue" },
+      { label: "d", url: "u", type: "pr" },
+      { label: "e", url: "u", type: "commit" },
+    ];
+    expect(deriveReferenceTypes(refs)).toEqual(["commit", "doc", "file", "issue", "pr"]);
+  });
+});
+
+describe("formatFeedbackSummary", () => {
+  const mkEntry = (type: "positive" | "negative", i: number): FeedbackEntry => ({
+    type,
+    question: `question ${i}`,
+    detail: `detail ${i}`,
+    timestamp: "2026-04-22",
+  });
+
+  it("returns null when no entries", () => {
+    expect(formatFeedbackSummary([])).toBeNull();
+  });
+
+  it("counts positive and negative entries separately", () => {
+    const entries: FeedbackEntry[] = [
+      mkEntry("positive", 1),
+      mkEntry("positive", 2),
+      mkEntry("negative", 3),
+    ];
+    const summary = formatFeedbackSummary(entries);
+    expect(summary).not.toBeNull();
+    expect(summary!.positiveCount).toBe(2);
+    expect(summary!.negativeCount).toBe(1);
+    expect(summary!.totalEntries).toBe(3);
+  });
+
+  it("renders the positive section only when positives exist", () => {
+    const entries = [mkEntry("positive", 1)];
+    const summary = formatFeedbackSummary(entries)!;
+    expect(summary.markdown).toMatch(/What worked well/i);
+    expect(summary.markdown).not.toMatch(/needed correction/i);
+  });
+
+  it("renders the negative section only when negatives exist", () => {
+    const entries = [mkEntry("negative", 1)];
+    const summary = formatFeedbackSummary(entries)!;
+    expect(summary.markdown).toMatch(/needed correction/i);
+    expect(summary.markdown).not.toMatch(/What worked well/i);
+  });
+
+  it("caps at 30 entries but counts are post-cap", () => {
+    // Pass 40 entries; only first 30 get rendered. Counts reflect what
+    // WENT INTO the prompt, not raw storage.
+    const entries = Array.from({ length: 40 }, (_, i) =>
+      mkEntry(i % 2 === 0 ? "positive" : "negative", i),
+    );
+    const summary = formatFeedbackSummary(entries)!;
+    // 30 entries rendered, with index 0..29 → 15 positive (even) + 15 negative (odd)
+    expect(summary.totalEntries).toBe(30);
+    expect(summary.positiveCount).toBe(15);
+    expect(summary.negativeCount).toBe(15);
+  });
+
+  it("preserves insertion order within each section", () => {
+    const entries = [mkEntry("positive", 1), mkEntry("positive", 2)];
+    const summary = formatFeedbackSummary(entries)!;
+    const idx1 = summary.markdown.indexOf("question 1");
+    const idx2 = summary.markdown.indexOf("question 2");
+    expect(idx1).toBeGreaterThan(-1);
+    expect(idx2).toBeGreaterThan(idx1);
+  });
+});
+
+describe("QAContext schema", () => {
+  // The type is the contract — this test pins all fields so a future
+  // refactor removing one breaks here first.
+  it("has all required observability fields", () => {
+    const ctx: QAContext = {
+      question: "q",
+      answer: "a",
+      references: ["f1"],
+      answerTs: "1234.5678",
+      chunkIndex: 0,
+      chunkCount: 1,
+      postedAt: 1234567890,
+      referenceTypes: ["file"],
+    };
+    expect(ctx.answerTs).toBe("1234.5678");
+    expect(ctx.chunkIndex).toBe(0);
+    expect(ctx.chunkCount).toBe(1);
+    expect(ctx.postedAt).toBe(1234567890);
+    expect(ctx.referenceTypes).toEqual(["file"]);
+  });
+});

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -1,4 +1,5 @@
 import { kv } from "@vercel/kv";
+import type { Reference } from "@/tools";
 
 /**
  * Feedback System — Vercel KV storage
@@ -7,18 +8,29 @@ import { kv } from "@vercel/kv";
  * Feedback shapes future answers via the system prompt.
  *
  * Two data structures:
- * 1. "feedback:context:{channel}:{ts}" — stores the Q&A context for each bot message
- * 2. "feedback:entries" — sorted set of feedback entries (like knowledge base)
+ * 1. "feedback:context:{channel}:{ts}" — stores the Q&A context for each
+ *     bot-posted chunk. Multi-chunk answers write one record per chunk
+ *     TS so reactions on ANY chunk resolve to the same answer context
+ *     (see #114).
+ * 2. "feedback:entries" — sorted set of feedback entries (like knowledge
+ *     base); rendered into the system prompt to shape future answers.
  */
 
 const CONTEXT_PREFIX = "feedback:context";
 const FEEDBACK_KEY = "feedback:entries";
 const CONTEXT_TTL = 86400 * 7; // 7 days — after that, reactions are ignored
+const MAX_FEEDBACK_ENTRIES_IN_PROMPT = 30;
 
 export interface QAContext {
   question: string;
   answer: string;
   references: string[]; // file paths or issue numbers accessed
+  // ── Observability + cross-chunk reaction resolution (#114) ──────────
+  answerTs: string; // chunk 0 ts — stable identifier for the whole answer
+  chunkIndex: number; // 0-based position of the chunk this record indexes
+  chunkCount: number; // total chunks posted for this answer
+  postedAt: number; // Date.now() at post time — used to compute reaction latency
+  referenceTypes: string[]; // ["file","doc","issue",...] derived from the Reference[]
 }
 
 export interface FeedbackEntry {
@@ -28,8 +40,30 @@ export interface FeedbackEntry {
   timestamp: string;
 }
 
+export interface FeedbackSummary {
+  markdown: string;
+  positiveCount: number;
+  negativeCount: number;
+  totalEntries: number; // count of entries actually included (post-cap)
+}
+
 /**
- * Store the Q&A context for a bot message so we can retrieve it on reaction.
+ * Derive the set of reference TYPES present in a Reference[] — sorted
+ * unique types. Used for observability events to bucket "what kinds of
+ * sources produced feedback-worthy answers".
+ *
+ * Pure function.
+ */
+export function deriveReferenceTypes(refs: Reference[]): string[] {
+  const unique = new Set<string>();
+  for (const r of refs) unique.add(r.type);
+  return [...unique].sort();
+}
+
+/**
+ * Store the Q&A context for a single chunk's TS. Callers are expected
+ * to invoke this once per chunk when splitting a long answer; each call
+ * passes the same shared context with its own `chunkIndex`.
  */
 export async function storeQAContext(
   channel: string,
@@ -41,7 +75,10 @@ export async function storeQAContext(
 }
 
 /**
- * Retrieve the Q&A context for a bot message.
+ * Retrieve the Q&A context for a bot message. Returns the context
+ * whether the user reacted on chunk 0 or a later chunk — all chunks of
+ * the same answer share the same question/answer/references but carry
+ * their own chunkIndex.
  */
 export async function getQAContext(
   channel: string,
@@ -68,11 +105,53 @@ export async function saveFeedback(entry: FeedbackEntry): Promise<void> {
   });
 }
 
+// ── Pure formatter (extracted so it's unit-testable) ──────────────────
+// Returns the prompt markdown plus counts — emit the counts as an
+// observability event from the caller so we can see per-turn how much
+// feedback context the model saw.
+export function formatFeedbackSummary(
+  entries: FeedbackEntry[],
+): FeedbackSummary | null {
+  if (entries.length === 0) return null;
+
+  // Cap BEFORE counting so counts reflect what went into the prompt,
+  // not raw storage.
+  const capped = entries.slice(0, MAX_FEEDBACK_ENTRIES_IN_PROMPT);
+
+  const positives = capped.filter((e) => e.type === "positive");
+  const negatives = capped.filter((e) => e.type === "negative");
+
+  const lines: string[] = [];
+  if (positives.length > 0) {
+    lines.push("*What worked well (do more of this):*");
+    for (const e of positives) {
+      lines.push(`- [${e.timestamp}] Q: "${e.question.slice(0, 80)}" → ${e.detail}`);
+    }
+  }
+  if (negatives.length > 0) {
+    if (lines.length > 0) lines.push("");
+    lines.push("*What needed correction (avoid repeating):*");
+    for (const e of negatives) {
+      lines.push(`- [${e.timestamp}] Q: "${e.question.slice(0, 80)}" → ${e.detail}`);
+    }
+  }
+
+  return {
+    markdown: lines.join("\n"),
+    positiveCount: positives.length,
+    negativeCount: negatives.length,
+    totalEntries: capped.length,
+  };
+}
+
 /**
- * Get all feedback entries formatted as markdown for the system prompt.
- * Returns null if no entries exist.
+ * Fetch feedback entries from KV and return a summary suitable for both
+ * prompt injection and observability logging. Callers should emit a
+ * `prompt_feedback_included` log event with the returned counts.
+ *
+ * Returns null if no entries exist (nothing to inject).
  */
-export async function getFeedbackAsMarkdown(): Promise<string | null> {
+export async function getFeedbackSummary(): Promise<FeedbackSummary | null> {
   try {
     const raw = await kv.zrange(FEEDBACK_KEY, 0, -1, { rev: true });
     const entries = (raw as string[]).map((item) => {
@@ -82,34 +161,18 @@ export async function getFeedbackAsMarkdown(): Promise<string | null> {
         return null;
       }
     }).filter(Boolean) as FeedbackEntry[];
-
-    if (entries.length === 0) return null;
-
-    // Limit to most recent 30 entries to keep prompt size manageable
-    const recent = entries.slice(0, 30);
-
-    const positives = recent.filter((e) => e.type === "positive");
-    const negatives = recent.filter((e) => e.type === "negative");
-
-    const lines: string[] = [];
-
-    if (positives.length > 0) {
-      lines.push("*What worked well (do more of this):*");
-      for (const e of positives) {
-        lines.push(`- [${e.timestamp}] Q: "${e.question.slice(0, 80)}" → ${e.detail}`);
-      }
-    }
-
-    if (negatives.length > 0) {
-      if (lines.length > 0) lines.push("");
-      lines.push("*What needed correction (avoid repeating):*");
-      for (const e of negatives) {
-        lines.push(`- [${e.timestamp}] Q: "${e.question.slice(0, 80)}" → ${e.detail}`);
-      }
-    }
-
-    return lines.join("\n");
+    return formatFeedbackSummary(entries);
   } catch {
     return null;
   }
+}
+
+/**
+ * Back-compat shim for callers that only want the markdown (e.g.
+ * assembleSystemPrompt in claude.ts). New callers should prefer
+ * `getFeedbackSummary()` so they can surface the counts.
+ */
+export async function getFeedbackAsMarkdown(): Promise<string | null> {
+  const summary = await getFeedbackSummary();
+  return summary?.markdown ?? null;
 }

--- a/src/lib/slack.test.ts
+++ b/src/lib/slack.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   requireSlackMessageText,
   SLACK_MESSAGE_CHAR_LIMIT,
   SlackMessageOversizeError,
+  postReplyInChunks,
+  slack,
 } from "./slack";
 
 describe("requireSlackMessageText (fail-loud boundary guard)", () => {
@@ -64,5 +66,84 @@ describe("requireSlackMessageText (fail-loud boundary guard)", () => {
     expect(() => requireSlackMessageText(overText, "chat.postMessage")).toThrow(
       SlackMessageOversizeError,
     );
+  });
+});
+
+// ── Multi-chunk delivery (#114) ──────────────────────────────────────
+describe("postReplyInChunks returns every posted TS", () => {
+  let postCounter = 0;
+
+  beforeEach(() => {
+    postCounter = 0;
+    vi.spyOn(slack.chat, "postMessage").mockImplementation(
+      (async () => ({ ok: true, ts: `9999.${postCounter++}` })) as never,
+    );
+    vi.spyOn(slack.chat, "update").mockResolvedValue({ ok: true } as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns empty allTs for empty text", async () => {
+    const result = await postReplyInChunks({ channel: "C1", threadTs: "T1", text: "" });
+    expect(result.chunks).toBe(0);
+    expect(result.firstTs).toBeUndefined();
+    expect(result.allTs).toEqual([]);
+  });
+
+  it("single-chunk (with thinkingTs) returns the thinkingTs in allTs", async () => {
+    const result = await postReplyInChunks({
+      channel: "C1",
+      threadTs: "T1",
+      thinkingTs: "THINK.1",
+      text: "short answer",
+    });
+    expect(result.chunks).toBe(1);
+    expect(result.firstTs).toBe("THINK.1");
+    expect(result.allTs).toEqual(["THINK.1"]);
+  });
+
+  it("single-chunk (no thinkingTs) returns the newly-posted TS", async () => {
+    const result = await postReplyInChunks({
+      channel: "C1",
+      threadTs: "T1",
+      text: "short answer",
+    });
+    expect(result.chunks).toBe(1);
+    expect(result.firstTs).toBe("9999.0");
+    expect(result.allTs).toEqual(["9999.0"]);
+  });
+
+  it("multi-chunk returns thinkingTs as chunk 0 plus every new-reply TS", async () => {
+    // Force a 3-chunk split with a large body (>> default 3K).
+    const bigText = "x".repeat(8_500);
+    const result = await postReplyInChunks({
+      channel: "C1",
+      threadTs: "T1",
+      thinkingTs: "THINK.1",
+      text: bigText,
+    });
+    expect(result.chunks).toBeGreaterThanOrEqual(3);
+    expect(result.firstTs).toBe("THINK.1");
+    expect(result.allTs[0]).toBe("THINK.1");
+    // Subsequent chunks are fresh posts with TS from the counter
+    expect(result.allTs.length).toBe(result.chunks);
+    for (let i = 1; i < result.chunks; i++) {
+      expect(result.allTs[i]).toMatch(/^9999\.\d+$/);
+    }
+    // Crucially: allTs contains UNIQUE values so per-chunk KV writes
+    // don't collide on the same key.
+    expect(new Set(result.allTs).size).toBe(result.allTs.length);
+  });
+
+  it("allTs length matches chunks exactly (no orphans, no dupes)", async () => {
+    const bigText = "y".repeat(7_000);
+    const result = await postReplyInChunks({
+      channel: "C1",
+      threadTs: "T1",
+      text: bigText,
+    });
+    expect(result.allTs.length).toBe(result.chunks);
   });
 });

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -123,13 +123,26 @@ export interface PostReplyInChunksInput {
   text: string;
 }
 
+export interface PostReplyInChunksResult {
+  // TS of chunk 0 — used as the stable "answer id" across the whole split.
+  firstTs: string | undefined;
+  // TS of every posted chunk in order (0..N-1). Callers store Q&A
+  // context against each TS so a reaction on any chunk resolves to the
+  // same answer (see #114). Empty when chunks === 0.
+  allTs: string[];
+  // Number of chunks posted. 0 if the text was empty after trim.
+  chunks: number;
+}
+
 export async function postReplyInChunks(
   input: PostReplyInChunksInput,
-): Promise<{ firstTs: string | undefined; chunks: number }> {
+): Promise<PostReplyInChunksResult> {
   const chunks = splitSlackReplyText(input.text);
   if (chunks.length === 0) {
-    return { firstTs: undefined, chunks: 0 };
+    return { firstTs: undefined, allTs: [], chunks: 0 };
   }
+
+  const allTs: string[] = [];
 
   const first = chunks[0] ?? "";
   let firstTs: string | undefined;
@@ -140,14 +153,16 @@ export async function postReplyInChunks(
   } else {
     firstTs = await replyInThread(input.channel, input.threadTs, first);
   }
+  if (firstTs) allTs.push(firstTs);
 
   // Remaining chunks post as fresh thread replies in order.
   for (let i = 1; i < chunks.length; i++) {
     const chunk = chunks[i] ?? "";
-    await replyInThread(input.channel, input.threadTs, chunk);
+    const ts = await replyInThread(input.channel, input.threadTs, chunk);
+    if (ts) allTs.push(ts);
   }
 
-  return { firstTs, chunks: chunks.length };
+  return { firstTs, allTs, chunks: chunks.length };
 }
 
 // ── Delete a message ──────────────────────────────────────────────────


### PR DESCRIPTION
Closes #114.

## Part 1 — Correctness

Post-#113, long answers split into multiple thread replies. The Q&A context used for 👍/👎 resolution was stored only against chunk 0's ts, so reactions on chunks 1..N silently failed — no 🧠 ack, no correction prompt, nothing.

Fix: \`postReplyInChunks\` now returns \`allTs: string[]\` alongside \`firstTs\`/\`chunks\`. The route writes one \`QAContext\` per chunk TS with the correct \`chunkIndex\`. Reaction on any chunk resolves to the same answer.

## Part 2 — Observability

Designed to answer the real questions the old logging couldn't:

| Question | Answer comes from |
|---|---|
| Do users react on non-first chunks? | \`feedback_saved.chunkIndex\` bucketed |
| How fresh is the feedback signal? | \`feedback_saved.latencyMs\` |
| How often do reactions silently drop? | \`count(reaction_skipped) / count(reaction_received)\` |
| Does the 👎 → correction funnel complete? | \`count(correction_saved) / count(correction_pending)\` |
| Does feedback in context correlate with quality? | Join \`prompt_feedback_included\` with downstream \`feedback_saved\` |

### Event taxonomy

- **reaction_received** — every \`reaction_added\` dispatch (pre-validation)
- **reaction_skipped** — every silent-drop path with \`reason\` in {\`non_message_item\`, \`bot_own_reaction\`, \`target_not_bot_message\`, \`no_qa_context\`}
- **feedback_saved** — unified positive/negative event with \`chunkIndex\`, \`chunkCount\`, \`latencyMs\`, \`referenceTypes\`, lengths
- **feedback_ack_added** / **feedback_ack_failed** — wraps the 🧠 reaction; surfaces \`already_reacted\` / \`permission_denied\` errors the old catch swallowed
- **correction_pending** → **correction_saved** — closes the 👎 funnel with \`timeSincePendingMs\`
- **prompt_feedback_included** — per-turn event in claude.ts showing how many feedback entries the model actually saw

Every feedback-domain event carries **\`answerTs\`** — chunk 0's ts — the stable identifier that joins events across all chunks of the same answer.

### Schema extension

\`QAContext\` gains \`answerTs\`, \`chunkIndex\`, \`chunkCount\`, \`postedAt\`, \`referenceTypes\`. Needed for cross-chunk reaction resolution AND the observability event fields.

## Legacy events removed

\`feedback_positive\`, \`feedback_negative\`, \`reaction_thumbsup\`, \`reaction_thumbsdown\` are replaced by the unified taxonomy. Nothing in prod parsed them by name — clean break.

## Tests

- **new** \`src/lib/feedback.test.ts\` (11 tests): \`deriveReferenceTypes\`, \`formatFeedbackSummary\`, \`QAContext\` schema pin
- **extended** \`src/lib/slack.test.ts\` (5 new tests): \`postReplyInChunks.allTs\` across single-chunk, multi-chunk, empty-input, no-duplicates
- 422/422 passing, typecheck clean

## Docs

Updated \`docs/observability.md\` with the full feedback event catalog, useful queries, and funnel-debug notes. Reference-updates in the troubleshooting section point at the new event names.

## Post-deploy validation

- [ ] Fire a 2-chunk answer, react 👍 on chunk 2 → confirm 🧠 ack + logs show \`feedback_saved { chunkIndex: 1 }\`
- [ ] React on a non-answer bot message (e.g. an old thinking msg that wasn't cleaned up) → confirm \`reaction_skipped { reason: \"no_qa_context\" }\` (silent drop is now loud)
- [ ] Check one turn's \`prompt_feedback_included\` log to validate the counts match \`feedback:entries\` in KV

## Follow-ups

- 30-day data audit → decide on Options B/C from the issue (drop positive saveFeedback / drop all saveFeedback and rely on KB)
- \`/debug\` slash command leveraging \`prompt_feedback_included\` for in-thread prompt-state inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)