### PR TITLE
fix: Explicit Sentry.flush fixes after() tail-drop (closes #98)

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -29,6 +29,14 @@ vercel logs --prod --follow # Live tail
 
 Why this works on Vercel when stdout doesn't: `@sentry/nextjs` internally calls `vercelWaitUntil(Sentry.flush())` to hold the function container open until events are transmitted. That's the same mechanism `getsentry/junior` uses on their Vercel-hosted Hono agent.
 
+### The `after()` tail-drop gotcha (#98)
+
+The SDK's auto-flush above fires at **route-handler response time** — which runs BEFORE Next.js's `after()` callbacks. Any log emitted inside `after()` (where BM does its real work: agent loop, answer post, reaction handlers, KV writes) lands in the Sentry buffer AFTER the auto-flush has already fired, and relies on the 5-second weight-timer for its next drain. Vercel often freezes the container before that timer runs — dropping the tail of the log stream.
+
+**Fix:** every `after()` body ends with `await flushLogs(rlog, "<flow>")` in its `finally` block. `flushLogs` emits `turn_end` and then explicitly calls `Sentry.flush(2000)` to drain the buffer before the container hibernates. This matches the SDK's own `flushSafelyWithTimeout` internal pattern.
+
+If you add a new `after()` callback, **you must end it with `flushLogs`** or its logs will tail-drop. The unit test at `src/lib/logger.test.ts` pins the explicit-flush behavior so accidental regression fails loudly in CI.
+
 ## Log Format
 
 Every log entry is a single JSON line:

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,4 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock @sentry/nextjs before importing the logger so flushLogs sees the
+// mocked flush. `vi.hoisted` ensures the spy exists before vi.mock runs
+// (vitest hoists vi.mock above top-level consts).
+const { flushSpy } = vi.hoisted(() => ({ flushSpy: vi.fn().mockResolvedValue(true) }));
+vi.mock("@sentry/nextjs", () => ({
+  flush: (...args: unknown[]) => flushSpy(...args),
+}));
+
 import { log, createRequestLogger, flushLogs } from "./logger";
 
 describe("log", () => {
@@ -106,6 +115,8 @@ describe("flushLogs", () => {
 
   beforeEach(() => {
     consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    flushSpy.mockClear();
+    flushSpy.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -123,20 +134,40 @@ describe("flushLogs", () => {
     expect(parsed.requestId).toBeDefined();
   });
 
-  it("yields the event loop via setImmediate before resolving", async () => {
-    // The `after()`-drop fix relies on flushLogs scheduling at least one
-    // setImmediate tick between the turn_end log and the promise
-    // resolution, so stdout can drain before Vercel hibernates the
-    // container. A regression that removes the `setImmediate` yield
-    // (e.g. switching to a sync return) must fail this test.
-    const spy = vi.spyOn(global, "setImmediate");
-    try {
-      const rlog = createRequestLogger();
-      await flushLogs(rlog, "mention");
-      expect(spy).toHaveBeenCalled();
-    } finally {
-      spy.mockRestore();
-    }
+  it("explicitly drains the Sentry buffer via Sentry.flush before resolving", async () => {
+    // Root fix for the after()-drop bug (#98): @sentry/nextjs auto-flushes
+    // on response-end, which fires BEFORE after() callbacks run. Logs
+    // emitted inside after() land in the buffer after the auto-flush
+    // and rely on the 5s weight timer — which Vercel may not give us.
+    // Calling Sentry.flush explicitly at the end of every after() body
+    // forces a drain before the container freezes.
+    const rlog = createRequestLogger();
+    await flushLogs(rlog, "mention");
+    expect(flushSpy).toHaveBeenCalled();
+  });
+
+  it("uses a 2000ms timeout — matches the SDK's own flushSafelyWithTimeout pattern", async () => {
+    const rlog = createRequestLogger();
+    await flushLogs(rlog, "mention");
+    // The SDK's own vercelWaitUntil(flushSafelyWithTimeout()) uses 2000ms.
+    // Pin that constant so a future refactor can't silently reduce it.
+    expect(flushSpy).toHaveBeenCalledWith(2000);
+  });
+
+  it("flushes AFTER emitting turn_end so the turn_end itself is in the buffer", async () => {
+    // Ordering matters: the turn_end log must be enqueued BEFORE flush
+    // runs, otherwise we drain an empty buffer and the final event
+    // still gets lost.
+    const rlog = createRequestLogger();
+    await flushLogs(rlog, "mention");
+    // Both happened; the console.log (which enqueues the log) must have
+    // been called before the flushSpy resolved.
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(flushSpy).toHaveBeenCalled();
+    // Vitest invocationCallOrder gives a monotonic id per call; lower = earlier.
+    const logOrder = consoleSpy.mock.invocationCallOrder[0];
+    const flushOrder = flushSpy.mock.invocationCallOrder[0];
+    expect(logOrder).toBeLessThan(flushOrder);
   });
 
   it("does not throw when the logger itself throws", async () => {
@@ -145,5 +176,13 @@ describe("flushLogs", () => {
     };
     // Must not reject — post-response flow depends on this invariant.
     await expect(flushLogs(throwing, "mention")).resolves.toBeUndefined();
+  });
+
+  it("does not throw when Sentry.flush rejects", async () => {
+    // If Sentry transport is broken or times out, flushLogs must still
+    // resolve — it's in a finally block of every after() callback.
+    flushSpy.mockRejectedValueOnce(new Error("sentry transport blew up"));
+    const rlog = createRequestLogger();
+    await expect(flushLogs(rlog, "mention")).resolves.toBeUndefined();
   });
 });

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -9,9 +9,23 @@
  *
  * Single sink: stdout/stderr. Sentry's consoleLoggingIntegration
  * (wired in sentry.server.config.ts) captures every console.* call and
- * ships it to Sentry's Logs UI. Sentry's SDK internally calls
- * `vercelWaitUntil(Sentry.flush())` so events emitted from inside
- * `after()` callbacks arrive reliably despite Vercel's stdout drop.
+ * ships it to Sentry's Logs UI.
+ *
+ * ### Tail-drop fix (#98)
+ *
+ * @sentry/nextjs auto-flushes via `vercelWaitUntil(flushSafelyWithTimeout())`
+ * at route-handler response time — which fires BEFORE Next.js's
+ * `after()` callbacks run. Any log emitted inside `after()` lands in
+ * the Sentry buffer AFTER the auto-flush has already fired, and relies
+ * on the 5-second weight-timer for its next drain — which Vercel may
+ * not give us before freezing the container. Result: the tail of long
+ * `after()` blocks (the `agent_complete` / `turn_end` / feedback
+ * events) would drop at ~12% of mention flows.
+ *
+ * `flushLogs()` below explicitly calls `Sentry.flush(2000)` after the
+ * final `turn_end` event so the buffer drains before the serverless
+ * function container hibernates. This matches the SDK's own
+ * `flushSafelyWithTimeout` pattern.
  *
  * Note: `sentry.server.config.ts` falls back to a hardcoded public DSN
  * when `SENTRY_DSN` is unset, so telemetry is ALWAYS shipped to Sentry
@@ -20,6 +34,8 @@
  * local dev / CI with no network path to sentry.io the SDK's transport
  * silently fails and logs degrade to stdout only.
  */
+
+import * as Sentry from "@sentry/nextjs";
 
 export function log(event: string, data?: Record<string, unknown>): void {
   const payload = { event, ...data, ts: Date.now() };
@@ -59,19 +75,33 @@ export function createRequestLogger(): RequestLogger {
 }
 
 /**
- * Emit a final `turn_end` log event and yield the Node event loop so
- * stdout drains before Vercel hibernates the function container.
+ * Emit a final `turn_end` log event and explicitly drain the Sentry
+ * buffer so any logs emitted inside this `after()` body make it off
+ * the container before it hibernates.
  *
  * Place this as the last statement in every `after()` body — ideally
  * inside a `finally` block so it runs even on errors. The `turn_end`
  * event itself acts as a canary: if it appears in production logs,
  * the flush worked and so did every earlier log in the same turn.
+ *
+ * See the file-header comment for the root cause this addresses (#98).
  */
+const FLUSH_TIMEOUT_MS = 2000;
+
 export async function flushLogs(rlog: LogFn, flow: string): Promise<void> {
   try {
     rlog("turn_end", { flow });
   } catch {
     // Never let a logging error break the post-response flow.
   }
-  await new Promise<void>((resolve) => setImmediate(resolve));
+  try {
+    // Matches the SDK's own `flushSafelyWithTimeout` pattern. Drains
+    // both console-captured logs and any `Sentry.logger.*` envelopes —
+    // they share the same buffer under `_INTERNAL_captureLog`.
+    await Sentry.flush(FLUSH_TIMEOUT_MS);
+  } catch {
+    // A failed flush must not surface as a post-response error. If
+    // Sentry is down, the turn has already completed correctly from
+    // the user's perspective.
+  }
 }


### PR DESCRIPTION
Closes #98.

## Why

Prod 7-day data on flow=mention:

| Event | Count |
|---|---|
| \`mention_start\` | 8 (baseline) |
| \`agent_start\` | 8 (early events land) |
| \`agent_complete\` | **7** |
| \`turn_end\` | **7** |

~12.5% tail-drop rate. Load-bearing for the observability we've built in #116 (feedback funnel) and #118 (KV events) — those all fire near the tail of long flows.

## The original hypothesis was wrong

Issue #98's AC proposed \`Sentry.logger.info\` dual-emit. Reading \`@sentry/nextjs\` v10.49 source: \`consoleLoggingIntegration\` and \`Sentry.logger.*\` share the same buffer (both converge in \`_INTERNAL_captureLog\`). Dual-emit would just double-buffer; same timing problem.

## Actual root cause

\`@sentry/nextjs\` auto-flushes via \`vercelWaitUntil(flushSafelyWithTimeout())\` at route-handler response time — which fires BEFORE Next.js's \`after()\` callbacks run. Logs emitted inside \`after()\` land in the buffer AFTER the auto-flush; only the 5s weight-timer might save them before Vercel freezes the container.

## Fix

\`src/lib/logger.ts\` → \`flushLogs()\` replaces the no-op \`setImmediate\` yield with \`await Sentry.flush(2000)\`, try/catch'd so it can't throw post-response. Matches the SDK's own \`flushSafelyWithTimeout\` pattern.

Every \`after()\` body in \`route.ts\` already ends with \`await flushLogs(rlog, \"<flow>\")\` in a finally block — no call-site changes needed.

## Tests

\`src/lib/logger.test.ts\`:
- **new**: \`flushLogs\` calls \`Sentry.flush()\`
- **new**: pinned at 2000ms (prevents silent reduction)
- **new**: \`turn_end\` emitted BEFORE flush (ordering)
- **new**: still resolves if \`Sentry.flush\` rejects (post-response safety)
- replaced: old \`setImmediate\`-pin test (the yield was a placebo)

445/445 passing, typecheck clean.

## Docs

\`docs/observability.md\` — new \"after() tail-drop gotcha\" subsection with the root cause + \`flushLogs\` contract, so future contributors don't reintroduce the regression when adding a new \`after()\` callback.

## Post-deploy validation

7-day window counts should equalize:
- \`count(message:*mention_start*)\`
- \`count(message:*agent_complete*)\`
- \`count(message:*turn_end*)\`

Currently 8/7/7. Expected post-merge: 8/8/8 (or whatever the true baseline).

## Related
- #116 (feedback observability — the tail events fire here)
- #118 (KV events — same)
- Source references in #98's update comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)