### PR TITLE
feat: Bulk issue creation — multi-proposal batches with single approval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ npm run dev                  # http://localhost:3000
 
 4. **Verify before asserting** — The agent uses GitHub tools to check that files, methods, and classes actually exist before referencing them. No hallucinated code references.
 
-5. **Issue creation requires confirmation** — The agent can propose a GitHub issue but NEVER creates one without explicit ✅ reaction approval in Slack.
+5. **Issue creation requires confirmation** — The agent can propose one or many GitHub issues in a single turn but NEVER creates any without explicit approval. Approval is either a ✅ reaction on the proposal message or a short thread reply like "confirm all" / "yes". See `docs/features/issue-creation.md`.
 
 6. **Thread follow-ups** — Once the bot is participating in a thread, users can send follow-up messages without re-mentioning. The bot checks for its own prior replies before responding.
 
@@ -49,6 +49,7 @@ src/
     github.ts             — Octokit client (search, read, issues, PRs, commits, tree)
     knowledge.ts          — Knowledge base (Vercel KV sorted set)
     feedback.ts           — Feedback storage (Vercel KV) and Q&A context
+    issue-batch.ts        — Pure helpers for multi-proposal formatting and bulk-confirm matching
     config.ts             — .battle-mage.json loader (path annotations with graduated trust)
     repo-index.ts         — Repository topic index (lazy rebuild on SHA change)
     auto-correct.ts       — Stale KB entry detection and doc reference flagging
@@ -80,6 +81,7 @@ docs/
     auto-correction.md    — Auto-correction on 👎 reactions
     progress-ux.md        — Live progress updates (emoji + status)
     message-splitting.md  — Long-reply chunking architecture (split-reply + boundary guard)
+    issue-creation.md     — Batch issue proposals + bulk-confirm flow
 ```
 
 ## Testing (TDD Required)

--- a/docs/features/issue-creation.md
+++ b/docs/features/issue-creation.md
@@ -1,0 +1,68 @@
+# Issue Creation
+
+Battle Mage can propose GitHub issues and — on user confirmation — file them. Proposals never turn into real issues automatically; the user must approve first.
+
+## Single vs. batch proposals
+
+The agent uses the `create_issue` tool to propose an issue. A single turn can emit **one or many** proposals:
+
+- **Single proposal** — the familiar "Proposed Issue:" block with title, labels, and full body inlined. Approved by a :white_check_mark: reaction on the message.
+- **Batch proposal (N > 1)** — a compact numbered list of titles with inline labels, no inlined bodies. Approved by either a :white_check_mark: reaction on the message OR a short thread reply like "confirm all" / "yes" / "create all" / "go ahead" / "approve all".
+
+Bodies are persisted in KV so the confirmation path can create issues without round-tripping the full body through Slack message text.
+
+## Flow
+
+1. **User asks** — e.g. "file bugs for the 8 issues you found."
+2. **Agent proposes** — the model calls `create_issue` once per proposed issue in the same turn. All proposals flow through `executeToolsInParallel` and land in `AgentResult.issueProposals` in order.
+3. **Slack route renders** — `formatBatchProposalMessage(proposals)` produces the Slack mrkdwn block:
+   - `proposals.length === 1` → legacy single-proposal format (unchanged UX)
+   - `proposals.length >= 2` → batch format (numbered list + bulk-confirm footer)
+4. **Batch persisted in KV** under two keys:
+   - `pending-issue-batch:{channel}:{firstTs}` — the canonical record (proposals, timing, requester, thread)
+   - `pending-issue-batch:thread:{channel}:{threadTs}` — pointer to `firstTs` for text-command lookup
+   - Both with a 24 h TTL.
+5. **User confirms** via one of:
+   - :white_check_mark: reaction on the proposal message — reaction handler calls `executeBatchCreation`
+   - `"confirm all"` (or synonym) in the thread — thread-followup handler calls `executeBatchCreation`
+6. **Atomic claim** — `executeBatchCreation` reads the canonical key, then `kv.del`s it. Redis DEL is atomic: only the first caller sees `deleted === 1`; racing reactions/texts see `0` and bail. No double-creation.
+7. **Parallel creation** via `Promise.allSettled` — per-issue failures do not abort the rest.
+8. **Summary reply** from `summarizeBatchResult(outcomes)` — lists created issues with links and any failures with error messages.
+
+## Bulk-confirm text matching
+
+`isBulkConfirmText(text)` is intentionally strict to avoid accidentally creating issues during normal conversation:
+
+- **Max 6 words** after whitespace/punctuation normalization.
+- **Allowlist** of short phrases: `yes`, `yes please`, `confirm`, `confirm all`, `create all`, `create them all`, `go ahead`, `approve all`, plus common variants.
+- **Disqualifier tokens** (`no`, `don't`, `only`, `just`, `this`, `#<digit>`, `issue`) reject the match even if an allowlist phrase is present. `"yes it failed"` and `"create this one"` correctly do not match.
+- Only fires when there is a pending batch in the thread. Without a pending batch, bulk-confirm phrases fall through to the normal agent flow.
+
+## Observability
+
+Lifecycle events (structured logs; same shape as `kv_op`):
+
+| Event | When | Key fields |
+|---|---|---|
+| `issue_batch_proposed` | After posting a proposal message | `count`, `sampleTitles`, `requestingUser`, `threadTs` |
+| `issue_batch_confirmed` | Claim succeeded | `count`, `confirmVia` (`"reaction"` \| `"text"`), `latencyMs` |
+| `issue_batch_claim_lost` | Claim raced another handler | `channel`, `firstTs`, `confirmVia` |
+| `issue_batch_created` | After all creations settle | `totalCount`, `successCount`, `failureCount`, `durationMs`, `numbers` |
+| `issue_create_error` | Per-issue failure | `title`, `errorClass`, `errorMessage` |
+
+Per-issue failures also emit `Sentry.captureException` tagged `{flow: "issue_create", batchSize: <N>}` so a rate-limit burst on one title surfaces as a distinct Sentry issue rather than hiding under the summary.
+
+## Edge cases
+
+- **Multi-chunk proposal messages** — the canonical record is keyed by the first chunk's ts. If a proposal splits across chunks (rare — batch mode is compact by design; single mode is under the 4 k body budget), a reaction on a later chunk will not find the batch and will fall through to the legacy parser for single-proposal back-compat.
+- **Racing confirmations** — two users react simultaneously, or one reacts while another types "confirm all". The atomic `kv.del` ensures exactly one `executeBatchCreation` call proceeds. The loser logs `issue_batch_claim_lost` and exits silently.
+- **Partial GitHub failures** — a rate limit or permission error on one title does not abort the rest. The summary reply lists every created issue AND every failure.
+- **Legacy single-proposal messages** — pre-#122 messages have no KV record. The reaction handler falls back to `parseProposalFromMessage` and creates exactly one issue. Natural drain via 24 h TTL.
+
+## Code layout
+
+- `src/lib/issue-batch.ts` — pure helpers (`formatBatchProposalMessage`, `isBulkConfirmText`, `summarizeBatchResult`). No I/O; safe to import in tests.
+- `src/app/api/slack/route.ts` — `PendingIssueBatch` shape, KV key helpers, `executeBatchCreation`, and the three entry points (mention → propose, thread text → confirm, reaction → confirm).
+- `src/tools/create-issue.ts` — `create_issue` tool schema and `parseProposalFromMessage` (legacy fallback).
+
+See #122 for the original motivation and design discussion.

--- a/docs/features/issue-creation.md
+++ b/docs/features/issue-creation.md
@@ -6,8 +6,10 @@ Battle Mage can propose GitHub issues and — on user confirmation — file them
 
 The agent uses the `create_issue` tool to propose an issue. A single turn can emit **one or many** proposals:
 
-- **Single proposal** — the familiar "Proposed Issue:" block with title, labels, and full body inlined. Approved by a :white_check_mark: reaction on the message.
-- **Batch proposal (N > 1)** — a compact numbered list of titles with inline labels, no inlined bodies. Approved by either a :white_check_mark: reaction on the message OR a short thread reply like "confirm all" / "yes" / "create all" / "go ahead" / "approve all".
+- **Single proposal** — the familiar "Proposed Issue:" block with title, labels, and full body inlined.
+- **Batch proposal (N > 1)** — a compact numbered list of titles with inline labels, no inlined bodies.
+
+**Both** cases persist a record in KV and accept the same two approval paths: a :white_check_mark: reaction on the proposal message, OR a short thread reply matched by `isBulkConfirmText` ("yes", "confirm", "confirm all", "create all", "go ahead", "approve all", etc.). The UX footer shown to users surfaces only the reaction path for N=1 to match the pre-#122 style, but the code path is identical to the N>1 case — any valid bulk-confirm phrase in the thread also works.
 
 Bodies are persisted in KV so the confirmation path can create issues without round-tripping the full body through Slack message text.
 
@@ -22,6 +24,7 @@ Bodies are persisted in KV so the confirmation path can create issues without ro
    - `pending-issue-batch:{channel}:{firstTs}` — the canonical record (proposals, timing, requester, thread)
    - `pending-issue-batch:thread:{channel}:{threadTs}` — pointer to `firstTs` for text-command lookup
    - Both with a 24 h TTL.
+   - On successful claim, a third key `pending-issue-batch:done:{channel}:{firstTs}` is written with a 1 h TTL as a tombstone. Any subsequent ✅ reaction on the same message checks this key and exits silently — without it, a double-tap would fall through to the legacy parser and re-create the issue (N=1 messages still have a body in their text).
 5. **User confirms** via one of:
    - :white_check_mark: reaction on the proposal message — reaction handler calls `executeBatchCreation`
    - `"confirm all"` (or synonym) in the thread — thread-followup handler calls `executeBatchCreation`
@@ -47,6 +50,7 @@ Lifecycle events (structured logs; same shape as `kv_op`):
 | `issue_batch_proposed` | After posting a proposal message | `count`, `sampleTitles`, `requestingUser`, `threadTs` |
 | `issue_batch_confirmed` | Claim succeeded | `count`, `confirmVia` (`"reaction"` \| `"text"`), `latencyMs` |
 | `issue_batch_claim_lost` | Claim raced another handler | `channel`, `firstTs`, `confirmVia` |
+| `issue_batch_reaction_after_claim` | ✅ arrived after a successful claim (tombstone hit) | `channel`, `messageTs` |
 | `issue_batch_created` | After all creations settle | `totalCount`, `successCount`, `failureCount`, `durationMs`, `numbers` |
 | `issue_create_error` | Per-issue failure | `title`, `errorClass`, `errorMessage` |
 

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -13,7 +13,13 @@ import {
 } from "@/lib/slack";
 import { runAgent } from "@/lib/claude";
 import { createIssue } from "@/lib/github";
-import { parseProposalFromMessage } from "@/tools/create-issue";
+import { parseProposalFromMessage, type IssueProposal } from "@/tools/create-issue";
+import {
+  formatBatchProposalMessage,
+  isBulkConfirmText,
+  summarizeBatchResult,
+  type BatchCreationOutcome,
+} from "@/lib/issue-batch";
 import { storeQAContext, getQAContext, saveFeedback, deriveReferenceTypes } from "@/lib/feedback";
 import { formatReferences, rankReferences } from "@/lib/references";
 import { getAllKnowledge } from "@/lib/knowledge";
@@ -27,7 +33,7 @@ import {
   resolveParticipants,
   type Participant,
 } from "@/lib/slack-users";
-import { createRequestLogger, flushLogs } from "@/lib/logger";
+import { createRequestLogger, flushLogs, type RequestLogger } from "@/lib/logger";
 import { getCachedTopics } from "@/lib/repo-index";
 import { matchTopicsToQuestion, buildQuestionHints } from "@/lib/topic-match";
 import { isAddressedToOtherUser, buildConversationHistory } from "@/lib/thread-filter";
@@ -43,6 +49,125 @@ interface PendingCorrection {
   flaggedKB: string[];
   pendingAt: number;
   answerTs: string;
+}
+
+// Shape of the pending-issue-batch record stored after the bot posts a
+// proposal message. Indexed by the proposal message's first TS. See #122.
+interface PendingIssueBatch {
+  proposals: IssueProposal[];
+  proposedAt: number;
+  requestedBy: string; // Slack user ID of the requester
+  threadTs: string;
+  messageFirstTs: string; // ts of the first chunk of the proposal message
+}
+
+const BATCH_KEY_PREFIX = "pending-issue-batch";
+const BATCH_TTL_SEC = 86400; // 24h — stale batches fall off naturally
+
+function batchKey(channel: string, firstTs: string): string {
+  return `${BATCH_KEY_PREFIX}:${channel}:${firstTs}`;
+}
+function batchThreadPointerKey(channel: string, threadTs: string): string {
+  return `${BATCH_KEY_PREFIX}:thread:${channel}:${threadTs}`;
+}
+
+/**
+ * Atomically claim and execute a pending issue batch.
+ *
+ * Concurrency: the claim uses `kv.del` on the canonical key — Redis
+ * DEL is atomic, so only the first caller sees `deleted === 1`. Any
+ * racing handler (a second reaction, or a racing text command) sees
+ * `0` and aborts without firing GitHub writes.
+ *
+ * Per-issue failures do not abort the rest: we use Promise.allSettled
+ * and surface both creates and errors in the final summary.
+ */
+async function executeBatchCreation(
+  channel: string,
+  threadTs: string,
+  firstTs: string,
+  confirmingUser: string,
+  confirmVia: "reaction" | "text",
+  rlog: RequestLogger,
+): Promise<{ claimed: boolean }> {
+  const { kv } = await import("@/lib/kv");
+  const primaryKey = batchKey(channel, firstTs);
+
+  // Read the batch before claiming so we have the data to create issues
+  // if we win the del race.
+  const batch = await kv.get<PendingIssueBatch>(primaryKey);
+  if (!batch) {
+    return { claimed: false };
+  }
+
+  const deleted = await kv.del(primaryKey);
+  if (deleted === 0) {
+    // Another handler won the race between get and del.
+    rlog("issue_batch_claim_lost", { channel, firstTs, confirmVia });
+    return { claimed: false };
+  }
+
+  // Best-effort cleanup of the thread pointer. We don't care if it was
+  // already removed — TTL would catch it anyway.
+  try {
+    await kv.del(batchThreadPointerKey(channel, threadTs));
+  } catch {
+    // Non-fatal; Sentry already captured via the kv wrapper.
+  }
+
+  rlog("issue_batch_confirmed", {
+    count: batch.proposals.length,
+    confirmVia,
+    confirmingUser,
+    requestedBy: batch.requestedBy,
+    latencyMs: Date.now() - batch.proposedAt,
+    channel,
+    threadTs,
+  });
+
+  const createStart = Date.now();
+  const settled = await Promise.allSettled(
+    batch.proposals.map((p) => createIssue(p.title, p.body, p.labels)),
+  );
+
+  const outcomes: BatchCreationOutcome[] = settled.map((res, i) => {
+    const proposal = batch.proposals[i];
+    if (res.status === "fulfilled") {
+      return { status: "success", proposal, issue: res.value };
+    }
+    const errorMessage =
+      res.reason instanceof Error ? res.reason.message : String(res.reason);
+    // Per-issue Sentry capture so a rate-limit spike on one title doesn't
+    // hide under the summary event. Tagged for dashboard filtering.
+    Sentry.captureException(res.reason, {
+      tags: { flow: "issue_create", batchSize: String(batch.proposals.length) },
+      extra: { proposalTitle: proposal.title },
+    });
+    rlog("issue_create_error", {
+      title: proposal.title,
+      errorClass:
+        res.reason instanceof Error ? res.reason.constructor.name : "Unknown",
+      errorMessage: errorMessage.slice(0, 200),
+    });
+    return { status: "error", proposal, errorMessage };
+  });
+
+  const successCount = outcomes.filter((o) => o.status === "success").length;
+  const failureCount = outcomes.length - successCount;
+  rlog("issue_batch_created", {
+    totalCount: outcomes.length,
+    successCount,
+    failureCount,
+    durationMs: Date.now() - createStart,
+    numbers: outcomes
+      .filter((o) => o.status === "success")
+      .map((o) => (o as Extract<BatchCreationOutcome, { status: "success" }>).issue.number),
+    channel,
+    threadTs,
+  });
+
+  await replyInThread(channel, threadTs, summarizeBatchResult(outcomes));
+  return { claimed: true };
 }
 
 /**
@@ -184,22 +309,10 @@ export async function POST(request: NextRequest) {
           ? formatReplyFooter(result.metrics, rlog.requestId)
           : "";
 
-        if (result.issueProposal) {
-          const proposal = result.issueProposal;
-          const labelsText = proposal.labels?.length
-            ? `\nLabels: ${proposal.labels.join(", ")}`
-            : "";
-
-          const finalBody = [
-            text,
-            "",
-            "───────────────────",
-            `*Proposed Issue:* ${proposal.title}${labelsText}`,
-            "",
-            proposal.body,
-            "",
-            "React with :white_check_mark: to create this issue, or ignore to cancel.",
-          ].join("\n") + refsFooter + replyFooter;
+        if (result.issueProposals.length > 0) {
+          const proposals = result.issueProposals;
+          const proposalBlock = formatBatchProposalMessage(proposals);
+          const finalBody = [text, "", proposalBlock].join("\n") + refsFooter + replyFooter;
 
           const posted = await postReplyInChunks({
             channel,
@@ -210,7 +323,41 @@ export async function POST(request: NextRequest) {
           // Only mark as finalized when we actually posted. A 0-chunk
           // result (empty body) falls through to the finally cleanup.
           if (posted.chunks > 0) thinkingTs = undefined;
-          rlog("answer_posted", { channel, threadTs, chunks: posted.chunks, kind: "proposal" });
+
+          // Persist the batch so confirmation (reaction OR thread text)
+          // can create without re-parsing Slack message text. Key is the
+          // first chunk's ts; thread pointer enables "confirm all" text.
+          if (posted.firstTs) {
+            const { kv } = await import("@/lib/kv");
+            const record: PendingIssueBatch = {
+              proposals,
+              proposedAt: Date.now(),
+              requestedBy: event.user,
+              threadTs,
+              messageFirstTs: posted.firstTs,
+            };
+            await kv.set(batchKey(channel, posted.firstTs), record, { ex: BATCH_TTL_SEC });
+            await kv.set(
+              batchThreadPointerKey(channel, threadTs),
+              posted.firstTs,
+              { ex: BATCH_TTL_SEC },
+            );
+            rlog("issue_batch_proposed", {
+              count: proposals.length,
+              threadTs,
+              channel,
+              firstTs: posted.firstTs,
+              sampleTitles: proposals.slice(0, 3).map((p) => p.title.slice(0, 80)),
+              requestingUser: event.user,
+            });
+          }
+          rlog("answer_posted", {
+            channel,
+            threadTs,
+            chunks: posted.chunks,
+            kind: "proposal",
+            proposalCount: proposals.length,
+          });
         } else {
           const finalBody = text + refsFooter + replyFooter;
           const posted = await postReplyInChunks({
@@ -336,6 +483,31 @@ export async function POST(request: NextRequest) {
           return;
         }
 
+        // ── Bulk-confirm interception (#122) ────────────────────────────
+        // If there's a pending issue batch in this thread AND the user's
+        // reply is a bulk-confirm phrase ("confirm all", "yes", etc.),
+        // create all issues instead of running the agent. `isBulkConfirmText`
+        // is strict (short intent-only phrases) so normal conversation is
+        // unaffected.
+        if (isBulkConfirmText(userMessage)) {
+          const pointerKey = batchThreadPointerKey(channel, threadTs);
+          const batchFirstTs = await kv.get<string>(pointerKey);
+          if (batchFirstTs) {
+            const outcome = await executeBatchCreation(
+              channel,
+              threadTs,
+              batchFirstTs,
+              event.user,
+              "text",
+              rlog,
+            );
+            if (outcome.claimed) return;
+            // Not claimed → either the batch expired or another handler
+            // consumed it. Fall through to the normal agent flow so the
+            // user still gets a response.
+          }
+        }
+
         // Fetch thread messages — used for both participation check and context
         const bid = botId || (await getBotUserId());
         const threadMessages = await fetchThreadMessages(channel, threadTs);
@@ -393,22 +565,10 @@ export async function POST(request: NextRequest) {
           ? formatReplyFooter(result.metrics, rlog.requestId)
           : "";
 
-        if (result.issueProposal) {
-          const proposal = result.issueProposal;
-          const labelsText = proposal.labels?.length
-            ? `\nLabels: ${proposal.labels.join(", ")}`
-            : "";
-
-          const finalBody = [
-            text,
-            "",
-            "───────────────────",
-            `*Proposed Issue:* ${proposal.title}${labelsText}`,
-            "",
-            proposal.body,
-            "",
-            "React with :white_check_mark: to create this issue, or ignore to cancel.",
-          ].join("\n") + refsFooter + replyFooter;
+        if (result.issueProposals.length > 0) {
+          const proposals = result.issueProposals;
+          const proposalBlock = formatBatchProposalMessage(proposals);
+          const finalBody = [text, "", proposalBlock].join("\n") + refsFooter + replyFooter;
 
           const posted = await postReplyInChunks({
             channel,
@@ -417,7 +577,37 @@ export async function POST(request: NextRequest) {
             text: finalBody,
           });
           if (posted.chunks > 0) thinkTs = undefined;
-          rlog("answer_posted", { channel, threadTs, chunks: posted.chunks, kind: "proposal" });
+
+          if (posted.firstTs) {
+            const record: PendingIssueBatch = {
+              proposals,
+              proposedAt: Date.now(),
+              requestedBy: event.user,
+              threadTs,
+              messageFirstTs: posted.firstTs,
+            };
+            await kv.set(batchKey(channel, posted.firstTs), record, { ex: BATCH_TTL_SEC });
+            await kv.set(
+              batchThreadPointerKey(channel, threadTs),
+              posted.firstTs,
+              { ex: BATCH_TTL_SEC },
+            );
+            rlog("issue_batch_proposed", {
+              count: proposals.length,
+              threadTs,
+              channel,
+              firstTs: posted.firstTs,
+              sampleTitles: proposals.slice(0, 3).map((p) => p.title.slice(0, 80)),
+              requestingUser: event.user,
+            });
+          }
+          rlog("answer_posted", {
+            channel,
+            threadTs,
+            chunks: posted.chunks,
+            kind: "proposal",
+            proposalCount: proposals.length,
+          });
         } else {
           const finalBody = text + refsFooter + replyFooter;
           const posted = await postReplyInChunks({
@@ -492,21 +682,33 @@ export async function POST(request: NextRequest) {
         // Only act on our own messages (proposals posted by the bot)
         if (msg.user !== botId) return;
 
-        // Parse the proposal from the message text
+        const threadTs = msg.thread_ts || messageTs;
+
+        // Preferred path (#122): batch record in KV keyed by this message's
+        // ts. Handles 1-proposal AND N-proposal batches uniformly.
+        const outcome = await executeBatchCreation(
+          channel,
+          threadTs,
+          messageTs,
+          reactingUser,
+          "reaction",
+          rlog,
+        );
+        if (outcome.claimed) return;
+
+        // Legacy fallback: in-flight pre-#122 proposal messages whose
+        // KV record expired (or never existed). Parse from message text
+        // exactly as before. Drops out naturally after the 24h TTL
+        // window from rollout.
         const proposal = parseProposalFromMessage(msg.text);
         if (!proposal) return; // Not a proposal message — ignore
 
-        // Create the issue on GitHub
         const issue = await createIssue(
           proposal.title,
           proposal.body,
           proposal.labels,
         );
-
-        rlog("issue_created", { number: issue.number });
-
-        // Reply in the same thread with the new issue link
-        const threadTs = msg.thread_ts || messageTs;
+        rlog("issue_created", { number: issue.number, via: "legacy_parser" });
         await replyInThread(
           channel,
           threadTs,

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -63,12 +63,21 @@ interface PendingIssueBatch {
 
 const BATCH_KEY_PREFIX = "pending-issue-batch";
 const BATCH_TTL_SEC = 86400; // 24h — stale batches fall off naturally
+// Tombstone TTL: long enough to cover any plausible double-tap ✅ window
+// on a single-proposal message whose body still matches the legacy parser.
+// See PR #123 CodeRabbit finding — without this, a second reaction finds
+// the canonical record deleted, falls to parseProposalFromMessage, and
+// re-creates the issue.
+const BATCH_TOMBSTONE_TTL_SEC = 3600;
 
 function batchKey(channel: string, firstTs: string): string {
   return `${BATCH_KEY_PREFIX}:${channel}:${firstTs}`;
 }
 function batchThreadPointerKey(channel: string, threadTs: string): string {
   return `${BATCH_KEY_PREFIX}:thread:${channel}:${threadTs}`;
+}
+function batchTombstoneKey(channel: string, firstTs: string): string {
+  return `${BATCH_KEY_PREFIX}:done:${channel}:${firstTs}`;
 }
 
 /**
@@ -105,6 +114,20 @@ async function executeBatchCreation(
     // Another handler won the race between get and del.
     rlog("issue_batch_claim_lost", { channel, firstTs, confirmVia });
     return { claimed: false };
+  }
+
+  // Tombstone the claim so a second ✅ on the same message can't fall
+  // through to the legacy parser and re-create the issue. The legacy
+  // fallback checks this before parsing message text. 1h is enough for
+  // any plausible double-tap; long-lived record stays under the canonical
+  // 24h TTL of the original batch.
+  try {
+    await kv.set(batchTombstoneKey(channel, firstTs), 1, {
+      ex: BATCH_TOMBSTONE_TTL_SEC,
+    });
+  } catch {
+    // Non-fatal; Sentry already captured via the kv wrapper. Worst case
+    // a racing second reaction takes the legacy path.
   }
 
   // Best-effort cleanup of the thread pointer. We don't care if it was
@@ -695,6 +718,19 @@ export async function POST(request: NextRequest) {
           rlog,
         );
         if (outcome.claimed) return;
+
+        // Tombstone guard: a prior confirmation already claimed this
+        // message's batch. Without this check, a second ✅ on the same
+        // post-#122 single-proposal message would fall through to the
+        // legacy parser (body still inlined in the message text) and
+        // create the issue a second time. See CodeRabbit feedback on
+        // PR #123.
+        const { kv } = await import("@/lib/kv");
+        const tombstone = await kv.get(batchTombstoneKey(channel, messageTs));
+        if (tombstone) {
+          rlog("issue_batch_reaction_after_claim", { channel, messageTs });
+          return;
+        }
 
         // Legacy fallback: in-flight pre-#122 proposal messages whose
         // KV record expired (or never existed). Parse from message text

--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -908,7 +908,7 @@ describe("executeToolsInParallel", () => {
     expect(references.some((r) => r.url.endsWith("pull/42"))).toBe(true);
   });
 
-  it("propagates issue proposal from create_issue tool result", async () => {
+  it("propagates a single issue proposal from create_issue tool result", async () => {
     const executor = vi.fn(async (name: string) => {
       if (name === "create_issue") {
         return {
@@ -921,16 +921,69 @@ describe("executeToolsInParallel", () => {
 
     const blocks: FakeBlock[] = [makeBlock("t1", "create_issue")];
 
-    const { toolResults, issueProposal } = await executeToolsInParallel(blocks, {
+    const { toolResults, issueProposals } = await executeToolsInParallel(blocks, {
       round: 0,
       log: vi.fn(),
       executor,
     });
 
-    expect(issueProposal).toBeDefined();
-    expect(issueProposal?.title).toBe("Test Issue");
+    expect(issueProposals).toHaveLength(1);
+    expect(issueProposals[0].title).toBe("Test Issue");
     expect(String(toolResults[0].content)).toContain("Test Issue");
     expect(String(toolResults[0].content)).toContain("Awaiting user confirmation");
+  });
+
+  it("collects all proposals when create_issue is called multiple times in one turn", async () => {
+    // Bulk-creation flow (#122): the agent may emit N create_issue tool_use
+    // blocks in a single turn. Previously the last one overwrote earlier
+    // ones; now every proposal is captured, in original block order, so
+    // the batch-confirmation path can fire them in parallel on approval.
+    const executor = vi.fn(async (_name: string, input: Record<string, unknown>) => {
+      return {
+        type: "issue_proposal" as const,
+        proposal: {
+          title: input.title as string,
+          body: input.body as string,
+          labels: input.labels as string[] | undefined,
+        },
+      };
+    });
+
+    const blocks: FakeBlock[] = [
+      makeBlock("t1", "create_issue", { title: "fix: one", body: "b1" }),
+      makeBlock("t2", "create_issue", { title: "fix: two", body: "b2", labels: ["bug"] }),
+      makeBlock("t3", "create_issue", { title: "fix: three", body: "b3" }),
+    ];
+
+    const { issueProposals } = await executeToolsInParallel(blocks, {
+      round: 0,
+      log: vi.fn(),
+      executor,
+    });
+
+    expect(issueProposals).toHaveLength(3);
+    // Order must match the original block order — downstream UX numbers
+    // proposals 1..N based on this array.
+    expect(issueProposals.map((p) => p.title)).toEqual([
+      "fix: one",
+      "fix: two",
+      "fix: three",
+    ]);
+    expect(issueProposals[1].labels).toEqual(["bug"]);
+  });
+
+  it("returns an empty issueProposals array when no create_issue block is present", async () => {
+    const executor = vi.fn().mockResolvedValue({ type: "text", text: "ok" });
+    const blocks: FakeBlock[] = [makeBlock("t1", "read_file")];
+
+    const { issueProposals } = await executeToolsInParallel(blocks, {
+      round: 0,
+      log: vi.fn(),
+      executor,
+    });
+
+    // Always an array, never undefined — downstream can always iterate.
+    expect(issueProposals).toEqual([]);
   });
 
   it("truncates oversized tool results and logs the truncation", async () => {

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -225,6 +225,7 @@ function buildCorePrinciplesSection(): string {
 2. *Cite specifically* — When referencing code, include the file path and line numbers. Link to GitHub when possible.
 3. *Thread-only* — You are responding in a Slack thread. Keep answers concise but thorough.
 4. *Issue creation requires confirmation* — If asked to create a GitHub issue, propose it with title, body, and labels. The user must explicitly confirm before it is created.
+5. *Batch proposals* — When the user asks for multiple issues at once (e.g. "file bugs for X, Y, Z" or "create all these as separate issues"), call \`create_issue\` once for each proposed issue in the SAME turn. All proposals will be shown together and approved with a single :white_check_mark: reaction or by the user saying "confirm all" in the thread. Do not file them one at a time across multiple turns.
 </core-principles>`;
 }
 
@@ -485,7 +486,15 @@ async function buildSystemBlocks(
 
 export interface AgentResult {
   text: string;
-  issueProposal?: IssueProposal;
+  /**
+   * Issue proposals collected during this turn. Always an array — empty
+   * when no `create_issue` tool was used. Length >= 2 means the agent
+   * proposed a batch, which the Slack route renders as a compact
+   * numbered list gated behind a single bulk confirmation. Order
+   * matches the order of `create_issue` tool_use blocks in the
+   * model's response. See #122.
+   */
+  issueProposals: IssueProposal[];
   references: Reference[];
   /**
    * Per-turn telemetry snapshot: duration, token usage, cache reads,
@@ -556,7 +565,7 @@ export async function runAgent(
     { role: "user", content: userMessage },
   ];
 
-  let issueProposal: IssueProposal | undefined;
+  const issueProposals: IssueProposal[] = [];
   const allReferences: Reference[] = [];
   const startTime = Date.now();
   const { blocks: systemBlocks, feedbackMeta } = await buildSystemBlocks(participants);
@@ -603,7 +612,7 @@ export async function runAgent(
       });
       return {
         text: "I've been working on this for a while and want to give you what I have so far rather than keep you waiting. Here's my answer based on what I've found:\n\n_I ran out of time before completing a thorough analysis. Ask a follow-up question if you need more detail on a specific area._",
-        issueProposal,
+        issueProposals,
         references: finalRefs,
         metrics: buildMetrics(round),
       };
@@ -634,7 +643,7 @@ export async function runAgent(
       });
       return {
         text: userErrorMessage(errInfo),
-        issueProposal,
+        issueProposals,
         references: [],
         metrics: buildMetrics(round),
       };
@@ -662,7 +671,7 @@ export async function runAgent(
       _log("agent_complete", {
         rounds: round + 1,
         refCount: allReferences.length,
-        hasProposal: !!issueProposal,
+        proposalCount: issueProposals.length,
         duration_ms: Date.now() - startTime,
         input_tokens: totalInput,
         output_tokens: totalOutput,
@@ -670,7 +679,7 @@ export async function runAgent(
         cache_creation_tokens: totalCacheCreation,
         model: MODEL,
       });
-      return { text, issueProposal, references: dedupeRefs(), metrics: buildMetrics(round + 1) };
+      return { text, issueProposals, references: dedupeRefs(), metrics: buildMetrics(round + 1) };
     }
 
     // Process tool calls
@@ -687,7 +696,7 @@ export async function runAgent(
       }).join("\n");
       return {
         text: text || "I wasn't able to process that request.",
-        issueProposal,
+        issueProposals,
         references: dedupeRefs(),
         metrics: buildMetrics(round + 1),
       };
@@ -704,7 +713,7 @@ export async function runAgent(
         text:
           text ||
           "I gathered a lot of context while researching this. Here's what I've found so far — please ask a narrower follow-up if you need more detail on a specific area.",
-        issueProposal,
+        issueProposals,
         references: dedupeRefs(),
         metrics: buildMetrics(round + 1),
       };
@@ -723,9 +732,9 @@ export async function runAgent(
     );
     const toolResults: Anthropic.ToolResultBlockParam[] = parallelOutcome.toolResults;
     allReferences.push(...parallelOutcome.references);
-    if (parallelOutcome.issueProposal) {
-      issueProposal = parallelOutcome.issueProposal;
-    }
+    // Accumulate across rounds — an agent that spends multiple rounds
+    // proposing issues (rare but possible) still yields a full batch.
+    issueProposals.push(...parallelOutcome.issueProposals);
 
     // Inject time budget warning by appending to the last tool result.
     // Re-run truncateToolResult on the combined string so the cap stays
@@ -772,7 +781,7 @@ export async function runAgent(
   });
   return {
     text: "I hit the maximum number of tool calls for this request. Here's what I found so far — please ask a more specific question if you need more detail.",
-    issueProposal,
+    issueProposals,
     references: finalRefs,
     metrics: buildMetrics(MAX_TOOL_ROUNDS),
   };
@@ -803,7 +812,12 @@ export interface ParallelToolsContext {
 export interface ParallelToolsResult {
   toolResults: Anthropic.ToolResultBlockParam[];
   references: Reference[];
-  issueProposal?: IssueProposal;
+  /**
+   * Every `create_issue` tool_use in this turn yields one proposal.
+   * Order matches the input `blocks` order (i.e. the order Claude
+   * emitted them). See #122 for the bulk-creation flow.
+   */
+  issueProposals: IssueProposal[];
 }
 
 export async function executeToolsInParallel(
@@ -846,12 +860,14 @@ export async function executeToolsInParallel(
 
   const toolResults: Anthropic.ToolResultBlockParam[] = [];
   const references: Reference[] = [];
-  let issueProposal: IssueProposal | undefined;
+  const issueProposals: IssueProposal[] = [];
 
   // Iterate outcomes in original block order so toolResults matches the
   // input sequence. Anthropic's API correlates results to uses by
   // `tool_use_id`, so order isn't strictly required for correctness — but
   // deterministic order eases log readability and test assertions.
+  // For `create_issue` specifically, order IS observable: the UI numbers
+  // proposals 1..N based on this array.
   for (const { block, result, error } of outcomes) {
     if (error !== null) {
       toolResults.push({
@@ -867,7 +883,7 @@ export async function executeToolsInParallel(
       references.push(...r.references);
     }
     if (r.type === "issue_proposal") {
-      issueProposal = r.proposal;
+      issueProposals.push(r.proposal);
       toolResults.push({
         type: "tool_result",
         tool_use_id: block.id,
@@ -891,5 +907,5 @@ export async function executeToolsInParallel(
     }
   }
 
-  return { toolResults, references, issueProposal };
+  return { toolResults, references, issueProposals };
 }

--- a/src/lib/issue-batch.test.ts
+++ b/src/lib/issue-batch.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatBatchProposalMessage,
+  isBulkConfirmText,
+  summarizeBatchResult,
+  BATCH_CONFIRM_LINE,
+  type BatchCreationOutcome,
+} from "./issue-batch";
+import type { IssueProposal } from "@/tools/create-issue";
+
+const p = (title: string, body = "Short body.", labels?: string[]): IssueProposal => ({
+  title,
+  body,
+  labels,
+});
+
+// ── formatBatchProposalMessage ───────────────────────────────────────
+describe("formatBatchProposalMessage — single proposal (parity with legacy)", () => {
+  it("renders the *Proposed Issue:* anchor line for a single proposal", () => {
+    const out = formatBatchProposalMessage([p("Fix login timeout")]);
+    expect(out).toContain("*Proposed Issue:* Fix login timeout");
+  });
+
+  it("includes the body verbatim for a single proposal", () => {
+    const out = formatBatchProposalMessage([p("Fix bug", "## Problem\nDetails here")]);
+    expect(out).toContain("## Problem");
+    expect(out).toContain("Details here");
+  });
+
+  it("includes labels line when labels present", () => {
+    const out = formatBatchProposalMessage([p("Fix bug", "body", ["bug", "priority:high"])]);
+    expect(out).toContain("Labels: bug, priority:high");
+  });
+
+  it("omits labels line when labels absent", () => {
+    const out = formatBatchProposalMessage([p("Fix bug")]);
+    expect(out).not.toContain("Labels:");
+  });
+
+  it("ends with the single-issue confirmation line", () => {
+    const out = formatBatchProposalMessage([p("Fix bug")]);
+    expect(out).toContain("React with :white_check_mark: to create this issue");
+  });
+
+  it("includes the divider separator", () => {
+    const out = formatBatchProposalMessage([p("Fix bug")]);
+    expect(out).toContain("───────────────────");
+  });
+});
+
+describe("formatBatchProposalMessage — multi-proposal batch", () => {
+  const three = [
+    p("fix: STATUS_PROVISIONING never written", "Body 1", ["bug", "priority:high"]),
+    p("fix: template RIA fetched outside transaction", "Body 2", ["bug"]),
+    p("fix: stuck PROVISIONING rows never cleaned up", "Body 3"),
+  ];
+
+  it("uses *Proposed Issues* (plural) header for N>1", () => {
+    const out = formatBatchProposalMessage(three);
+    expect(out).toContain("*Proposed Issues*");
+    // Guard: must NOT fall through to the singular anchor used by the legacy parser
+    expect(out).not.toContain("*Proposed Issue:*");
+  });
+
+  it("shows the total count in the header", () => {
+    const out = formatBatchProposalMessage(three);
+    expect(out).toMatch(/3 to file/);
+  });
+
+  it("renders a numbered list with each title", () => {
+    const out = formatBatchProposalMessage(three);
+    expect(out).toContain("1. *fix: STATUS_PROVISIONING never written*");
+    expect(out).toContain("2. *fix: template RIA fetched outside transaction*");
+    expect(out).toContain("3. *fix: stuck PROVISIONING rows never cleaned up*");
+  });
+
+  it("preserves proposal order (order-sensitive)", () => {
+    const out = formatBatchProposalMessage(three);
+    const idx1 = out.indexOf("fix: STATUS_PROVISIONING");
+    const idx2 = out.indexOf("fix: template RIA");
+    const idx3 = out.indexOf("fix: stuck PROVISIONING");
+    expect(idx1).toBeGreaterThan(-1);
+    expect(idx1).toBeLessThan(idx2);
+    expect(idx2).toBeLessThan(idx3);
+  });
+
+  it("renders labels as inline italics per item when present", () => {
+    const out = formatBatchProposalMessage(three);
+    expect(out).toContain("_bug, priority:high_");
+    expect(out).toContain("_bug_");
+  });
+
+  it("ends with the bulk-confirm footer line", () => {
+    const out = formatBatchProposalMessage(three);
+    expect(out).toContain(BATCH_CONFIRM_LINE);
+    // The footer must mention both approval paths so users know their options
+    expect(out).toMatch(/:white_check_mark:/);
+    expect(out).toMatch(/confirm all/i);
+  });
+
+  it("does NOT inline the full bodies (keeps message compact)", () => {
+    // Bodies are stored in KV and retrieved on confirmation, not round-tripped
+    // through the Slack message. Inlining 8 full bodies would blow past
+    // Slack's 40k char limit and re-introduce the same msg_too_long risk
+    // fixed in #112. For N>1, only titles + labels render.
+    const out = formatBatchProposalMessage(three);
+    expect(out).not.toContain("Body 1");
+    expect(out).not.toContain("Body 2");
+    expect(out).not.toContain("Body 3");
+  });
+
+  it("handles a large batch (8 proposals) without error", () => {
+    const eight = Array.from({ length: 8 }, (_, i) => p(`issue ${i}`, `body ${i}`));
+    const out = formatBatchProposalMessage(eight);
+    expect(out).toContain("8 to file");
+    for (let i = 0; i < 8; i++) {
+      expect(out).toContain(`${i + 1}. *issue ${i}*`);
+    }
+  });
+});
+
+describe("formatBatchProposalMessage — edge cases", () => {
+  it("returns empty string when proposals array is empty", () => {
+    // Pure helper; route.ts never calls with [], but defending against it is
+    // cheaper than debugging a malformed message in prod.
+    expect(formatBatchProposalMessage([])).toBe("");
+  });
+});
+
+// ── isBulkConfirmText ────────────────────────────────────────────────
+describe("isBulkConfirmText — positive matches", () => {
+  const positives = [
+    "yes",
+    "Yes",
+    "YES",
+    "yes!",
+    "yes please",
+    "confirm",
+    "confirm all",
+    "confirm all issues",
+    "create all",
+    "create all remaining",
+    "create them all",
+    "go ahead",
+    "go ahead and create them",
+    "go ahead and create all issues",
+    "approve all",
+    "approve",
+    "  confirm all  ", // trimmed
+    "Yes.",
+  ];
+
+  for (const text of positives) {
+    it(`matches: ${JSON.stringify(text)}`, () => {
+      expect(isBulkConfirmText(text)).toBe(true);
+    });
+  }
+});
+
+describe("isBulkConfirmText — negative matches (must NOT trigger)", () => {
+  const negatives = [
+    "",
+    "   ",
+    "no",
+    "no thanks",
+    "maybe later",
+    "cancel",
+    "don't",
+    "yes it failed",              // 'yes' substring but not a bare confirm
+    "yes this is a bug",
+    "create only issue 1",
+    "create this one",
+    "create just the first",
+    "approve only the epic",
+    "confirm issue 3",
+    "tell me more about issue 2",
+    "what's the difference between #1 and #2", // long conversational
+    "go ahead with just the first one",
+    "let's not",
+    // Long-form answers that contain 'yes' or 'ok' but are actually explanations,
+    // not approvals. The matcher must require SHORT intent-only phrases.
+    "yes we had the same bug last quarter, the fix was to move it out of the transaction",
+  ];
+
+  for (const text of negatives) {
+    it(`rejects: ${JSON.stringify(text)}`, () => {
+      expect(isBulkConfirmText(text)).toBe(false);
+    });
+  }
+});
+
+// ── summarizeBatchResult ─────────────────────────────────────────────
+describe("summarizeBatchResult", () => {
+  const success = (num: number, title: string): BatchCreationOutcome => ({
+    status: "success",
+    proposal: p(title),
+    issue: { number: num, title, url: `https://github.com/o/r/issues/${num}` },
+  });
+  const failure = (title: string, errorMessage: string): BatchCreationOutcome => ({
+    status: "error",
+    proposal: p(title),
+    errorMessage,
+  });
+
+  it("renders all-success summary with per-issue links and numbers", () => {
+    const out = summarizeBatchResult([
+      success(100, "fix: a"),
+      success(101, "fix: b"),
+      success(102, "fix: c"),
+    ]);
+    expect(out).toContain("3 issue");              // plural wording, exact count
+    expect(out).toContain("#100");
+    expect(out).toContain("#101");
+    expect(out).toContain("#102");
+    expect(out).toContain("<https://github.com/o/r/issues/100|fix: a>");
+    expect(out).toContain(":white_check_mark:");
+  });
+
+  it("renders single-success summary in singular form", () => {
+    const out = summarizeBatchResult([success(42, "fix: only one")]);
+    expect(out).toContain("#42");
+    // Singular — no trailing 's' in "1 issue"
+    expect(out).toMatch(/1 issue(?!s)/);
+  });
+
+  it("reports mixed success + failure without dropping either side", () => {
+    const out = summarizeBatchResult([
+      success(200, "fix: ok"),
+      failure("fix: broken title", "rate limited"),
+      success(201, "fix: also ok"),
+    ]);
+    expect(out).toContain("#200");
+    expect(out).toContain("#201");
+    expect(out).toContain("fix: broken title");
+    expect(out).toContain("rate limited");
+    // Mixed result must signal that not everything succeeded
+    expect(out).toMatch(/failed|couldn't|could not|error/i);
+  });
+
+  it("renders all-failure summary without claiming any success", () => {
+    const out = summarizeBatchResult([
+      failure("fix: a", "perm denied"),
+      failure("fix: b", "rate limited"),
+    ]);
+    expect(out).not.toContain(":white_check_mark:");
+    expect(out).toContain("fix: a");
+    expect(out).toContain("fix: b");
+    expect(out).toContain("perm denied");
+    expect(out).toContain("rate limited");
+  });
+
+  it("returns an empty string for an empty outcome array", () => {
+    // Defensive — route.ts never calls with []
+    expect(summarizeBatchResult([])).toBe("");
+  });
+});

--- a/src/lib/issue-batch.ts
+++ b/src/lib/issue-batch.ts
@@ -1,0 +1,167 @@
+// ── Batch issue-creation helpers (pure) ──────────────────────────────
+// Formats multi-proposal Slack messages, recognizes bulk-confirmation
+// phrases, and summarizes per-issue creation outcomes.
+//
+// Keep this file side-effect-free — it's imported by the Slack route and
+// by tests that run without KV/GitHub. All I/O (KV persistence, GitHub
+// createIssue, Slack posting) lives in route.ts; this module only
+// produces strings and classifies text.
+//
+// See #122 for context.
+
+import type { IssueProposal } from "@/tools/create-issue";
+
+// Shared divider + anchor strings. Exported so the legacy single-issue
+// message parser (`parseProposalFromMessage` in tools/create-issue.ts)
+// and these helpers stay in lock-step on the singular anchor.
+export const SINGLE_PROPOSAL_ANCHOR = "*Proposed Issue:*";
+export const BATCH_PROPOSAL_HEADER = "*Proposed Issues*";
+export const DIVIDER = "───────────────────";
+export const SINGLE_CONFIRM_LINE =
+  "React with :white_check_mark: to create this issue, or ignore to cancel.";
+export const BATCH_CONFIRM_LINE =
+  "React with :white_check_mark: or say *confirm all* to create them all. Ignore to cancel.";
+
+// ── Format ───────────────────────────────────────────────────────────
+// For N=1: render the familiar single-proposal block (title, labels,
+// body inline, singular confirmation). Keeps the existing UX unchanged
+// for the common case and keeps the legacy parser happy for in-flight
+// messages during the rollout window.
+//
+// For N>1: render a compact numbered list — title + inline labels only.
+// Full bodies are NOT inlined; they are persisted in KV and pulled back
+// when the user confirms. Inlining 8 bodies would blow Slack's 40k-char
+// limit (see #112).
+
+function formatSingle(p: IssueProposal): string {
+  const labelsLine = p.labels?.length ? `\nLabels: ${p.labels.join(", ")}` : "";
+  return [
+    DIVIDER,
+    `${SINGLE_PROPOSAL_ANCHOR} ${p.title}${labelsLine}`,
+    "",
+    p.body,
+    "",
+    SINGLE_CONFIRM_LINE,
+  ].join("\n");
+}
+
+function formatBatch(proposals: IssueProposal[]): string {
+  const header = `${BATCH_PROPOSAL_HEADER} — ${proposals.length} to file. ${BATCH_CONFIRM_LINE}`;
+  const lines = proposals.map((p, i) => {
+    const labelsTag = p.labels?.length ? ` — _${p.labels.join(", ")}_` : "";
+    return `${i + 1}. *${p.title}*${labelsTag}`;
+  });
+  return [DIVIDER, header, "", ...lines].join("\n");
+}
+
+export function formatBatchProposalMessage(
+  proposals: IssueProposal[],
+): string {
+  if (proposals.length === 0) return "";
+  if (proposals.length === 1) return formatSingle(proposals[0]);
+  return formatBatch(proposals);
+}
+
+// ── Bulk confirmation text matcher ───────────────────────────────────
+// Intent: recognize short, approval-only phrases in a thread reply. Be
+// conservative — a false positive fires GitHub writes. The guard is a
+// strict allowlist of short phrases (≤ 6 words after normalization).
+//
+// Matches: "yes", "confirm all", "create all", "create them all",
+//   "go ahead", "go ahead and create all issues", "approve all",
+//   "approve", "confirm"
+//
+// Rejects anything longer or containing disqualifying tokens like
+// "no", "don't", "only", "just", "this one", "#<digit>".
+
+const ALLOWED_PATTERNS: RegExp[] = [
+  /^y+e+s+$/,
+  /^yes please$/,
+  /^confirm$/,
+  /^confirm all( issues| remaining)?$/,
+  /^create all( issues| remaining)?$/,
+  /^create them all$/,
+  /^go ahead$/,
+  /^go ahead and create( all| them)?( issues)?$/,
+  /^approve$/,
+  /^approve all$/,
+];
+
+const DISQUALIFIERS = /\b(no|not|don'?t|only|just|this|issue|#\d+)\b/;
+
+function normalize(text: string): string {
+  // Strip common punctuation, collapse whitespace, lowercase.
+  return text
+    .toLowerCase()
+    .replace(/[.!?,;:"'`]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function isBulkConfirmText(text: string): boolean {
+  const t = normalize(text);
+  if (t.length === 0) return false;
+
+  const wordCount = t.split(" ").length;
+  // Hard upper bound — real approvals fit in a few words. Anything
+  // longer is prose, not an approval.
+  if (wordCount > 6) return false;
+
+  // Reject if any disqualifier token is present — guards "yes it failed"
+  // from matching even though it starts with "yes".
+  if (DISQUALIFIERS.test(t)) return false;
+
+  return ALLOWED_PATTERNS.some((rx) => rx.test(t));
+}
+
+// ── Summarize creation outcomes ──────────────────────────────────────
+
+export type BatchCreationOutcome =
+  | {
+      status: "success";
+      proposal: IssueProposal;
+      issue: { number: number; title: string; url: string };
+    }
+  | {
+      status: "error";
+      proposal: IssueProposal;
+      errorMessage: string;
+    };
+
+export function summarizeBatchResult(
+  outcomes: BatchCreationOutcome[],
+): string {
+  if (outcomes.length === 0) return "";
+
+  const successes = outcomes.filter(
+    (o): o is Extract<BatchCreationOutcome, { status: "success" }> =>
+      o.status === "success",
+  );
+  const failures = outcomes.filter(
+    (o): o is Extract<BatchCreationOutcome, { status: "error" }> =>
+      o.status === "error",
+  );
+
+  const lines: string[] = [];
+
+  if (successes.length > 0) {
+    const noun = successes.length === 1 ? "issue" : "issues";
+    lines.push(`:white_check_mark: Created ${successes.length} ${noun}:`);
+    for (const s of successes) {
+      lines.push(`  • *#${s.issue.number}* <${s.issue.url}|${s.issue.title}>`);
+    }
+  }
+
+  if (failures.length > 0) {
+    if (lines.length > 0) lines.push("");
+    const noun = failures.length === 1 ? "issue" : "issues";
+    lines.push(
+      `:warning: ${failures.length} ${noun} failed to create:`,
+    );
+    for (const f of failures) {
+      lines.push(`  • *${f.proposal.title}* — ${f.errorMessage}`);
+    }
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
Closes #122.

## Summary

- Agent can now propose multiple issues in a single turn; approval is one ✅ reaction or a short "confirm all" reply.
- Shape change: `AgentResult.issueProposal` → `issueProposals: IssueProposal[]` (always an array). Single-proposal UX unchanged.
- New pure module `src/lib/issue-batch.ts`: `formatBatchProposalMessage`, `isBulkConfirmText`, `summarizeBatchResult`. 57 unit tests.
- Batches persist in KV under `pending-issue-batch:{channel}:{firstTs}` + thread pointer `pending-issue-batch:thread:{channel}:{threadTs}`. 24 h TTL.
- Concurrency: atomic `kv.del` claim — racing ✅ + "confirm all" can't double-fire.
- Per-issue GitHub failures via `Promise.allSettled` → summary reply lists creates and failures. Per-issue `Sentry.captureException` tagged `{flow: "issue_create", batchSize}`.

## Why

Previous flow required one ✅ per issue. Filing 8 issues from a single audit = 8 reactions + 8 agent round-trips. Worse: the bot recently told the user *"Next time you say 'confirm all' I'll fire them in parallel"* — but no code implemented that promise. It was saved only as a KB entry, which is a false-capability bug. This PR makes the capability real.

## Observability (new events)

| Event | When |
|---|---|
| `issue_batch_proposed` | After posting a batch proposal |
| `issue_batch_confirmed` | Claim succeeded — `confirmVia: "reaction" \| "text"` |
| `issue_batch_claim_lost` | Raced another handler |
| `issue_batch_created` | All creations settled — `{totalCount, successCount, failureCount, durationMs, numbers}` |
| `issue_create_error` | Per-issue failure |

## Test plan

- [x] `npm test` → 500/500 pass
- [x] `npx tsc --noEmit` clean
- [ ] **Manual in Slack sandbox** — single-proposal regression: request one issue, react ✅, verify filed
- [ ] **Manual in Slack sandbox** — batch proposal: request 3 issues, react ✅, verify all 3 filed with summary
- [ ] **Manual in Slack sandbox** — batch proposal: request 3 issues, reply `"confirm all"`, verify all 3 filed
- [ ] **Manual in Slack sandbox** — bulk-confirm strictness: with a pending batch, reply `"yes it failed"` → does NOT trigger creation; falls through to the agent
- [ ] **Manual in Slack sandbox** — race: react ✅ AND type `"confirm all"` near-simultaneously; exactly one creation summary posts; the other handler logs `issue_batch_claim_lost`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent can propose multiple GitHub issues in one turn with compact batch formatting.
  * Batch proposals require explicit bulk confirmation (✅ reaction or specific thread reply) to create issues.
  * Confirmations are handled atomically to prevent duplicate issue creation and produce a combined in-thread summary with per-issue results.

* **Documentation**
  * New docs detailing batch proposal/confirmation lifecycle, observability events, and edge cases.

* **Tests**
  * Added tests covering batch formatting, bulk-confirm matching, and batch result summarization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->