### PR TITLE
feat: KB entry lifecycle — supersession + stale-context framing (closes #124)

### DIFF
--- a/docs/features/auto-correction.md
+++ b/docs/features/auto-correction.md
@@ -15,7 +15,8 @@ The flow:
 7. A pending correction state is stored in KV for this thread
 8. Bot replies listing flagged items and asks "What was wrong?"
 9. The user's next reply is saved directly to the knowledge base (not through the agent loop)
-10. Negative feedback entry is recorded with the actual correction text
+10. The flagged KB entries are marked **superseded** by the new correction — hidden from future prompts but preserved with a link to their replacement (#124)
+11. Negative feedback entry is recorded with the actual correction text
 
 ## How Stale KB Entries Are Identified
 
@@ -55,9 +56,9 @@ Match: "auth" appears in both -> entry flagged
 
 ### Step 3: Flag for User Review (NOT auto-remove)
 
-Flagged KB entries are shown to the user but **not automatically removed**. This is a deliberate design choice -- a thumbs-down might mean the answer was formatted badly, or the question was misunderstood, not necessarily that the KB entries are wrong.
+Flagged KB entries are shown to the user but **not automatically retired**. This is a deliberate design choice -- a thumbs-down might mean the answer was formatted badly, or the question was misunderstood, not necessarily that the KB entries are wrong.
 
-The user sees the flagged entries and can reply to confirm which (if any) should be removed.
+Only when the user replies with an actual correction are the flagged entries retired -- each is marked superseded by the newly saved correction. If the user never replies, the pending state expires (24h TTL) and nothing changes.
 
 ## How Doc References Are Flagged
 
@@ -104,7 +105,7 @@ When a user thumbs-down an answer that referenced auth files and the KB had a ma
 ```
 :thinking_face: Thanks for the feedback.
 
-Possibly related KB entries (reply to confirm removal):
+Possibly related KB entries (a correction reply retires these, keeping history):
   • "Auth uses JWT tokens, not session cookies"
 
 Docs referenced: `docs/auth-guide.md`
@@ -133,7 +134,7 @@ The keyword matching heuristic is deliberately broad. It can produce false posit
 
 - A KB entry about "AuthController response format" would be flagged if the answer referenced any auth file, even if the KB entry is still correct.
 
-Auto-removing on a false positive would destroy valid knowledge. By flagging instead, the user stays in control -- they confirm what's actually wrong, and the correction is specific and meaningful.
+Auto-retiring on a false positive would hide valid knowledge. By flagging instead, the user stays in control -- entries are only superseded once the user supplies an actual correction, and even then the old entry is preserved in history with a link to its replacement rather than deleted.
 
 ## Testing
 

--- a/docs/features/knowledge-base.md
+++ b/docs/features/knowledge-base.md
@@ -29,7 +29,7 @@ Entries with either marker are hidden from the prompt but preserved in the sorte
 
 When a user corrects the bot in a conversation, the bot uses the `save_knowledge` tool to persist the correction:
 
-```
+```text
 User: @bm Where does the auth config live?
 Bot:  It's in config/auth.php
 User: No, we moved that to config/security.php last month
@@ -52,7 +52,7 @@ When a user reacts with :thumbsdown: and then replies with a correction, the fla
 
 The function `getKnowledgeAsMarkdown()` fetches the *visible* entries (not superseded, not archived) from KV and formats them as a timestamped list ending with a stale-context footer:
 
-```
+```text
 - [2026-03-28] The auth module lives in app/Services/Auth, not app/Http/Auth
 - [2026-03-27] API rate limit is 120 req/min, not 60
 - [2026-03-25] The deploy pipeline uses Docker Alpine, not Ubuntu

--- a/docs/features/knowledge-base.md
+++ b/docs/features/knowledge-base.md
@@ -10,10 +10,18 @@ Each entry is a JSON string:
 
 ```json
 {
+  "id": "b4f7c2e1-...",
   "entry": "The auth module lives in app/Services/Auth, not app/Http/Auth",
   "timestamp": "2026-03-28"
 }
 ```
+
+Entries are never deleted when corrected — they carry lifecycle fields instead (#124):
+
+- `supersededById` — set when a correction replaced this entry; points at the replacement's `id`
+- `archivedAt` / `archivedReason` — set when an entry was soft-deleted with a reason
+
+Entries with either marker are hidden from the prompt but preserved in the sorted set, so the history of what was believed and why it changed survives. Legacy entries written before ids existed still parse and can be superseded by matching their text.
 
 ## How Entries Are Saved
 
@@ -38,16 +46,18 @@ The system prompt instructs the bot to save corrections immediately when:
 
 ### Via Auto-Correction on Thumbs Down
 
-When a user reacts with :thumbsdown:, the auto-correction system may **remove** stale KB entries. See [Auto-Correction](./auto-correction.md) for details.
+When a user reacts with :thumbsdown: and then replies with a correction, the flagged stale entries are **superseded** by the correction (hidden from the prompt, linked to their replacement). See [Auto-Correction](./auto-correction.md) for details.
 
 ## How Entries Flow Into the System Prompt
 
-The function `getKnowledgeAsMarkdown()` fetches all entries from KV and formats them as a timestamped list:
+The function `getKnowledgeAsMarkdown()` fetches the *visible* entries (not superseded, not archived) from KV and formats them as a timestamped list ending with a stale-context footer:
 
 ```
 - [2026-03-28] The auth module lives in app/Services/Auth, not app/Http/Auth
 - [2026-03-27] API rate limit is 120 req/min, not 60
 - [2026-03-25] The deploy pipeline uses Docker Alpine, not Ubuntu
+
+_Treat these as possibly stale context. Current user instructions and repository evidence take priority._
 ```
 
 This is injected into the system prompt under the heading "Knowledge Base (learned corrections)" with a staleness warning:
@@ -89,17 +99,21 @@ The `knowledge.ts` module exports these functions:
 
 | Function | Description |
 |----------|-------------|
-| `saveKnowledgeEntry(entry)` | Add a new entry |
-| `getAllKnowledge()` | Get all entries, newest first |
-| `removeKnowledgeEntry(entryText)` | Remove an entry by matching its text |
-| `getKnowledgeAsMarkdown()` | Format all entries as markdown for the prompt |
+| `saveKnowledgeEntry(entry)` | Add a new entry; returns its id |
+| `supersedeKnowledgeEntry(oldIdOrText, newText)` | Save a replacement and mark the old entry superseded by it |
+| `markKnowledgeSuperseded(idOrText, newId)` | Mark an existing entry superseded by an already-saved entry |
+| `archiveKnowledgeEntry(idOrText, reason)` | Soft-delete an entry with a reason |
+| `getAllKnowledge()` | Get visible entries (not superseded/archived), newest first |
+| `getKnowledgeHistory()` | Get every entry including superseded and archived, newest first |
+| `getKnowledgeAsMarkdown()` | Format visible entries as markdown (with stale-context footer) for the prompt |
 
-### Removing a Stale Entry
+### Retiring a Stale Entry
 
-If you need to manually remove a KB entry, you can:
+If you need to retire a KB entry:
 
-1. Use the Vercel KV browser to find and delete the specific member from the sorted set
-2. Or let the auto-correction system handle it -- thumbs-down an answer that relied on stale KB data, and the bot will identify and remove related entries
+1. Let the auto-correction system handle it -- thumbs-down an answer that relied on stale KB data and reply with the correction; flagged entries are superseded by it automatically
+2. Or call `archiveKnowledgeEntry(idOrText, reason)` to soft-delete with a reason
+3. Deleting the raw member in the Vercel KV browser still works but erases history -- prefer the lifecycle functions
 
 ## Graceful Degradation
 

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -476,46 +476,63 @@ export async function POST(request: NextRequest) {
             "@/lib/knowledge"
           );
 
-          const correctionId = await saveKnowledgeEntry(userMessage);
+          // Strip @-mentions and trim, matching the normalization used
+          // for questions, so raw Slack tokens don't end up in the KB.
+          const correctionText = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
+          const correctionId = await saveKnowledgeEntry(correctionText);
+
+          // Clear the pending state as soon as the correction is durably
+          // saved — everything after this point is best-effort. If a later
+          // step throws, the error reply must NOT leave pending state
+          // behind, or the user's re-reply would save a duplicate entry.
+          await kv.del(pendingKey);
 
           // Retire the KB entries flagged at 👎 time: mark them superseded
           // by the correction instead of leaving them visible (or deleting
           // them and losing history). Text-matched; entries already
           // superseded or archived in the meantime are skipped. See #124.
           let supersededCount = 0;
-          for (const flaggedText of pending.flaggedKB) {
-            if (await markKnowledgeSuperseded(flaggedText, correctionId)) {
-              supersededCount++;
+          try {
+            for (const flaggedText of pending.flaggedKB) {
+              if (await markKnowledgeSuperseded(flaggedText, correctionId)) {
+                supersededCount++;
+              }
             }
+          } catch (err) {
+            // Correction is saved; a KV flake while retiring old entries
+            // must not fail the flow. Worst case a stale entry stays
+            // visible — observable via the count on correction_saved.
+            rlog("correction_supersede_error", {
+              channel,
+              threadTs,
+              message: err instanceof Error ? err.message : String(err),
+            });
           }
 
           // Save the negative feedback NOW with the actual correction text
           await saveFeedback({
             type: "negative",
             question: pending.question || "",
-            detail: `Correction: "${userMessage.slice(0, 200)}"`,
+            detail: `Correction: "${correctionText.slice(0, 200)}"`,
             timestamp: new Date().toISOString().split("T")[0],
           });
-
-          // Clear the pending state
-          await kv.del(pendingKey);
           // Close the 👎 → correction funnel with latency from the
           // moment 👎 was registered.
           rlog("correction_saved", {
             channel,
             threadTs,
             answerTs: pending.answerTs ?? null,
-            correctionLength: userMessage.length,
+            correctionLength: correctionText.length,
             timeSincePendingMs: Date.now() - pending.pendingAt,
             flaggedKBCount: pending.flaggedKB.length,
             supersededCount,
-            correctionSample: userMessage.slice(0, 100),
+            correctionSample: correctionText.slice(0, 100),
           });
 
           await replyInThread(
             channel,
             threadTs,
-            `:white_check_mark: Saved to knowledge base: _"${userMessage.slice(0, 100)}"_`,
+            `:white_check_mark: Saved to knowledge base: _"${correctionText.slice(0, 100)}"_`,
           );
           return;
         }

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -472,9 +472,22 @@ export async function POST(request: NextRequest) {
         const pending = await kv.get<PendingCorrection>(pendingKey);
         if (pending) {
           // This reply is a correction — save directly to KB
-          const { saveKnowledgeEntry } = await import("@/lib/knowledge");
+          const { saveKnowledgeEntry, markKnowledgeSuperseded } = await import(
+            "@/lib/knowledge"
+          );
 
-          await saveKnowledgeEntry(userMessage);
+          const correctionId = await saveKnowledgeEntry(userMessage);
+
+          // Retire the KB entries flagged at 👎 time: mark them superseded
+          // by the correction instead of leaving them visible (or deleting
+          // them and losing history). Text-matched; entries already
+          // superseded or archived in the meantime are skipped. See #124.
+          let supersededCount = 0;
+          for (const flaggedText of pending.flaggedKB) {
+            if (await markKnowledgeSuperseded(flaggedText, correctionId)) {
+              supersededCount++;
+            }
+          }
 
           // Save the negative feedback NOW with the actual correction text
           await saveFeedback({
@@ -495,6 +508,7 @@ export async function POST(request: NextRequest) {
             correctionLength: userMessage.length,
             timeSincePendingMs: Date.now() - pending.pendingAt,
             flaggedKBCount: pending.flaggedKB.length,
+            supersededCount,
             correctionSample: userMessage.slice(0, 100),
           });
 
@@ -930,7 +944,7 @@ export async function POST(request: NextRequest) {
 
         const notes: string[] = [];
         if (actions.kbEntriesToFlag.length > 0) {
-          notes.push("*Possibly related KB entries* (reply to confirm removal):");
+          notes.push("*Possibly related KB entries* (a correction reply retires these, keeping history):");
           for (const entry of actions.kbEntriesToFlag) {
             notes.push(`  • _"${entry.entry}"_`);
           }

--- a/src/lib/knowledge.test.ts
+++ b/src/lib/knowledge.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { vi } from "vitest";
+
+// In-memory zset fake for the kv wrapper. Only the ops knowledge.ts uses.
+// `store` maps member JSON → score, mirroring a Redis sorted set.
+const { store } = vi.hoisted(() => ({
+  store: new Map<string, number>(),
+}));
+
+vi.mock("./kv", () => ({
+  kv: {
+    zadd: vi.fn(async (_key: string, entry: { score: number; member: string }) => {
+      const isNew = !store.has(entry.member);
+      store.set(entry.member, entry.score);
+      return isNew ? 1 : 0;
+    }),
+    zrem: vi.fn(async (_key: string, member: string) => {
+      return store.delete(member) ? 1 : 0;
+    }),
+    zscore: vi.fn(async (_key: string, member: string) => {
+      return store.has(member) ? store.get(member)! : null;
+    }),
+    zrange: vi.fn(
+      async (
+        _key: string,
+        _start: number,
+        _stop: number,
+        options?: { rev?: boolean },
+      ) => {
+        const sorted = [...store.entries()].sort((a, b) => a[1] - b[1]);
+        if (options?.rev) sorted.reverse();
+        // Mimic @upstash/redis auto-deserialization: JSON members come
+        // back as objects, non-JSON members as raw strings (verified
+        // against the live instance, #124).
+        return sorted.map(([member]) => {
+          try {
+            return JSON.parse(member);
+          } catch {
+            return member;
+          }
+        });
+      },
+    ),
+  },
+}));
+
+import {
+  saveKnowledgeEntry,
+  supersedeKnowledgeEntry,
+  markKnowledgeSuperseded,
+  archiveKnowledgeEntry,
+  getAllKnowledge,
+  getKnowledgeHistory,
+  getKnowledgeAsMarkdown,
+  STALE_CONTEXT_FOOTER,
+} from "./knowledge";
+
+// Inject a raw member directly, bypassing the public API — used to
+// simulate legacy entries written before ids existed.
+function injectRawMember(member: string, score: number): void {
+  store.set(member, score);
+}
+
+beforeEach(() => {
+  store.clear();
+});
+
+describe("saveKnowledgeEntry", () => {
+  it("returns a stable non-empty id", async () => {
+    const id = await saveKnowledgeEntry("Auth lives in src/lib/auth.ts");
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it("saved entry is visible with its id and a YYYY-MM-DD timestamp", async () => {
+    const id = await saveKnowledgeEntry("The deploy target is Vercel");
+    const entries = await getAllKnowledge();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe(id);
+    expect(entries[0].entry).toBe("The deploy target is Vercel");
+    expect(entries[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("assigns distinct ids to distinct saves", async () => {
+    const a = await saveKnowledgeEntry("fact a");
+    const b = await saveKnowledgeEntry("fact b");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("legacy entries (no id field)", () => {
+  it("parse as visible entries", async () => {
+    injectRawMember(
+      JSON.stringify({ entry: "Legacy fact", timestamp: "2025-11-01" }),
+      1_700_000_000_000,
+    );
+    const entries = await getAllKnowledge();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].entry).toBe("Legacy fact");
+    expect(entries[0].id).toBeUndefined();
+  });
+
+  it("plain non-JSON string members surface in history without crashing", async () => {
+    injectRawMember("bare legacy string entry", 900);
+    const history = await getKnowledgeHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].entry).toBe("bare legacy string entry");
+    expect(history[0].timestamp).toBe("unknown");
+  });
+
+  it("can be superseded by matching entry text", async () => {
+    injectRawMember(
+      JSON.stringify({ entry: "Old legacy fact", timestamp: "2025-11-01" }),
+      1_700_000_000_000,
+    );
+    const newId = await saveKnowledgeEntry("Corrected fact");
+    const ok = await markKnowledgeSuperseded("Old legacy fact", newId);
+    expect(ok).toBe(true);
+
+    const visible = await getAllKnowledge();
+    expect(visible.map((e) => e.entry)).toEqual(["Corrected fact"]);
+
+    const history = await getKnowledgeHistory();
+    const old = history.find((e) => e.entry === "Old legacy fact");
+    expect(old?.supersededById).toBe(newId);
+  });
+});
+
+describe("supersedeKnowledgeEntry", () => {
+  it("hides the old entry, creates the replacement, and links them", async () => {
+    const oldId = await saveKnowledgeEntry("Auth uses sessions");
+    const newId = await supersedeKnowledgeEntry(oldId, "Auth uses JWT");
+    expect(newId).not.toBeNull();
+
+    const visible = await getAllKnowledge();
+    expect(visible.map((e) => e.entry)).toEqual(["Auth uses JWT"]);
+
+    const history = await getKnowledgeHistory();
+    const old = history.find((e) => e.id === oldId);
+    expect(old?.supersededById).toBe(newId);
+  });
+
+  it("returns null and creates nothing when the old entry does not exist", async () => {
+    const result = await supersedeKnowledgeEntry("no-such-id", "new text");
+    expect(result).toBeNull();
+    expect(await getKnowledgeHistory()).toHaveLength(0);
+  });
+
+  it("preserves the superseded entry's zset score so history ordering is stable", async () => {
+    const oldId = await saveKnowledgeEntry("original");
+    const rawBefore = [...store.entries()].find(([m]) => m.includes("original"));
+    expect(rawBefore).toBeDefined();
+    const scoreBefore = rawBefore![1];
+
+    await supersedeKnowledgeEntry(oldId, "replacement");
+
+    const rawAfter = [...store.entries()].find(([m]) => m.includes("original"));
+    expect(rawAfter).toBeDefined();
+    expect(rawAfter![1]).toBe(scoreBefore);
+  });
+});
+
+describe("markKnowledgeSuperseded", () => {
+  it("matches by id", async () => {
+    const oldId = await saveKnowledgeEntry("fact to retire");
+    const newId = await saveKnowledgeEntry("newer fact");
+    expect(await markKnowledgeSuperseded(oldId, newId)).toBe(true);
+    const visible = await getAllKnowledge();
+    expect(visible.map((e) => e.entry)).toEqual(["newer fact"]);
+  });
+
+  it("returns false when no entry matches", async () => {
+    expect(await markKnowledgeSuperseded("ghost", "x")).toBe(false);
+  });
+
+  it("never marks an entry as superseded by itself (text collision with its own replacement)", async () => {
+    // A correction whose text matches the flagged entry text must not
+    // self-link when the old entry is gone and text-matching falls
+    // through to the replacement itself.
+    const newId = await saveKnowledgeEntry("Auth uses JWT");
+    const ok = await markKnowledgeSuperseded("Auth uses JWT", newId);
+    expect(ok).toBe(false);
+    const entries = await getAllKnowledge();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].supersededById).toBeUndefined();
+  });
+
+  it("is a no-op on an already-superseded entry (does not resurrect or relink)", async () => {
+    const oldId = await saveKnowledgeEntry("fact");
+    const firstNewId = await saveKnowledgeEntry("first correction");
+    await markKnowledgeSuperseded(oldId, firstNewId);
+    const ok = await markKnowledgeSuperseded(oldId, "some-other-id");
+    expect(ok).toBe(false);
+    const history = await getKnowledgeHistory();
+    const old = history.find((e) => e.id === oldId);
+    expect(old?.supersededById).toBe(firstNewId);
+  });
+});
+
+describe("archiveKnowledgeEntry", () => {
+  it("hides the entry and records reason + archive date", async () => {
+    const id = await saveKnowledgeEntry("obsolete fact");
+    const ok = await archiveKnowledgeEntry(id, "confirmed stale via 👎");
+    expect(ok).toBe(true);
+
+    expect(await getAllKnowledge()).toHaveLength(0);
+    const history = await getKnowledgeHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].archivedReason).toBe("confirmed stale via 👎");
+    expect(history[0].archivedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("returns false for an unknown entry", async () => {
+    expect(await archiveKnowledgeEntry("nope", "reason")).toBe(false);
+  });
+});
+
+describe("getAllKnowledge ordering", () => {
+  it("returns visible entries newest first by zset score", async () => {
+    injectRawMember(JSON.stringify({ entry: "oldest", timestamp: "2025-01-01" }), 1000);
+    injectRawMember(JSON.stringify({ entry: "middle", timestamp: "2025-06-01" }), 2000);
+    injectRawMember(JSON.stringify({ entry: "newest", timestamp: "2026-01-01" }), 3000);
+    const entries = await getAllKnowledge();
+    expect(entries.map((e) => e.entry)).toEqual(["newest", "middle", "oldest"]);
+  });
+});
+
+describe("getKnowledgeAsMarkdown", () => {
+  it("renders dated visible entries and ends with the stale-context footer", async () => {
+    await saveKnowledgeEntry("KB fact one");
+    const md = await getKnowledgeAsMarkdown();
+    expect(md).not.toBeNull();
+    expect(md!).toContain("KB fact one");
+    expect(md!).toMatch(/- \[\d{4}-\d{2}-\d{2}\] KB fact one/);
+    expect(md!.trimEnd().endsWith(STALE_CONTEXT_FOOTER)).toBe(true);
+  });
+
+  it("excludes superseded entries", async () => {
+    const oldId = await saveKnowledgeEntry("stale fact");
+    await supersedeKnowledgeEntry(oldId, "fresh fact");
+    const md = await getKnowledgeAsMarkdown();
+    expect(md!).toContain("fresh fact");
+    expect(md!).not.toContain("stale fact");
+  });
+
+  it("returns null when no visible entries remain", async () => {
+    const id = await saveKnowledgeEntry("only fact");
+    await archiveKnowledgeEntry(id, "cleanup");
+    expect(await getKnowledgeAsMarkdown()).toBeNull();
+  });
+
+  it("returns null when the KB is empty", async () => {
+    expect(await getKnowledgeAsMarkdown()).toBeNull();
+  });
+});

--- a/src/lib/knowledge.test.ts
+++ b/src/lib/knowledge.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { vi } from "vitest";
 
+const { logSpy } = vi.hoisted(() => ({ logSpy: vi.fn() }));
+vi.mock("./logger", () => ({
+  log: (...args: unknown[]) => logSpy(...args),
+}));
+
 // In-memory zset fake for the kv wrapper. Only the ops knowledge.ts uses.
 // `store` maps member JSON → score, mirroring a Redis sorted set.
 const { store } = vi.hoisted(() => ({
@@ -61,8 +66,11 @@ function injectRawMember(member: string, score: number): void {
   store.set(member, score);
 }
 
+import { kv } from "./kv";
+
 beforeEach(() => {
   store.clear();
+  logSpy.mockClear();
 });
 
 describe("saveKnowledgeEntry", () => {
@@ -146,6 +154,23 @@ describe("supersedeKnowledgeEntry", () => {
     expect(await getKnowledgeHistory()).toHaveLength(0);
   });
 
+  it("still returns the new id (correction preserved) and logs when linking fails", async () => {
+    const oldId = await saveKnowledgeEntry("original");
+    // Simulate losing the zrem race: the old member vanishes between
+    // the visibility check and the rewrite.
+    vi.mocked(kv.zrem).mockResolvedValueOnce(0);
+
+    const newId = await supersedeKnowledgeEntry(oldId, "replacement");
+    expect(newId).not.toBeNull();
+
+    const visible = await getAllKnowledge();
+    expect(visible.some((e) => e.entry === "replacement")).toBe(true);
+    expect(logSpy).toHaveBeenCalledWith(
+      "knowledge_supersede_link_failed",
+      expect.objectContaining({ newId }),
+    );
+  });
+
   it("preserves the superseded entry's zset score so history ordering is stable", async () => {
     const oldId = await saveKnowledgeEntry("original");
     const rawBefore = [...store.entries()].find(([m]) => m.includes("original"));
@@ -171,6 +196,26 @@ describe("markKnowledgeSuperseded", () => {
 
   it("returns false when no entry matches", async () => {
     expect(await markKnowledgeSuperseded("ghost", "x")).toBe(false);
+  });
+
+  it("skips a non-visible first text match and supersedes a later visible duplicate", async () => {
+    // Two entries share the same text; the older one is already
+    // superseded. Text matching must not stop at the rejected first
+    // match — the visible duplicate should be retired.
+    injectRawMember(
+      JSON.stringify({ id: "a", entry: "dup fact", timestamp: "2025-01-01", supersededById: "x" }),
+      1000,
+    );
+    injectRawMember(
+      JSON.stringify({ id: "b", entry: "dup fact", timestamp: "2025-06-01" }),
+      2000,
+    );
+    const ok = await markKnowledgeSuperseded("dup fact", "n1");
+    expect(ok).toBe(true);
+
+    const history = await getKnowledgeHistory();
+    expect(history.find((e) => e.id === "a")?.supersededById).toBe("x");
+    expect(history.find((e) => e.id === "b")?.supersededById).toBe("n1");
   });
 
   it("never marks an entry as superseded by itself (text collision with its own replacement)", async () => {

--- a/src/lib/knowledge.ts
+++ b/src/lib/knowledge.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
 import { kv } from "./kv";
+import { log } from "./logger";
 
 /**
  * Knowledge Base — Vercel KV storage
@@ -85,11 +86,13 @@ export async function saveKnowledgeEntry(entry: string): Promise<string> {
 }
 
 /**
- * Find the member matching an entry id or exact entry text and rewrite
- * it in place (zrem + zadd of the mutated JSON, preserving the original
- * score so ordering is stable). Returns false if no match, if `mutate`
- * rejects the entry (returns null), or if the member disappeared
- * between read and remove.
+ * Find a member matching an entry id or exact entry text that `mutate`
+ * accepts, and rewrite it in place (zrem + zadd of the mutated JSON,
+ * preserving the original score so ordering is stable). Matches that
+ * `mutate` rejects (returns null) are skipped, not terminal — duplicate
+ * entry texts where the first duplicate is already superseded must not
+ * shadow a later visible one. Returns false if no acceptable match
+ * exists or the member disappeared between read and remove.
  *
  * Concurrency: zscore→zrem→zadd is not atomic. The zrem-count guard
  * ensures we never resurrect a member a concurrent writer already
@@ -108,7 +111,7 @@ async function updateEntry(
     if (parsed.id !== idOrText && parsed.entry !== idOrText) continue;
 
     const updated = mutate(parsed);
-    if (!updated) return false;
+    if (!updated) continue;
 
     const member = toMemberString(rawMember);
     const score = await kv.zscore(KNOWLEDGE_KEY, member);
@@ -143,6 +146,11 @@ export async function markKnowledgeSuperseded(
  * Replace an entry: saves `newEntryText` as a fresh entry and marks the
  * old one superseded by it. Returns the new entry's id, or null (and
  * saves nothing) if no visible entry matches `oldIdOrText`.
+ *
+ * If a concurrent writer retires the old entry between the visibility
+ * check and the mark, the correction still stands (its id is returned)
+ * but the history link is lost — logged as knowledge_supersede_link_failed
+ * so the gap is observable rather than silent.
  */
 export async function supersedeKnowledgeEntry(
   oldIdOrText: string,
@@ -158,7 +166,10 @@ export async function supersedeKnowledgeEntry(
   if (!target) return null;
 
   const newId = await saveKnowledgeEntry(newEntryText);
-  await markKnowledgeSuperseded(oldIdOrText, newId);
+  const linked = await markKnowledgeSuperseded(oldIdOrText, newId);
+  if (!linked) {
+    log("knowledge_supersede_link_failed", { newId });
+  }
   return newId;
 }
 

--- a/src/lib/knowledge.ts
+++ b/src/lib/knowledge.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { kv } from "./kv";
 
 /**
@@ -6,76 +7,200 @@ import { kv } from "./kv";
  * Stores corrections and learned facts from Slack conversations.
  * No GitHub write access needed — all data lives in Vercel KV.
  *
- * Schema: sorted set "knowledge:entries" with score = unix timestamp
- * Each entry is a string like "The auth module lives in app/Services/Auth"
+ * Schema: sorted set "knowledge:entries" with score = unix timestamp.
+ * Each member is a JSON-encoded KnowledgeEntry. Entries are never
+ * deleted on correction — they are superseded (linked to their
+ * replacement) or archived (soft-deleted with a reason), so the full
+ * history of what was believed and why it changed is preserved. See #124.
+ *
+ * Legacy members ({entry, timestamp} without id) predate #124 and parse
+ * as visible entries; they can be superseded/archived by entry text.
  */
 
 const KNOWLEDGE_KEY = "knowledge:entries";
 
 export interface KnowledgeEntry {
+  /** Stable id assigned at save time. Absent on legacy entries. */
+  id?: string;
   entry: string;
   timestamp: string; // ISO date (YYYY-MM-DD)
+  /** Set when a correction replaced this entry — points at the replacement's id. */
+  supersededById?: string;
+  /** ISO date the entry was soft-deleted. */
+  archivedAt?: string;
+  archivedReason?: string;
+}
+
+/**
+ * Rendered after KB entries in the system prompt so a stale entry never
+ * competes head-to-head with fresh repository evidence.
+ */
+export const STALE_CONTEXT_FOOTER =
+  "_Treat these as possibly stale context. Current user instructions and repository evidence take priority._";
+
+function isVisible(e: KnowledgeEntry): boolean {
+  return !e.supersededById && !e.archivedAt;
+}
+
+function todayISO(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+// @upstash/redis auto-deserializes zrange members: JSON members come back
+// as objects, not strings (verified against the live instance, #124).
+// Accept both shapes so the code also survives clients/fixtures that
+// return raw strings.
+function toEntry(raw: unknown): KnowledgeEntry | null {
+  if (raw !== null && typeof raw === "object") {
+    const e = raw as KnowledgeEntry;
+    return typeof e.entry === "string" ? e : null;
+  }
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw) as KnowledgeEntry;
+      return typeof parsed.entry === "string" ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+// The member string to pass to zscore/zrem so it matches the stored
+// bytes. JSON.stringify of a deserialized member reproduces the original
+// compact encoding (object key order survives the parse round-trip).
+function toMemberString(raw: unknown): string {
+  return typeof raw === "string" ? raw : JSON.stringify(raw);
 }
 
 /**
  * Save a correction or fact to the knowledge base.
+ * Returns the new entry's id so callers can link supersessions to it.
  */
-export async function saveKnowledgeEntry(entry: string): Promise<void> {
-  const timestamp = Date.now();
-  // Store as JSON with date for display
-  const value = JSON.stringify({
-    entry,
-    timestamp: new Date().toISOString().split("T")[0],
-  });
-  await kv.zadd(KNOWLEDGE_KEY, { score: timestamp, member: value });
+export async function saveKnowledgeEntry(entry: string): Promise<string> {
+  const id = randomUUID();
+  const value = JSON.stringify({ id, entry, timestamp: todayISO() });
+  await kv.zadd(KNOWLEDGE_KEY, { score: Date.now(), member: value });
+  return id;
 }
 
 /**
- * Remove a knowledge entry by matching its entry text.
- * Returns true if the entry was found and removed.
+ * Find the member matching an entry id or exact entry text and rewrite
+ * it in place (zrem + zadd of the mutated JSON, preserving the original
+ * score so ordering is stable). Returns false if no match, if `mutate`
+ * rejects the entry (returns null), or if the member disappeared
+ * between read and remove.
+ *
+ * Concurrency: zscore→zrem→zadd is not atomic. The zrem-count guard
+ * ensures we never resurrect a member a concurrent writer already
+ * rewrote — if zrem removes nothing, we abort instead of zadd-ing a
+ * stale copy. Worst case under a race is a skipped update, never a
+ * duplicated or revived entry.
  */
-export async function removeKnowledgeEntry(entryText: string): Promise<boolean> {
-  const entries = await getAllKnowledge();
-  // Find the raw JSON member that matches this entry text
+async function updateEntry(
+  idOrText: string,
+  mutate: (e: KnowledgeEntry) => KnowledgeEntry | null,
+): Promise<boolean> {
   const raw = await kv.zrange(KNOWLEDGE_KEY, 0, -1);
-  for (const member of raw as string[]) {
-    try {
-      const parsed = JSON.parse(member) as KnowledgeEntry;
-      if (parsed.entry === entryText) {
-        await kv.zrem(KNOWLEDGE_KEY, member);
-        return true;
-      }
-    } catch {
-      continue;
-    }
+  for (const rawMember of raw) {
+    const parsed = toEntry(rawMember);
+    if (!parsed) continue;
+    if (parsed.id !== idOrText && parsed.entry !== idOrText) continue;
+
+    const updated = mutate(parsed);
+    if (!updated) return false;
+
+    const member = toMemberString(rawMember);
+    const score = await kv.zscore(KNOWLEDGE_KEY, member);
+    if (score === null) return false;
+    const removed = await kv.zrem(KNOWLEDGE_KEY, member);
+    if (removed === 0) return false;
+    await kv.zadd(KNOWLEDGE_KEY, { score, member: JSON.stringify(updated) });
+    return true;
   }
   return false;
 }
 
 /**
- * Get all knowledge entries, newest first.
+ * Mark an existing visible entry as superseded by `supersededById`.
+ * Matches by id or exact entry text (text supports legacy entries and
+ * the 👎 flow, which stores flagged entry texts). Already-superseded or
+ * archived entries are left untouched (returns false) so a stale flag
+ * can't relink history.
  */
-export async function getAllKnowledge(): Promise<KnowledgeEntry[]> {
-  const raw = await kv.zrange(KNOWLEDGE_KEY, 0, -1, { rev: true });
-  return (raw as string[]).map((item) => {
-    try {
-      return JSON.parse(item) as KnowledgeEntry;
-    } catch {
-      // Legacy string entry (shouldn't happen but be safe)
-      return { entry: String(item), timestamp: "unknown" };
-    }
-  });
+export async function markKnowledgeSuperseded(
+  idOrText: string,
+  supersededById: string,
+): Promise<boolean> {
+  return updateEntry(idOrText, (e) =>
+    // The id guard prevents self-supersession when a correction's text
+    // exactly matches the flagged entry text it replaces.
+    isVisible(e) && e.id !== supersededById ? { ...e, supersededById } : null,
+  );
 }
 
 /**
- * Format all knowledge entries as markdown for the system prompt.
- * Returns null if no entries exist.
+ * Replace an entry: saves `newEntryText` as a fresh entry and marks the
+ * old one superseded by it. Returns the new entry's id, or null (and
+ * saves nothing) if no visible entry matches `oldIdOrText`.
+ */
+export async function supersedeKnowledgeEntry(
+  oldIdOrText: string,
+  newEntryText: string,
+): Promise<string | null> {
+  const raw = await kv.zrange(KNOWLEDGE_KEY, 0, -1);
+  const target = raw
+    .map(toEntry)
+    .find(
+      (e): e is KnowledgeEntry =>
+        e !== null && isVisible(e) && (e.id === oldIdOrText || e.entry === oldIdOrText),
+    );
+  if (!target) return null;
+
+  const newId = await saveKnowledgeEntry(newEntryText);
+  await markKnowledgeSuperseded(oldIdOrText, newId);
+  return newId;
+}
+
+/**
+ * Soft-delete an entry with a reason. Matches by id or exact entry text.
+ */
+export async function archiveKnowledgeEntry(
+  idOrText: string,
+  reason: string,
+): Promise<boolean> {
+  return updateEntry(idOrText, (e) =>
+    isVisible(e) ? { ...e, archivedAt: todayISO(), archivedReason: reason } : null,
+  );
+}
+
+/**
+ * All entries — visible, superseded, and archived — newest first.
+ */
+export async function getKnowledgeHistory(): Promise<KnowledgeEntry[]> {
+  const raw = await kv.zrange(KNOWLEDGE_KEY, 0, -1, { rev: true });
+  return raw.map(
+    (item) => toEntry(item) ?? { entry: String(item), timestamp: "unknown" },
+  );
+}
+
+/**
+ * Get visible knowledge entries (not superseded, not archived), newest first.
+ */
+export async function getAllKnowledge(): Promise<KnowledgeEntry[]> {
+  return (await getKnowledgeHistory()).filter(isVisible);
+}
+
+/**
+ * Format visible knowledge entries as markdown for the system prompt,
+ * ending with the stale-context footer. Returns null if none exist.
  */
 export async function getKnowledgeAsMarkdown(): Promise<string | null> {
   try {
     const entries = await getAllKnowledge();
     if (entries.length === 0) return null;
-    return entries.map((e) => `- [${e.timestamp}] ${e.entry}`).join("\n");
+    const lines = entries.map((e) => `- [${e.timestamp}] ${e.entry}`).join("\n");
+    return `${lines}\n\n${STALE_CONTEXT_FOOTER}`;
   } catch {
     // KV not configured (local dev without Vercel KV) — skip silently
     return null;

--- a/src/lib/kv.test.ts
+++ b/src/lib/kv.test.ts
@@ -22,6 +22,7 @@ const redisMock = vi.hoisted(() => ({
   zadd: vi.fn(),
   zrange: vi.fn(),
   zrem: vi.fn(),
+  zscore: vi.fn(),
 }));
 vi.mock("@upstash/redis", () => ({
   Redis: {
@@ -218,6 +219,48 @@ describe("kv.zrem observability", () => {
         keyPrefix: "knowledge",
         removed: 1,
       }),
+    );
+  });
+});
+
+describe("kv.zscore observability", () => {
+  beforeEach(() => {
+    logSpy.mockClear();
+    vi.mocked(Sentry.captureException).mockClear();
+    redisMock.zscore.mockReset();
+  });
+
+  it("logs op=zscore with key prefix and found=true when member exists", async () => {
+    redisMock.zscore.mockResolvedValue(1720000000000);
+    const result = await kv.zscore("knowledge:entries", "some member");
+    expect(result).toBe(1720000000000);
+    expect(logSpy).toHaveBeenCalledWith(
+      "kv_op",
+      expect.objectContaining({
+        op: "zscore",
+        keyPrefix: "knowledge",
+        found: true,
+      }),
+    );
+  });
+
+  it("returns null and logs found=false for a missing member", async () => {
+    redisMock.zscore.mockResolvedValue(null);
+    const result = await kv.zscore("knowledge:entries", "missing");
+    expect(result).toBeNull();
+    expect(logSpy).toHaveBeenCalledWith(
+      "kv_op",
+      expect.objectContaining({ op: "zscore", found: false }),
+    );
+  });
+
+  it("captures Sentry exception and rethrows on failure", async () => {
+    const err = new Error("zscore failed");
+    redisMock.zscore.mockRejectedValue(err);
+    await expect(kv.zscore("knowledge:entries", "m")).rejects.toThrow("zscore failed");
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      err,
+      expect.objectContaining({ tags: expect.objectContaining({ "kv.op": "zscore" }) }),
     );
   });
 });

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -41,7 +41,7 @@ export function keyPrefix(key: string): string {
 
 // ── Core wrap helpers (private) ──────────────────────────────────────
 
-type KVOp = "get" | "set" | "del" | "zadd" | "zrange" | "zrem";
+type KVOp = "get" | "set" | "del" | "zadd" | "zrange" | "zrem" | "zscore";
 
 function sentryTags(op: KVOp, prefix: string): Sentry.CaptureContext {
   return { tags: { "kv.op": op, "kv.keyPrefix": prefix } };
@@ -169,6 +169,24 @@ export const kv = {
       return result;
     } catch (err) {
       logError("zrem", prefix, startedAt, err);
+      throw err;
+    }
+  },
+
+  async zscore(key: string, member: string): Promise<number | null> {
+    const prefix = keyPrefix(key);
+    const startedAt = Date.now();
+    try {
+      const result = await client.zscore(key, member);
+      log("kv_op", {
+        op: "zscore",
+        keyPrefix: prefix,
+        durationMs: Date.now() - startedAt,
+        found: result !== null && result !== undefined,
+      });
+      return result ?? null;
+    } catch (err) {
+      logError("zscore", prefix, startedAt, err);
       throw err;
     }
   },


### PR DESCRIPTION
## Summary

Implements #124 — knowledge base entries are never deleted on correction anymore. They're **superseded** (linked to their replacement) or **archived** (soft-deleted with a reason), preserving the history of what was believed and why it changed. Prompt rendering now ends with a stale-context footer so a KB entry never competes head-to-head with fresh repository evidence.

## Changes

- **`src/lib/knowledge.ts`**: entries get a stable `id` at save; new `markKnowledgeSuperseded`, `supersedeKnowledgeEntry`, `archiveKnowledgeEntry`, `getKnowledgeHistory`; `getAllKnowledge` returns visible entries only; `getKnowledgeAsMarkdown` appends the stale-context footer; dead `removeKnowledgeEntry` removed
- **`src/lib/kv.ts`**: `zscore` op added with the standard observability wrapping (needed to preserve zset ordering when rewriting a member in place)
- **`src/app/api/slack/route.ts`**: a correction reply now retires the KB entries flagged at 👎 time — each is marked superseded by the saved correction (`supersededCount` added to the `correction_saved` event)
- **Docs**: `knowledge-base.md` and `auto-correction.md` updated for the lifecycle

## Latent bug fixed along the way

`@upstash/redis` auto-deserializes zrange members — JSON members arrive as **objects**, not strings. The previous `JSON.parse(member)` pattern threw and fell into the legacy fallback, rendering entries as `[object Object]`. Member handling now accepts both shapes. Round-trip semantics (`zrange`/`zscore`/`zrem` member matching) were verified against the live Upstash instance on a scratch key.

## Concurrency notes

`zscore → zrem → zadd` is not atomic. The zrem-count guard aborts the rewrite if a concurrent writer already removed/rewrote the member — worst case under a race is a skipped update, never a duplicated or revived entry. Self-supersession (correction text colliding with the flagged entry text) is explicitly guarded and tested.

## Testing

- TDD: 19 new tests in `knowledge.test.ts` (written first, RED verified), 3 new `zscore` tests in `kv.test.ts`
- Full suite: **523 passed**, typecheck clean
- Test fake mimics real Upstash deserialization (objects for JSON members, strings otherwise)

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Knowledge-base entries can now be updated with corrections while preserving older versions as history.
  * Entries can also be hidden from future prompts without being fully deleted.

* **Bug Fixes**
  * Thumbs-down feedback now only retires entries after a real correction is provided.
  * Hidden or outdated entries are excluded from generated prompt context, reducing stale results.

* **Documentation**
  * Updated guidance and examples to reflect the new entry lifecycle and correction flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->