### PR TITLE
feat: Adaptive effort routing — follow-up gate + per-turn budgets (closes #126)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ A Slack agent with Claude AI intelligence and full GitHub repo access — reads 
 
 - **Runtime**: Vercel (Next.js serverless functions)
 - **Slack**: Webhook mode via Next.js API route (`/api/slack`), ack-then-process via `after()`
-- **AI**: Anthropic Claude API with tool use (7 tools, 15-round budget)
+- **AI**: Anthropic Claude API with tool use (7 tools, adaptive per-turn round budget: quick 4 / standard 10 / deep 15)
 - **GitHub**: Octokit REST API (fine-grained PAT, read-only for code/PRs, read-write for issues)
 - **Knowledge**: Vercel KV (corrections, feedback, repo index cache)
 - **Context**: CLAUDE.md + KB + feedback + repo index + source hierarchy + search strategy + recency/brevity rules
@@ -34,7 +34,7 @@ npm run dev                  # http://localhost:3000
 
 5. **Issue creation requires confirmation** — The agent can propose one or many GitHub issues in a single turn but NEVER creates any without explicit approval. Approval is either a ✅ reaction on the proposal message or a short thread reply like "confirm all" / "yes". See `docs/features/issue-creation.md`.
 
-6. **Thread follow-ups** — Once the bot is participating in a thread, users can send follow-up messages without re-mentioning. The bot checks for its own prior replies before responding.
+6. **Thread follow-ups** — Once the bot is participating in a thread, users can send follow-up messages without re-mentioning. The bot checks for its own prior replies, then a fast-model classifier decides whether the message is actually addressed to the bot — anything else (human-to-human chatter, classifier errors) fails closed to silence. See `docs/features/effort-routing.md`.
 
 ## Project Structure
 
@@ -50,6 +50,7 @@ src/
     knowledge.ts          — Knowledge base (Vercel KV sorted set)
     feedback.ts           — Feedback storage (Vercel KV) and Q&A context
     issue-batch.ts        — Pure helpers for multi-proposal formatting and bulk-confirm matching
+    effort-routing.ts     — Turn classifier (follow-up shouldReply gate + effort buckets → round/answer budgets)
     config.ts             — .battle-mage.json loader (path annotations with graduated trust)
     repo-index.ts         — Repository topic index (lazy rebuild on SHA change)
     auto-correct.ts       — Stale KB entry detection and doc reference flagging
@@ -82,6 +83,7 @@ docs/
     progress-ux.md        — Live progress updates (emoji + status)
     message-splitting.md  — Long-reply chunking architecture (split-reply + boundary guard)
     issue-creation.md     — Batch issue proposals + bulk-confirm flow
+    effort-routing.md     — Fast-model follow-up gate + per-turn effort budgets
 ```
 
 ## Testing (TDD Required)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ See the [full setup guide](docs/setup.md) for Slack app creation, GitHub PAT, Ve
 | Auto-Correction on 👎 | [docs/features/auto-correction.md](docs/features/auto-correction.md) |
 | Live Progress Updates | [docs/features/progress-ux.md](docs/features/progress-ux.md) |
 | Path Annotations (.battle-mage.json) | [docs/features/config.md](docs/features/config.md) |
+| Adaptive Effort Routing | [docs/features/effort-routing.md](docs/features/effort-routing.md) |
 
 ## Environment Variables
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ POST /api/slack (Next.js API route)
         │     │   └── Update thinking message: "🔍 Searching for auth middleware..."
         │     ├── Tool round 2: read_file("src/middleware/auth.ts")
         │     │   └── Update thinking message: "📖 Reading src/middleware/auth.ts..."
-        │     └── ... up to 15 rounds
+        │     └── ... up to the effort-routed round budget (quick 4 / standard 10 / deep 15)
         ├── Convert markdown to Slack mrkdwn
         ├── Format reference links
         └── Post final answer via `postReplyInChunks`
@@ -167,7 +167,7 @@ A warm thread should see `cache_read_tokens` dominate after the first turn. A co
 
 ## The Agent Loop
 
-The agent loop is a Claude tool-use loop with a hard cap of 15 rounds. It is **non-streaming** — each round is a single `messages.create` call that returns the complete response before any tools run (see [Message Splitting](./features/message-splitting.md) for why streaming was removed):
+The agent loop is a Claude tool-use loop with a per-turn round cap set by the effort classifier — quick 4 / standard 10 / deep 15, hard ceiling `MAX_TOOL_ROUNDS = 15` (see [Effort Routing](./features/effort-routing.md)). It is **non-streaming** — each round is a single `messages.create` call that returns the complete response before any tools run (see [Message Splitting](./features/message-splitting.md) for why streaming was removed):
 
 ```
 for round in 0..MAX_TOOL_ROUNDS:
@@ -194,11 +194,11 @@ Progress updates run via `onProgress(toolName, input)` → `progressThrottle.upd
 Battle Mage uses two Anthropic models:
 
 - **`MODEL = "claude-sonnet-4-6"`** — the main agent. All tool-use reasoning, synthesis, and answer generation run on Sonnet. Everything that the user sees is produced by this model.
-- **`FAST_MODEL = "claude-haiku-4-5-20251001"`** — side tasks where Sonnet would be overkill. Today: **thread-history compaction**. Future candidates: thread title generation, LLM-based topic classification.
+- **`FAST_MODEL = "claude-haiku-4-5-20251001"`** — side tasks where Sonnet would be overkill. Today: **thread-history compaction** and the **turn classifier** (one combined call for the follow-up shouldReply gate + effort bucketing — see [Effort Routing](./features/effort-routing.md)). Future candidates: thread title generation.
 
 Rule: tasks that face the user directly or require multi-step reasoning stay on Sonnet. Tasks that are one-shot, summarization-shaped, or high-volume low-nuance classification go to Haiku. Haiku is ~5× cheaper and ~2× faster for this shape of work; the quality drop on summarization is imperceptible.
 
-Every per-call log (`agent_start`, `agent_complete`, `agent_api_error`, `thread_compacted`) includes a `model` field so you can audit which tier ran which call from Sentry.
+Every per-call log (`agent_start`, `agent_complete`, `agent_api_error`, `thread_compacted`, `turn_classified`) includes a `model` field so you can audit which tier ran which call from Sentry.
 
 ### Thread-history compaction (see #76)
 
@@ -326,7 +326,7 @@ This ensures users see the most authoritative sources first.
 | **Verify before asserting** | The agent uses GitHub tools to check that files and methods actually exist before referencing them. No hallucinated code references. |
 | **Issue creation requires confirmation** | The bot proposes issues but never creates them without explicit :white_check_mark: reaction. Prevents accidental issue spam. |
 | **Search first, read second** | The system prompt instructs Claude to search for code patterns before reading files. A single search returns multiple paths with context, avoiding blind file reads. |
-| **15 tool round budget** | Hard cap prevents runaway tool loops. The system prompt instructs Claude to synthesize early rather than exhausting all rounds. |
+| **Adaptive tool round budget** | An effort classifier sizes each turn's round cap (quick 4 / standard 10 / deep 15). The hard ceiling of 15 prevents runaway tool loops, and the system prompt instructs Claude to synthesize early rather than exhausting all rounds. See [Effort Routing](./features/effort-routing.md). |
 | **References from reads only** | Search results are discovery aids and do not appear in references. Only files the agent actually reads (via `read_file`) are cited. |
 | **KV for knowledge, not GitHub** | The knowledge base lives in Vercel KV, not in the GitHub repo. The GitHub PAT does not need Contents: Write permission. |
 | **Split long answers, don't truncate** | Answers over ~3K chars post as multiple thread replies (`[continued ↓]`) instead of being silently cut off. Makes Slack's `msg_too_long` architecturally unreachable on the happy path. See [Message Splitting](./features/message-splitting.md). |

--- a/docs/features/effort-routing.md
+++ b/docs/features/effort-routing.md
@@ -1,0 +1,78 @@
+# Adaptive Effort Routing
+
+Two per-turn decisions, one cheap Haiku call (see #126):
+
+1. **shouldReply** — is a thread follow-up actually addressed to the bot? The old heuristic (bot has a prior reply in the thread) made the bot answer human-to-human chatter. Now a fast-model classifier reads the recent transcript and the new message and gates the reply.
+2. **effort** — bucket the question into `quick | standard | deep`, sizing the agent's tool-round budget and answer-length target so trivial questions stop costing 15 rounds and hard ones stop being squeezed into a 3K-char answer.
+
+All logic lives in `src/lib/effort-routing.ts`; the Slack route (`src/app/api/slack/route.ts`) composes it.
+
+## The classifier call
+
+`classifyTurn(input, deps)` makes **one** structured call on `FAST_MODEL` (Haiku, `max_tokens: 256`) with `TURN_CLASSIFIER_PROMPT` — a reviewed exported constant with `<INVOCATION>` / `<TRANSCRIPT>` / `<QUESTION>` slots. The model returns exactly:
+
+```json
+{"shouldReply": true, "shouldReplyConfidence": 0.92, "effort": "quick", "effortConfidence": 0.85}
+```
+
+- The transcript slot is filled by `extractTranscriptTail(messages, botUserId)` (`src/lib/thread-filter.ts`): the last 6 thread entries, mention-stripped, 500 chars max each, labeled `bot:` / `user:`.
+- The call is capped at `CLASSIFIER_TIMEOUT_MS = 3000` via `Promise.race`.
+- `classifyTurn` **never throws**. API errors, timeouts, unparseable output, and shape violations (missing keys, unknown bucket, confidences outside `[0, 1]` — rejected, never clamped) all return `null` and log `turn_classifier_error` with a stable `reason`.
+- Dependency injection mirrors `compaction.ts`: `ClassifyDeps { call?, log? }`, so every branch is unit-testable without network.
+
+## Decisions and thresholds
+
+`CONFIDENCE_THRESHOLD = 0.75`, compared with `>=`. Two pure sync interpreters consume the (possibly null) verdict:
+
+| Function | Verdict null / below threshold | Confident verdict |
+|----------|-------------------------------|-------------------|
+| `decideShouldReply` | **fail closed** → `false` (stay silent) | `shouldReply` as classified |
+| `decideEffort` | **fail open** → `"standard"` (today's behavior) | bucket as classified |
+
+The asymmetry is deliberate: a wrongly-silent bot costs one re-mention; a wrongly-chatty bot poisons the channel. A broken effort classifier, by contrast, must never degrade an answer — so it degrades to the standard budget instead.
+
+### Fail-closed matrix (follow-up gate)
+
+| Classifier outcome | `turn_classifier_error` reason | Reply? |
+|--------------------|-------------------------------|--------|
+| API error / sync throw | `api_error` | No |
+| Over 3s | `timeout` | No |
+| Non-JSON output | `malformed_json` | No |
+| Missing key, bad bucket, confidence out of `[0,1]` or NaN | `invalid_shape` | No |
+| `shouldReply: false` (any confidence) | — | No |
+| `shouldReply: true`, confidence `< 0.75` | — | No |
+| `shouldReply: true`, confidence `>= 0.75` | — | **Yes** |
+
+## Effort tiers → budgets
+
+`EFFORT_BUDGETS` in `effort-routing.ts` (imports `MAX_TOOL_ROUNDS` / `ANSWER_BUDGET_CHARS` from `claude.ts` — never the reverse):
+
+| Bucket | maxRounds | answerCharsTarget |
+|--------|-----------|-------------------|
+| `quick` | 4 | 1,200 |
+| `standard` | 10 | 3,000 (`ANSWER_BUDGET_CHARS`) |
+| `deep` | 15 (`MAX_TOOL_ROUNDS`) | 6,000 |
+
+Two delivery mechanisms:
+
+- **Round cap** — the route passes `{ maxRounds, effort }` as `runAgent`'s optional 6th parameter. `resolveMaxRounds` (pure, exported from `claude.ts`) floors, clamps to `[1, MAX_TOOL_ROUNDS]`, and defaults to `MAX_TOOL_ROUNDS` when absent — so `claude.ts` never trusts a raw number and stays classifier-agnostic.
+- **Answer-length steering** — `buildEffortHint(effort)` is appended to the **user message** (like `buildQuestionHints`), never the system prompt: the stable prompt zone stays byte-identical so prompt caching keeps hitting. For `standard` the hint is `""` — the default path is byte-for-byte unchanged.
+
+## Route wiring
+
+- **Mention path** (`app_mention`): `classifyTurn` runs with `invocation: "mention"` in a `Promise.all` with the topic fetch, and **shouldReply is never consulted** — an explicit @mention always gets an answer. Only `decideEffort` is used.
+- **Follow-up path** (`message` in a bot thread): after the structural checks (bot-in-thread, not addressed to another user) and AFTER the pending-correction / bulk-confirm branches short-circuit, `evaluateFollowup` runs **before** the thinking message is posted. A decline produces **zero Slack writes** — just a `followup_reply_declined` log event (`reason`: `not_addressed` | `low_confidence` | `classifier_unavailable`) and a silent return.
+
+## Observability
+
+| Event | Fields |
+|-------|--------|
+| `turn_classified` | invocation, shouldReply, shouldReplyConfidence, effort, effortConfidence, duration_ms, model |
+| `turn_classifier_error` | reason (`api_error` \| `timeout` \| `malformed_json` \| `invalid_shape`), message, duration_ms, model |
+| `followup_reply_declined` | reason, confidence, channel, threadTs |
+| `agent_start` / `agent_complete` | now carry `effort` + `max_rounds` — join with token fields to measure spend per bucket |
+
+## Testing
+
+- Unit tests: `src/lib/effort-routing.test.ts` (every fail-closed branch, threshold edges, prompt shape), `src/lib/thread-filter.test.ts` (`extractTranscriptTail`), `src/lib/claude.test.ts` (`resolveMaxRounds`).
+- Eval fixtures: `src/evals/fixtures/should-reply.test.ts` runs representative transcripts against the real classifier — `npm run eval` only, never `npm test`.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -83,10 +83,19 @@ Filter: requestId=a3f2b1c4
 
 | Event | When | Key data |
 |-------|------|----------|
-| `agent_start` | Agent loop begins | promptLength, question, model |
+| `agent_start` | Agent loop begins | promptLength, question, model, effort, max_rounds |
 | `agent_tool_call` | Each tool execution | tool, round, input (truncated) |
-| `agent_complete` | Agent produces final answer | rounds, refCount, hasProposal, duration_ms |
+| `agent_complete` | Agent produces final answer | rounds, refCount, hasProposal, duration_ms, effort, max_rounds |
 | `prompt_feedback_included` | System prompt assembled — fires **every** turn, even when no entries | positiveCount, negativeCount, totalEntries, promptZone |
+
+The `effort` / `max_rounds` fields on `agent_start` and `agent_complete` come from the turn classifier (see below) — use them to compare token spend per effort bucket.
+
+### Classifier Events (effort-routing.ts) — #126
+
+| Event | When | Key data |
+|-------|------|----------|
+| `turn_classified` | Turn classifier returned a valid verdict | invocation, shouldReply, shouldReplyConfidence, effort, effortConfidence, duration_ms, model |
+| `turn_classifier_error` | Classifier failed — verdict is null (follow-ups fail closed, effort falls back to standard) | reason (`api_error` \| `timeout` \| `malformed_json` \| `invalid_shape`), message, duration_ms, model |
 
 ### Index Events (repo-index.ts)
 
@@ -104,6 +113,7 @@ Filter: requestId=a3f2b1c4
 | `answer_posted` | Bot's answer sent to Slack | channel, threadTs, chunks |
 | `issue_created` | GitHub issue created after ✅ | number |
 | `followup_agent_start` | Thread follow-up triggering agent | channel, threadTs |
+| `followup_reply_declined` | Follow-up gate stayed silent (not addressed to the bot, low confidence, or classifier unavailable) | reason, confidence, channel, threadTs |
 
 ### KV Events (lib/kv.ts) — #117
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -70,7 +70,7 @@ If you see it anyway, Sentry will have a `SlackMessageOversizeError` with the of
 **Possible causes:**
 
 - **Vercel function timeout**: By default, Vercel Hobby plans have a 10-second function timeout. The `after()` callback runs outside the response lifecycle but still has a maximum execution time based on your plan. Pro plans get up to 60 seconds, Enterprise gets more.
-- **Complex questions**: If the bot uses all 15 tool rounds, each involving a GitHub API call and a Claude API call, the total execution time can exceed timeout limits.
+- **Complex questions**: If the bot uses its full tool-round budget (up to 15 rounds for deep-bucket questions), each involving a GitHub API call and a Claude API call, the total execution time can exceed timeout limits.
 - **Large files**: Reading very large files from GitHub can be slow. The bot does not paginate or truncate file reads.
 
 **Fixes:**
@@ -93,6 +93,8 @@ If you see it anyway, Sentry will have a `SlackMessageOversizeError` with the of
 4. **Is the bot's user ID resolvable?** The bot calls `auth.test()` to get its own user ID (cached per cold start). If this fails, the thread follow-up handler cannot determine if the bot has replied in the thread.
 
 5. **Are `channels:history` and `groups:history` scopes granted?** These are required for the bot to read thread history. Without them, `conversations.replies` will fail silently.
+
+6. **Did the classifier decline?** Follow-ups are gated by a fast-model classifier that stays silent when the message doesn't look addressed to the bot — and also fails closed to silence on classifier errors or timeouts. Check Sentry for a `followup_reply_declined` event (with `reason` and `confidence`) and the preceding `turn_classified` / `turn_classifier_error` events. If it was wrongly declined, @mention the bot — the mention path never consults the gate. See [Effort Routing](features/effort-routing.md).
 
 ## KV Not Configured (Knowledge Base Not Working)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,7 +41,7 @@ Can you show me the relevant tests?
   [bot answers]
 ```
 
-The bot checks whether it has already replied in the thread. If it has, it treats any new message in that thread as a follow-up and responds automatically.
+The bot checks whether it has already replied in the thread. If it has, a fast-model classifier then decides whether your message is actually addressed to the bot — questions and requests get a reply, while human-to-human chatter, status updates, and messages aimed at a teammate are declined silently. If the bot stays quiet on something you *did* mean for it, just @mention it.
 
 > **Tip**: This only works in threads where the bot has already posted. If you start a new thread, you need to @mention the bot again.
 
@@ -70,7 +70,7 @@ Battle Mage has access to seven tools for exploring your codebase:
 
 **Less effective questions**:
 
-- Extremely broad questions like "explain the entire codebase" -- the bot has a budget of 15 tool rounds per question, so it cannot read every file
+- Extremely broad questions like "explain the entire codebase" -- the bot has a budget of at most 15 tool rounds per question (deep bucket), so it cannot read every file
 - Questions about runtime behavior or logs -- the bot has read access to code, not production systems
 - Questions about other repositories -- the bot is scoped to a single repo
 
@@ -175,7 +175,7 @@ Feedback is stored in Vercel KV and injected into the system prompt. The bot see
 
 ## Limitations
 
-- **15 tool rounds per question**. The bot budgets its tool calls. For very complex questions, it may answer with partial information and suggest follow-ups.
+- **Up to 15 tool rounds per question**. An effort classifier sizes each turn's budget (quick 4 / standard 10 / deep 15). For very complex questions, the bot may answer with partial information and suggest follow-ups.
 - **Read-only GitHub access**. The bot can read code and create issues (with confirmation), but cannot push code, merge PRs, or modify files.
 - **Single repository**. The bot is configured to read one repository. It cannot cross-reference multiple repos.
 - **No runtime access**. The bot reads source code and GitHub metadata. It does not have access to logs, databases, or production environments.

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -36,7 +36,18 @@ import {
 import { createRequestLogger, flushLogs, type RequestLogger } from "@/lib/logger";
 import { getCachedTopics } from "@/lib/repo-index";
 import { matchTopicsToQuestion, buildQuestionHints } from "@/lib/topic-match";
-import { isAddressedToOtherUser, buildConversationHistory } from "@/lib/thread-filter";
+import {
+  isAddressedToOtherUser,
+  buildConversationHistory,
+  extractTranscriptTail,
+} from "@/lib/thread-filter";
+import {
+  classifyTurn,
+  decideEffort,
+  evaluateFollowup,
+  buildEffortHint,
+  EFFORT_BUDGETS,
+} from "@/lib/effort-routing";
 
 // Shape of the pending-correction record stored under
 // `pending-correction:{channel}:{threadTs}` when a user reacts 👎.
@@ -266,12 +277,16 @@ export async function POST(request: NextRequest) {
         // and thread follow-ups (all thread authors + anyone mentioned).
         let mentionHistory: { role: "user" | "assistant"; content: string }[] | undefined;
         let mentionParticipants: Participant[] | undefined;
+        // Recent-thread tail for the effort classifier — empty for fresh
+        // top-level mentions (the question alone is enough to bucket).
+        let mentionTranscript = "";
         const botId = await getBotUserId();
         if (event.thread_ts) {
           const threadMsgs = await fetchThreadMessages(channel, threadTs);
           if (botId) {
             mentionHistory = buildConversationHistory(threadMsgs, botId);
           }
+          mentionTranscript = extractTranscriptTail(threadMsgs, botId ?? "");
           const ids = extractParticipantIds(threadMsgs, botId);
           if (ids.length > 0) {
             mentionParticipants = await resolveParticipants(ids);
@@ -288,10 +303,22 @@ export async function POST(request: NextRequest) {
           }
         }
 
-        // Pre-match question against topic index for concrete file hints
-        const topics = await getCachedTopics();
+        // Pre-match question against topic index for concrete file hints.
+        // The effort classifier (#126) runs in parallel — on the mention
+        // path shouldReply is NEVER consulted (the user explicitly invoked
+        // the bot); the classifier only buckets the question so the agent
+        // gets a right-sized round budget and answer target.
+        const [topics, mentionClassification] = await Promise.all([
+          getCachedTopics(),
+          classifyTurn(
+            { invocation: "mention", transcript: mentionTranscript, question: cleanMessage },
+            { log: rlog },
+          ),
+        ]);
+        const mentionEffort = decideEffort(mentionClassification);
         const topicMatches = matchTopicsToQuestion(cleanMessage, topics);
-        const augmentedMessage = buildQuestionHints(cleanMessage, topicMatches);
+        const augmentedMessage =
+          buildQuestionHints(cleanMessage, topicMatches) + buildEffortHint(mentionEffort);
         if (topicMatches.length > 0) {
           rlog("topic_hints_injected", { topics: topicMatches.map((m) => m.topic), fileCount: topicMatches.reduce((s, m) => s + m.paths.length, 0) });
         }
@@ -316,6 +343,7 @@ export async function POST(request: NextRequest) {
           (toolName, input) => {
             progressThrottle.update(buildThinkingMessage(toolName, input));
           },
+          { maxRounds: EFFORT_BUDGETS[mentionEffort].maxRounds, effort: mentionEffort },
         );
         // Drain any pending progress update before the final write so a
         // stale progress message can't land on top of the final answer.
@@ -567,14 +595,43 @@ export async function POST(request: NextRequest) {
         const threadMessages = await fetchThreadMessages(channel, threadTs);
         const botInThread = bid ? threadMessages.some((m) => m.user === bid) : false;
         if (!bid || !botInThread) return;
+
+        const cleanMessage = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
+
+        // Follow-up gate (#126): the structural heuristic above only says
+        // "maybe" — ask the fast-model classifier whether this message is
+        // actually addressed to the bot. Fail-closed: any classifier
+        // error/timeout/low-confidence verdict means we stay silent. Runs
+        // BEFORE the thinking message so a decline produces ZERO Slack
+        // writes — just the log event below.
+        const followupEval = await evaluateFollowup(
+          {
+            invocation: "followup",
+            transcript: extractTranscriptTail(threadMessages, bid),
+            question: cleanMessage,
+          },
+          { log: rlog },
+        );
+        if (!followupEval.proceed) {
+          rlog("followup_reply_declined", {
+            reason:
+              followupEval.decision === null
+                ? "classifier_unavailable"
+                : followupEval.decision.shouldReply
+                  ? "low_confidence"
+                  : "not_addressed",
+            confidence: followupEval.decision?.shouldReplyConfidence ?? null,
+            channel,
+            threadTs,
+          });
+          return;
+        }
         rlog("followup_agent_start", { channel, threadTs });
 
         thinkTs = await replyInThread(
           channel, threadTs,
           THINKING_HEADER,
         );
-
-        const cleanMessage = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
 
         // Build proper multi-turn conversation history from thread
         // (uses Anthropic's native message format, not string hacking)
@@ -587,10 +644,13 @@ export async function POST(request: NextRequest) {
           ? await resolveParticipants(followupParticipantIds)
           : undefined;
 
-        // Pre-match for thread follow-ups too
+        // Pre-match for thread follow-ups too; the effort hint from the
+        // classifier rides along on the user message (never the system
+        // prompt — see effort-routing.ts on prompt caching).
         const followupTopics = await getCachedTopics();
         const followupMatches = matchTopicsToQuestion(cleanMessage, followupTopics);
-        const followupMessage = buildQuestionHints(cleanMessage, followupMatches);
+        const followupMessage =
+          buildQuestionHints(cleanMessage, followupMatches) + buildEffortHint(followupEval.effort);
 
         // Mirror of the mention-flow progress updater — see comment
         // there + #110 for rationale.
@@ -608,6 +668,7 @@ export async function POST(request: NextRequest) {
           (toolName, input) => {
             followupProgress.update(buildThinkingMessage(toolName, input));
           },
+          { maxRounds: EFFORT_BUDGETS[followupEval.effort].maxRounds, effort: followupEval.effort },
         );
         await followupProgress.flush();
 

--- a/src/evals/fixtures/should-reply.test.ts
+++ b/src/evals/fixtures/should-reply.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { classifyTurn, decideShouldReply } from "@/lib/effort-routing";
+
+/**
+ * Eval: shouldReply classifier on representative thread transcripts.
+ *
+ * Hits the real Anthropic API (FAST_MODEL) via classifyTurn's default
+ * call — runs ONLY under `npm run eval`, never in `npm test`
+ * (vitest.config.ts excludes src/evals/fixtures/**). Each fixture is a
+ * follow-up-shaped turn: the bot already replied in the thread, and the
+ * classifier must decide whether the new message is addressed to it.
+ */
+
+async function shouldReply(transcript: string, question: string): Promise<boolean> {
+  const decision = await classifyTurn({
+    invocation: "followup",
+    transcript,
+    question,
+  });
+  return decideShouldReply(decision);
+}
+
+describe("eval: shouldReply follow-up gate", () => {
+  const TRANSCRIPT = [
+    "user: where is the tool-round limit enforced?",
+    "bot: The agent loop in src/lib/claude.ts caps tool use at MAX_TOOL_ROUNDS (15) per turn.",
+  ].join("\n");
+
+  it("declines human-to-human chatter", async () => {
+    const result = await shouldReply(
+      TRANSCRIPT,
+      "lol classic, anyway are we still on for lunch?",
+    );
+    expect(result).toBe(false);
+  });
+
+  it("declines a status update meant for teammates", async () => {
+    const result = await shouldReply(
+      TRANSCRIPT,
+      "cool — I'll bump the limit in my branch and deploy after standup",
+    );
+    expect(result).toBe(false);
+  });
+
+  it("replies to a direct question about the bot's prior answer", async () => {
+    const result = await shouldReply(
+      TRANSCRIPT,
+      "can you show me the exact loop where that cap is checked?",
+    );
+    expect(result).toBe(true);
+  });
+
+  it("replies to a follow-up lookup request", async () => {
+    const result = await shouldReply(
+      TRANSCRIPT,
+      "which file defines the 15-round limit again?",
+    );
+    expect(result).toBe(true);
+  });
+});

--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -5,6 +5,7 @@ import {
   truncateToolResult,
   estimateMessagesTokens,
   executeToolsInParallel,
+  resolveMaxRounds,
   FAST_MODEL,
   MAX_TOOL_ROUNDS,
   TOOL_RESULT_MAX_CHARS,
@@ -1006,4 +1007,32 @@ describe("executeToolsInParallel", () => {
     expect(truncLog?.[1]).toMatchObject({ tool: "read_file", round: 0 });
   });
 
+});
+
+describe("resolveMaxRounds", () => {
+  it("defaults to MAX_TOOL_ROUNDS when options are absent", () => {
+    expect(resolveMaxRounds()).toBe(MAX_TOOL_ROUNDS);
+    expect(resolveMaxRounds({})).toBe(MAX_TOOL_ROUNDS);
+    expect(resolveMaxRounds({ maxRounds: undefined })).toBe(MAX_TOOL_ROUNDS);
+  });
+
+  it("passes a valid in-range value through", () => {
+    expect(resolveMaxRounds({ maxRounds: 4 })).toBe(4);
+    expect(resolveMaxRounds({ maxRounds: 10 })).toBe(10);
+  });
+
+  it("floors fractional values", () => {
+    expect(resolveMaxRounds({ maxRounds: 4.9 })).toBe(4);
+  });
+
+  it("clamps to the [1, MAX_TOOL_ROUNDS] range", () => {
+    expect(resolveMaxRounds({ maxRounds: 0 })).toBe(1);
+    expect(resolveMaxRounds({ maxRounds: -3 })).toBe(1);
+    expect(resolveMaxRounds({ maxRounds: 999 })).toBe(MAX_TOOL_ROUNDS);
+  });
+
+  it("defaults to MAX_TOOL_ROUNDS on non-finite input", () => {
+    expect(resolveMaxRounds({ maxRounds: Number.NaN })).toBe(MAX_TOOL_ROUNDS);
+    expect(resolveMaxRounds({ maxRounds: Number.POSITIVE_INFINITY })).toBe(MAX_TOOL_ROUNDS);
+  });
 });

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -522,6 +522,30 @@ export type ProgressCallback = (
   input: Record<string, unknown>,
 ) => void | Promise<void>;
 
+/**
+ * Per-turn agent options from the effort classifier (#126). claude.ts
+ * stays classifier-agnostic — the route resolves the effort bucket via
+ * effort-routing.ts and passes only the resulting numbers/label here.
+ * Answer-length steering is NOT in this file either: the route appends
+ * buildEffortHint() to the user message so the stable system-prompt
+ * zone stays byte-identical for prompt caching.
+ */
+export interface RunAgentOptions {
+  /** Per-turn tool-round cap. Floored and clamped to [1, MAX_TOOL_ROUNDS]. */
+  maxRounds?: number;
+  /** Effort bucket label — observability only (agent_start/agent_complete). */
+  effort?: string;
+}
+
+// Pure resolver for the per-turn round cap: floor → clamp to
+// [1, MAX_TOOL_ROUNDS] → default MAX_TOOL_ROUNDS when absent or
+// non-finite. Exported for unit testing.
+export function resolveMaxRounds(options?: RunAgentOptions): number {
+  const v = options?.maxRounds;
+  if (typeof v !== "number" || !Number.isFinite(v)) return MAX_TOOL_ROUNDS;
+  return Math.min(MAX_TOOL_ROUNDS, Math.max(1, Math.floor(v)));
+}
+
 // Non-streaming Anthropic call. Previously used `messages.stream` +
 // `finalMessage()` to enable live text-delta forwarding to Slack. With
 // the API-minimization refactor (#108) we no longer stream text to
@@ -545,11 +569,17 @@ export async function runAgent(
   rlog?: LogFn,
   participants?: Participant[],
   onProgress?: ProgressCallback,
+  options?: RunAgentOptions,
 ): Promise<AgentResult> {
   // Use request-scoped logger if provided, fall back to bare log. Typed
   // as LogFn because runAgent itself only calls the logger (the route
   // keeps the full RequestLogger for the reply footer's requestId).
   const _log: LogFn = rlog ?? log;
+
+  // Per-turn round budget from the effort classifier (#126); defaults to
+  // the historical MAX_TOOL_ROUNDS ceiling when no options are passed.
+  const maxRounds = resolveMaxRounds(options);
+  const effort = options?.effort ?? "standard";
 
   // Compact conversation history if it exceeds the trigger. Runs before
   // the messages array is built so the round-0 request is already slim.
@@ -575,6 +605,8 @@ export async function runAgent(
     promptLength,
     question: userMessage.slice(0, 100),
     model: MODEL,
+    effort,
+    max_rounds: maxRounds,
   });
   // Observability (#114): emit how much feedback context the model saw
   // this turn. Fires on every turn (even when totalEntries === 0) so we
@@ -600,7 +632,7 @@ export async function runAgent(
   let totalInput = 0;
   let totalOutput = 0;
 
-  for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+  for (let round = 0; round < maxRounds; round++) {
     // Time budget check — force-stop if over 5 minutes
     if (shouldForceStop(startTime)) {
       _log("agent_timeout", { rounds: round, duration_ms: Date.now() - startTime });
@@ -678,6 +710,8 @@ export async function runAgent(
         cache_read_tokens: totalCacheRead,
         cache_creation_tokens: totalCacheCreation,
         model: MODEL,
+        effort,
+        max_rounds: maxRounds,
       });
       return { text, issueProposals, references: dedupeRefs(), metrics: buildMetrics(round + 1) };
     }
@@ -783,7 +817,7 @@ export async function runAgent(
     text: "I hit the maximum number of tool calls for this request. Here's what I found so far — please ask a more specific question if you need more detail.",
     issueProposals,
     references: finalRefs,
-    metrics: buildMetrics(MAX_TOOL_ROUNDS),
+    metrics: buildMetrics(maxRounds),
   };
 }
 

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -579,7 +579,10 @@ export async function runAgent(
   // Per-turn round budget from the effort classifier (#126); defaults to
   // the historical MAX_TOOL_ROUNDS ceiling when no options are passed.
   const maxRounds = resolveMaxRounds(options);
-  const effort = options?.effort ?? "standard";
+  // "default" (not "standard") when no routing ran: an unrouted turn logs
+  // max_rounds=15, which would corrupt per-bucket metrics if labeled
+  // standard (whose routed budget is 10).
+  const effort = options?.effort ?? "default";
 
   // Compact conversation history if it exceeds the trigger. Runs before
   // the messages array is built so the round-0 request is already slim.

--- a/src/lib/effort-routing.test.ts
+++ b/src/lib/effort-routing.test.ts
@@ -163,9 +163,25 @@ describe("classifyTurn", () => {
     await classifyTurn(input, { call, log: vi.fn() });
     expect(seen).toContain(input.transcript);
     expect(seen).toContain(input.question);
-    expect(seen).toContain("followup");
+    // Assert the substituted LINE, not just the word "followup" — the
+    // template's own descriptive text contains both mode words, so a
+    // bare toContain("followup") passes even if <INVOCATION> is never
+    // replaced.
+    expect(seen).toContain("Invocation mode: followup");
+    expect(seen).not.toContain("<INVOCATION>");
     expect(seen).not.toContain("<TRANSCRIPT>");
     expect(seen).not.toContain("<QUESTION>");
+  });
+
+  it("substitutes the mention invocation mode", async () => {
+    let seen = "";
+    const call = async (prompt: string) => {
+      seen = prompt;
+      return JSON.stringify(VALID);
+    };
+    await classifyTurn({ ...input, invocation: "mention" }, { call, log: vi.fn() });
+    expect(seen).toContain("Invocation mode: mention");
+    expect(seen).not.toContain("<INVOCATION>");
   });
 
   it("does not interpret $-substitution patterns in user content", async () => {
@@ -183,6 +199,12 @@ describe("classifyTurn", () => {
 
   it("tolerates a fenced ```json response", async () => {
     const call = async () => "```json\n" + JSON.stringify(VALID) + "\n```";
+    const result = await classifyTurn(input, { call, log: vi.fn() });
+    expect(result).toEqual(VALID);
+  });
+
+  it("tolerates an untagged ``` fence too", async () => {
+    const call = async () => "```\n" + JSON.stringify(VALID) + "\n```";
     const result = await classifyTurn(input, { call, log: vi.fn() });
     expect(result).toEqual(VALID);
   });
@@ -232,6 +254,51 @@ describe("classifyTurn", () => {
         call: callReturning({ ...VALID, shouldReplyConfidence: bad }),
         log,
       });
+      expect(result).toBeNull();
+      expect(log).toHaveBeenCalledWith(
+        "turn_classifier_error",
+        expect.objectContaining({ reason: "invalid_shape" }),
+      );
+    }
+  });
+
+  it("validates effortConfidence independently of shouldReplyConfidence", async () => {
+    // Each confidence field has its own guard — dropping either one is a
+    // mutation this must catch.
+    for (const bad of [1.5, -0.1, Number.NaN, "0.9", undefined]) {
+      const log = vi.fn();
+      const result = await classifyTurn(input, {
+        call: callReturning({ ...VALID, effortConfidence: bad }),
+        log,
+      });
+      expect(result).toBeNull();
+      expect(log).toHaveBeenCalledWith(
+        "turn_classifier_error",
+        expect.objectContaining({ reason: "invalid_shape" }),
+      );
+    }
+  });
+
+  it("rejects a non-boolean shouldReply (string 'true') as invalid_shape", async () => {
+    const log = vi.fn();
+    const result = await classifyTurn(input, {
+      call: callReturning({ ...VALID, shouldReply: "true" }),
+      log,
+    });
+    expect(result).toBeNull();
+    expect(log).toHaveBeenCalledWith(
+      "turn_classifier_error",
+      expect.objectContaining({ reason: "invalid_shape" }),
+    );
+  });
+
+  it("rejects JSON null and scalar payloads as invalid_shape without throwing", async () => {
+    // JSON.parse("null") is valid JSON — the null guard in
+    // validateClassification is what keeps classifyTurn from throwing on
+    // property access, upholding its NEVER-throws contract.
+    for (const raw of ["null", "42", '"quick"']) {
+      const log = vi.fn();
+      const result = await classifyTurn(input, { call: async () => raw, log });
       expect(result).toBeNull();
       expect(log).toHaveBeenCalledWith(
         "turn_classifier_error",
@@ -297,6 +364,46 @@ describe("classifyTurn", () => {
       expect.objectContaining({ reason: "timeout" }),
     );
   });
+
+  it("does not fire the timeout before CLASSIFIER_TIMEOUT_MS", async () => {
+    // Boundary partner to the timeout test: 1ms short of the wall the
+    // call must still be allowed to win the race.
+    vi.useFakeTimers();
+    const log = vi.fn();
+    let resolveCall!: (v: string) => void;
+    const call = () => new Promise<string>((res) => (resolveCall = res));
+    const pending = classifyTurn(input, { call, log });
+    await vi.advanceTimersByTimeAsync(CLASSIFIER_TIMEOUT_MS - 1);
+    resolveCall(JSON.stringify(VALID));
+    const result = await pending;
+    expect(result).toEqual(VALID);
+    expect(log).not.toHaveBeenCalledWith("turn_classifier_error", expect.anything());
+  });
+
+  it("clears the timeout timer on the win path (no dangling handle)", async () => {
+    // A surviving 3s timer would hold the serverless event loop open
+    // after every fast classifier response. Deleting the clearTimeout in
+    // the finally block must fail this test.
+    vi.useFakeTimers();
+    const result = await classifyTurn(input, {
+      call: callReturning(VALID),
+      log: vi.fn(),
+    });
+    expect(result).toEqual(VALID);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears the timeout timer on the error path too", async () => {
+    vi.useFakeTimers();
+    const result = await classifyTurn(input, {
+      call: async () => {
+        throw new Error("boom");
+      },
+      log: vi.fn(),
+    });
+    expect(result).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });
 
 describe("evaluateFollowup", () => {
@@ -325,6 +432,20 @@ describe("evaluateFollowup", () => {
     expect(result.decision?.shouldReply).toBe(false);
   });
 
+  it("declines on a low-confidence yes while keeping the decision and effort", async () => {
+    // The route distinguishes decline reasons: decision !== null with
+    // shouldReply=true maps to "low_confidence". The gate must read
+    // shouldReplyConfidence, NOT effortConfidence.
+    const result = await evaluateFollowup(input, {
+      call: callReturning({ ...VALID, shouldReplyConfidence: 0.6, effortConfidence: 0.9 }),
+      log: vi.fn(),
+    });
+    expect(result.proceed).toBe(false);
+    expect(result.decision?.shouldReply).toBe(true);
+    expect(result.decision?.shouldReplyConfidence).toBe(0.6);
+    expect(result.effort).toBe("quick"); // effort verdict is independent of the gate
+  });
+
   it("fails closed with standard effort on classifier error", async () => {
     const result = await evaluateFollowup(input, {
       call: async () => {
@@ -335,5 +456,40 @@ describe("evaluateFollowup", () => {
     expect(result.proceed).toBe(false);
     expect(result.decision).toBeNull();
     expect(result.effort).toBe("standard");
+  });
+});
+
+const ABORT_INPUT = {
+  invocation: "followup" as const,
+  transcript: "user: how does auth work?\nbot: Auth uses JWT tokens.",
+  question: "which file was that in?",
+};
+
+// ── Qodo finding 2 (PR #131): timeout must abort the underlying call ──
+
+describe("classifyTurn abort propagation", () => {
+  it("aborts the underlying call's signal when the timeout fires", async () => {
+    vi.useFakeTimers();
+    let seen: AbortSignal | undefined;
+    const call = vi.fn((_p: string, signal?: AbortSignal) => {
+      seen = signal;
+      return new Promise<string>(() => {}); // hangs past the timeout
+    });
+    const pending = classifyTurn(ABORT_INPUT, { call, log: vi.fn() });
+    await vi.advanceTimersByTimeAsync(CLASSIFIER_TIMEOUT_MS + 1);
+    await expect(pending).resolves.toBeNull();
+    expect(seen).toBeDefined();
+    expect(seen!.aborted).toBe(true);
+  });
+
+  it("does not abort the signal when the call wins the race", async () => {
+    let seen: AbortSignal | undefined;
+    const call = vi.fn((_p: string, signal?: AbortSignal) => {
+      seen = signal;
+      return Promise.resolve(JSON.stringify(VALID));
+    });
+    await expect(classifyTurn(ABORT_INPUT, { call, log: vi.fn() })).resolves.toEqual(VALID);
+    expect(seen).toBeDefined();
+    expect(seen!.aborted).toBe(false);
   });
 });

--- a/src/lib/effort-routing.test.ts
+++ b/src/lib/effort-routing.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  CONFIDENCE_THRESHOLD,
+  CLASSIFIER_TIMEOUT_MS,
+  EFFORT_BUDGETS,
+  TURN_CLASSIFIER_PROMPT,
+  classifyTurn,
+  decideShouldReply,
+  decideEffort,
+  buildEffortHint,
+  evaluateFollowup,
+  type TurnClassification,
+} from "./effort-routing";
+import { MAX_TOOL_ROUNDS, ANSWER_BUDGET_CHARS } from "./claude";
+
+// Shared fixture: a fully-valid classifier verdict. Individual tests
+// spread-override single fields to probe each validation branch.
+const VALID: TurnClassification = {
+  shouldReply: true,
+  shouldReplyConfidence: 0.9,
+  effort: "quick",
+  effortConfidence: 0.9,
+};
+
+function callReturning(value: unknown): (prompt: string) => Promise<string> {
+  return async () => JSON.stringify(value);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("constants", () => {
+  it("threshold is 0.75 and timeout is 3000ms", () => {
+    expect(CONFIDENCE_THRESHOLD).toBe(0.75);
+    expect(CLASSIFIER_TIMEOUT_MS).toBe(3000);
+  });
+
+  it("EFFORT_BUDGETS maps quick/standard/deep to round + answer budgets", () => {
+    expect(EFFORT_BUDGETS.quick).toEqual({ maxRounds: 4, answerCharsTarget: 1200 });
+    expect(EFFORT_BUDGETS.standard).toEqual({
+      maxRounds: 10,
+      answerCharsTarget: ANSWER_BUDGET_CHARS,
+    });
+    expect(EFFORT_BUDGETS.deep).toEqual({
+      maxRounds: MAX_TOOL_ROUNDS,
+      answerCharsTarget: 6000,
+    });
+  });
+});
+
+describe("TURN_CLASSIFIER_PROMPT", () => {
+  it("carries the transcript and question placeholders", () => {
+    expect(TURN_CLASSIFIER_PROMPT).toContain("<TRANSCRIPT>");
+    expect(TURN_CLASSIFIER_PROMPT).toContain("<QUESTION>");
+  });
+
+  it("demands JSON-only output with the exact four keys", () => {
+    expect(TURN_CLASSIFIER_PROMPT).toMatch(/JSON/);
+    for (const key of [
+      "shouldReply",
+      "shouldReplyConfidence",
+      "effort",
+      "effortConfidence",
+    ]) {
+      expect(TURN_CLASSIFIER_PROMPT).toContain(key);
+    }
+  });
+
+  it("names all three effort buckets", () => {
+    for (const bucket of ["quick", "standard", "deep"]) {
+      expect(TURN_CLASSIFIER_PROMPT).toContain(`"${bucket}"`);
+    }
+  });
+
+  it("states the invocation mode (followup vs mention differ)", () => {
+    expect(TURN_CLASSIFIER_PROMPT).toContain("followup");
+    expect(TURN_CLASSIFIER_PROMPT).toContain("mention");
+  });
+});
+
+describe("decideShouldReply", () => {
+  it("fails closed on null classification", () => {
+    expect(decideShouldReply(null)).toBe(false);
+  });
+
+  it("proceeds on a confident yes", () => {
+    expect(decideShouldReply({ ...VALID, shouldReplyConfidence: 0.9 })).toBe(true);
+  });
+
+  it("passes at exactly the threshold (>= semantics)", () => {
+    expect(
+      decideShouldReply({ ...VALID, shouldReplyConfidence: CONFIDENCE_THRESHOLD }),
+    ).toBe(true);
+  });
+
+  it("fails closed just below the threshold", () => {
+    expect(decideShouldReply({ ...VALID, shouldReplyConfidence: 0.74 })).toBe(false);
+  });
+
+  it("stays silent on a confident no", () => {
+    expect(
+      decideShouldReply({ ...VALID, shouldReply: false, shouldReplyConfidence: 0.99 }),
+    ).toBe(false);
+  });
+});
+
+describe("decideEffort", () => {
+  it("defaults to standard on null classification", () => {
+    expect(decideEffort(null)).toBe("standard");
+  });
+
+  it("honors a confident bucket", () => {
+    expect(decideEffort({ ...VALID, effort: "quick", effortConfidence: 0.9 })).toBe("quick");
+    expect(decideEffort({ ...VALID, effort: "deep", effortConfidence: 0.9 })).toBe("deep");
+  });
+
+  it("passes at exactly the threshold (>= semantics)", () => {
+    expect(
+      decideEffort({ ...VALID, effort: "deep", effortConfidence: CONFIDENCE_THRESHOLD }),
+    ).toBe("deep");
+  });
+
+  it("defaults to standard below the threshold", () => {
+    expect(decideEffort({ ...VALID, effort: "quick", effortConfidence: 0.5 })).toBe(
+      "standard",
+    );
+  });
+});
+
+describe("buildEffortHint", () => {
+  it("returns empty string for standard (byte-identical default path)", () => {
+    expect(buildEffortHint("standard")).toBe("");
+  });
+
+  it("returns distinct non-empty hints for quick and deep", () => {
+    const quick = buildEffortHint("quick");
+    const deep = buildEffortHint("deep");
+    expect(quick.length).toBeGreaterThan(0);
+    expect(deep.length).toBeGreaterThan(0);
+    expect(quick).not.toBe(deep);
+  });
+});
+
+describe("classifyTurn", () => {
+  const input = {
+    invocation: "followup" as const,
+    transcript: "user: how does auth work?\nbot: Auth uses JWT tokens.",
+    question: "which file was that in?",
+  };
+
+  it("returns the parsed classification on a valid response", async () => {
+    const result = await classifyTurn(input, { call: callReturning(VALID), log: vi.fn() });
+    expect(result).toEqual(VALID);
+  });
+
+  it("substitutes transcript, question, and invocation into the prompt", async () => {
+    let seen = "";
+    const call = async (prompt: string) => {
+      seen = prompt;
+      return JSON.stringify(VALID);
+    };
+    await classifyTurn(input, { call, log: vi.fn() });
+    expect(seen).toContain(input.transcript);
+    expect(seen).toContain(input.question);
+    expect(seen).toContain("followup");
+    expect(seen).not.toContain("<TRANSCRIPT>");
+    expect(seen).not.toContain("<QUESTION>");
+  });
+
+  it("does not interpret $-substitution patterns in user content", async () => {
+    // String.replace treats "$&" in a string replacement as "the match" —
+    // a message containing it must land in the prompt verbatim.
+    let seen = "";
+    const call = async (prompt: string) => {
+      seen = prompt;
+      return JSON.stringify(VALID);
+    };
+    await classifyTurn({ ...input, question: "what does $& mean here?" }, { call, log: vi.fn() });
+    expect(seen).toContain("what does $& mean here?");
+    expect(seen).not.toContain("<QUESTION>");
+  });
+
+  it("tolerates a fenced ```json response", async () => {
+    const call = async () => "```json\n" + JSON.stringify(VALID) + "\n```";
+    const result = await classifyTurn(input, { call, log: vi.fn() });
+    expect(result).toEqual(VALID);
+  });
+
+  it("logs turn_classified with the full verdict on success", async () => {
+    const log = vi.fn();
+    await classifyTurn(input, { call: callReturning(VALID), log });
+    expect(log).toHaveBeenCalledWith(
+      "turn_classified",
+      expect.objectContaining({
+        invocation: "followup",
+        shouldReply: true,
+        shouldReplyConfidence: 0.9,
+        effort: "quick",
+        effortConfidence: 0.9,
+        duration_ms: expect.any(Number),
+        model: expect.any(String),
+      }),
+    );
+  });
+
+  it("returns null + malformed_json on unparseable output", async () => {
+    const log = vi.fn();
+    const result = await classifyTurn(input, { call: async () => "not json at all", log });
+    expect(result).toBeNull();
+    expect(log).toHaveBeenCalledWith(
+      "turn_classifier_error",
+      expect.objectContaining({ reason: "malformed_json" }),
+    );
+  });
+
+  it("returns null + invalid_shape when a key is missing", async () => {
+    const { effort: _drop, ...missingKey } = VALID;
+    const log = vi.fn();
+    const result = await classifyTurn(input, { call: callReturning(missingKey), log });
+    expect(result).toBeNull();
+    expect(log).toHaveBeenCalledWith(
+      "turn_classifier_error",
+      expect.objectContaining({ reason: "invalid_shape" }),
+    );
+  });
+
+  it("rejects out-of-range confidences as invalid_shape, never clamps", async () => {
+    for (const bad of [1.5, -0.1, Number.NaN]) {
+      const log = vi.fn();
+      const result = await classifyTurn(input, {
+        call: callReturning({ ...VALID, shouldReplyConfidence: bad }),
+        log,
+      });
+      expect(result).toBeNull();
+      expect(log).toHaveBeenCalledWith(
+        "turn_classifier_error",
+        expect.objectContaining({ reason: "invalid_shape" }),
+      );
+    }
+  });
+
+  it("rejects an unknown effort bucket as invalid_shape", async () => {
+    const log = vi.fn();
+    const result = await classifyTurn(input, {
+      call: callReturning({ ...VALID, effort: "medium" }),
+      log,
+    });
+    expect(result).toBeNull();
+    expect(log).toHaveBeenCalledWith(
+      "turn_classifier_error",
+      expect.objectContaining({ reason: "invalid_shape" }),
+    );
+  });
+
+  it("returns null + api_error on a rejected call", async () => {
+    const log = vi.fn();
+    const result = await classifyTurn(input, {
+      call: async () => {
+        throw new Error("overloaded");
+      },
+      log,
+    });
+    expect(result).toBeNull();
+    expect(log).toHaveBeenCalledWith(
+      "turn_classifier_error",
+      expect.objectContaining({ reason: "api_error", message: "overloaded" }),
+    );
+  });
+
+  it("never throws even when the injected call throws synchronously", async () => {
+    const log = vi.fn();
+    const call = () => {
+      throw new Error("sync boom");
+    };
+    const result = await classifyTurn(input, {
+      call: call as unknown as (prompt: string) => Promise<string>,
+      log,
+    });
+    expect(result).toBeNull();
+    expect(log).toHaveBeenCalledWith(
+      "turn_classifier_error",
+      expect.objectContaining({ reason: "api_error" }),
+    );
+  });
+
+  it("times out after CLASSIFIER_TIMEOUT_MS and reports reason timeout", async () => {
+    vi.useFakeTimers();
+    const log = vi.fn();
+    const never = () => new Promise<string>(() => {});
+    const pending = classifyTurn(input, { call: never, log });
+    await vi.advanceTimersByTimeAsync(CLASSIFIER_TIMEOUT_MS);
+    const result = await pending;
+    expect(result).toBeNull();
+    expect(log).toHaveBeenCalledWith(
+      "turn_classifier_error",
+      expect.objectContaining({ reason: "timeout" }),
+    );
+  });
+});
+
+describe("evaluateFollowup", () => {
+  const input = {
+    invocation: "followup" as const,
+    transcript: "bot: The limit is 15 rounds.",
+    question: "which file defines that?",
+  };
+
+  it("proceeds with the classified effort on a confident yes", async () => {
+    const result = await evaluateFollowup(input, {
+      call: callReturning({ ...VALID, effort: "quick" }),
+      log: vi.fn(),
+    });
+    expect(result.proceed).toBe(true);
+    expect(result.effort).toBe("quick");
+    expect(result.decision).toEqual({ ...VALID, effort: "quick" });
+  });
+
+  it("declines on a confident no but still reports the decision", async () => {
+    const result = await evaluateFollowup(input, {
+      call: callReturning({ ...VALID, shouldReply: false }),
+      log: vi.fn(),
+    });
+    expect(result.proceed).toBe(false);
+    expect(result.decision?.shouldReply).toBe(false);
+  });
+
+  it("fails closed with standard effort on classifier error", async () => {
+    const result = await evaluateFollowup(input, {
+      call: async () => {
+        throw new Error("down");
+      },
+      log: vi.fn(),
+    });
+    expect(result.proceed).toBe(false);
+    expect(result.decision).toBeNull();
+    expect(result.effort).toBe("standard");
+  });
+});

--- a/src/lib/effort-routing.ts
+++ b/src/lib/effort-routing.ts
@@ -1,0 +1,299 @@
+/**
+ * Adaptive effort routing (#126).
+ *
+ * Two decisions, ONE cheap Haiku structured call per turn:
+ *
+ * 1. shouldReply — is a thread follow-up actually addressed to the bot?
+ *    The structural heuristic (bot has a prior reply in the thread) only
+ *    says "maybe"; the classifier reads the last few messages and decides.
+ *    FAIL-CLOSED: any error, timeout, malformed output, or low-confidence
+ *    verdict means the bot stays silent. A wrongly-silent bot is a minor
+ *    annoyance (re-mention it); a wrongly-chatty bot poisons the channel.
+ *
+ * 2. effort — bucket the question into quick | standard | deep, mapping
+ *    to a per-turn tool-round budget and an answer-length target.
+ *    FAIL-OPEN to "standard": a broken classifier must never degrade the
+ *    answer, so anything below threshold falls back to today's behavior.
+ *
+ * Layering: this module imports from claude.ts (FAST_MODEL and the budget
+ * constants) — never the reverse. claude.ts stays classifier-agnostic; the
+ * route composes the two. Answer-length steering happens by appending
+ * `buildEffortHint` to the USER message (like buildQuestionHints), keeping
+ * the stable system-prompt zone byte-identical for prompt caching.
+ *
+ * Injection idiom copied from compaction.ts: `ClassifyDeps { call?, log? }`
+ * with a private default Haiku call, so every branch is unit-testable
+ * without network.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { FAST_MODEL, MAX_TOOL_ROUNDS, ANSWER_BUDGET_CHARS } from "@/lib/claude";
+import { log as defaultLog, type LogFn } from "@/lib/logger";
+
+// Shared client. Same singleton pattern as compaction.ts — reads
+// ANTHROPIC_API_KEY from env at module-eval time.
+const anthropic = new Anthropic();
+
+/** Minimum confidence for a classifier verdict to be acted on. `>=` passes.
+ *  Below this: shouldReply fails closed (silence), effort falls back to
+ *  "standard". */
+export const CONFIDENCE_THRESHOLD = 0.75;
+
+/** Hard wall-clock cap on the classifier call. The follow-up gate runs
+ *  BEFORE any Slack write, so a hung classifier would silently eat the
+ *  turn — 3s is generous for a 256-token Haiku call. */
+export const CLASSIFIER_TIMEOUT_MS = 3000;
+
+export type EffortBucket = "quick" | "standard" | "deep";
+
+export interface EffortBudget {
+  /** Per-turn tool-round cap passed to runAgent (clamped by resolveMaxRounds). */
+  maxRounds: number;
+  /** Answer-length target surfaced to the model via buildEffortHint. */
+  answerCharsTarget: number;
+}
+
+/** Bucket → budgets. "standard" mirrors today's defaults exactly except
+ *  the round cap (10 covers virtually all observed standard turns; deep
+ *  keeps the full MAX_TOOL_ROUNDS ceiling). */
+export const EFFORT_BUDGETS: Record<EffortBucket, EffortBudget> = {
+  quick: { maxRounds: 4, answerCharsTarget: 1200 },
+  standard: { maxRounds: 10, answerCharsTarget: ANSWER_BUDGET_CHARS },
+  deep: { maxRounds: MAX_TOOL_ROUNDS, answerCharsTarget: 6000 },
+};
+
+/** Where the classifier was invoked from. The two modes read shouldReply
+ *  differently: a mention is an explicit invocation (shouldReply is never
+ *  consulted), a follow-up is ambiguous (shouldReply is the gate). */
+export type ClassifierInvocation = "mention" | "followup";
+
+export interface TurnClassification {
+  shouldReply: boolean;
+  shouldReplyConfidence: number;
+  effort: EffortBucket;
+  effortConfidence: number;
+}
+
+export interface ClassifyInput {
+  invocation: ClassifierInvocation;
+  /** Preformatted recent-thread tail (see extractTranscriptTail). May be "". */
+  transcript: string;
+  /** The message being classified, mention-stripped. */
+  question: string;
+}
+
+export interface ClassifyDeps {
+  /** Injectable model call for tests. In prod defaults to a Haiku call. */
+  call?: (prompt: string) => Promise<string>;
+  /** Logger for turn_classified / turn_classifier_error events. */
+  log?: LogFn;
+}
+
+export const TURN_CLASSIFIER_PROMPT = `You are a turn classifier for a Slack bot (@bm) that answers engineering questions about a GitHub repository. Classify the message below.
+
+Invocation mode: <INVOCATION>
+- "mention": the user explicitly @-mentioned the bot, so shouldReply is true by definition — only the effort classification matters.
+- "followup": the bot already replied earlier in this thread and the user posted WITHOUT mentioning it. Decide whether the message is genuinely addressed to the bot (a question or request it should answer) versus human-to-human chatter, status updates, acknowledgements, or something meant for another person.
+
+Effort buckets — how much repository investigation the question needs:
+- "quick": trivial lookups, yes/no checks, questions the transcript already answers, single small facts.
+- "standard": a typical single-topic question needing a few file reads.
+- "deep": broad, comparative, or multi-part questions spanning many files — audits, "summarize our whole X", architecture reviews.
+
+Recent thread transcript (oldest first; may be empty):
+---
+<TRANSCRIPT>
+---
+
+Message to classify:
+---
+<QUESTION>
+---
+
+Respond with ONLY a JSON object — no prose, no code fences — with exactly these four keys:
+{"shouldReply": true|false, "shouldReplyConfidence": 0.0-1.0, "effort": "quick"|"standard"|"deep", "effortConfidence": 0.0-1.0}`;
+
+// Internal sentinel so the catch block can distinguish our own timeout
+// from a real API failure without string-matching error messages.
+class ClassifierTimeoutError extends Error {
+  constructor() {
+    super(`classifier timed out after ${CLASSIFIER_TIMEOUT_MS}ms`);
+  }
+}
+
+function isConfidence(v: unknown): v is number {
+  // Out-of-range or NaN confidences are rejected (invalid_shape), never
+  // clamped — a model emitting 1.5 is a model we shouldn't act on.
+  return typeof v === "number" && Number.isFinite(v) && v >= 0 && v <= 1;
+}
+
+function validateClassification(v: unknown): TurnClassification | null {
+  if (typeof v !== "object" || v === null) return null;
+  const o = v as Record<string, unknown>;
+  if (typeof o.shouldReply !== "boolean") return null;
+  if (!isConfidence(o.shouldReplyConfidence)) return null;
+  if (!isConfidence(o.effortConfidence)) return null;
+  if (o.effort !== "quick" && o.effort !== "standard" && o.effort !== "deep") return null;
+  return {
+    shouldReply: o.shouldReply,
+    shouldReplyConfidence: o.shouldReplyConfidence,
+    effort: o.effort,
+    effortConfidence: o.effortConfidence,
+  };
+}
+
+// Belt-and-braces: the prompt demands bare JSON, but Haiku occasionally
+// wraps output in a markdown fence anyway. Strip one if present.
+function stripCodeFence(raw: string): string {
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  return fenced ? fenced[1] : trimmed;
+}
+
+/**
+ * ONE combined Haiku structured call for both decisions. NEVER throws —
+ * every failure mode (API error, sync throw from an injected call,
+ * timeout, malformed JSON, invalid shape) logs a `turn_classifier_error`
+ * with a stable reason and returns null. Callers interpret null via
+ * decideShouldReply (fail-closed) / decideEffort (fail-open to standard).
+ */
+export async function classifyTurn(
+  input: ClassifyInput,
+  deps: ClassifyDeps = {},
+): Promise<TurnClassification | null> {
+  const log = deps.log ?? defaultLog;
+  const call = deps.call ?? defaultCall;
+  const start = Date.now();
+
+  // Replacer functions, not bare strings — String.replace treats `$&`
+  // and friends in a string replacement as substitution patterns, so a
+  // user message containing `$&` would garble the prompt.
+  const prompt = TURN_CLASSIFIER_PROMPT.replace("<INVOCATION>", () => input.invocation)
+    .replace("<TRANSCRIPT>", () => input.transcript)
+    .replace("<QUESTION>", () => input.question);
+
+  let raw: string;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    raw = await Promise.race([
+      // Promise.resolve().then(...) converts a synchronously-throwing
+      // injected call into a rejection instead of an escaping throw.
+      Promise.resolve().then(() => call(prompt)),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new ClassifierTimeoutError()), CLASSIFIER_TIMEOUT_MS);
+      }),
+    ]);
+  } catch (err) {
+    log("turn_classifier_error", {
+      reason: err instanceof ClassifierTimeoutError ? "timeout" : "api_error",
+      message: err instanceof Error ? err.message : String(err),
+      duration_ms: Date.now() - start,
+      model: FAST_MODEL,
+    });
+    return null;
+  } finally {
+    // Clear on the win path too — a live timer would hold the serverless
+    // event loop open for the full 3s after a fast response.
+    if (timer !== undefined) clearTimeout(timer);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripCodeFence(raw));
+  } catch (err) {
+    log("turn_classifier_error", {
+      reason: "malformed_json",
+      message: err instanceof Error ? err.message : String(err),
+      duration_ms: Date.now() - start,
+      model: FAST_MODEL,
+    });
+    return null;
+  }
+
+  const classification = validateClassification(parsed);
+  if (!classification) {
+    log("turn_classifier_error", {
+      reason: "invalid_shape",
+      message: `unexpected classifier payload: ${JSON.stringify(parsed).slice(0, 200)}`,
+      duration_ms: Date.now() - start,
+      model: FAST_MODEL,
+    });
+    return null;
+  }
+
+  log("turn_classified", {
+    invocation: input.invocation,
+    shouldReply: classification.shouldReply,
+    shouldReplyConfidence: classification.shouldReplyConfidence,
+    effort: classification.effort,
+    effortConfidence: classification.effortConfidence,
+    duration_ms: Date.now() - start,
+    model: FAST_MODEL,
+  });
+  return classification;
+}
+
+/** Fail-closed gate for thread follow-ups: reply only on a confident yes. */
+export function decideShouldReply(c: TurnClassification | null): boolean {
+  return c !== null && c.shouldReply && c.shouldReplyConfidence >= CONFIDENCE_THRESHOLD;
+}
+
+/** Fail-open bucket pick: anything short of a confident verdict is "standard". */
+export function decideEffort(c: TurnClassification | null): EffortBucket {
+  if (c === null || c.effortConfidence < CONFIDENCE_THRESHOLD) return "standard";
+  return c.effort;
+}
+
+/**
+ * Answer-length steering appended to the USER message (never the system
+ * prompt — the stable zone must stay byte-identical for prompt caching).
+ * Returns "" for standard so the default path is unchanged byte-for-byte.
+ */
+export function buildEffortHint(effort: EffortBucket): string {
+  if (effort === "quick") {
+    return (
+      `\n\n[Effort hint: this looks like a quick question. Answer directly with ` +
+      `minimal tool use and keep the answer under ~${EFFORT_BUDGETS.quick.answerCharsTarget.toLocaleString()} characters.]`
+    );
+  }
+  if (effort === "deep") {
+    return (
+      `\n\n[Effort hint: this looks like a deep question. Investigate thoroughly ` +
+      `before answering; you may go up to ~${EFFORT_BUDGETS.deep.answerCharsTarget.toLocaleString()} characters if the question genuinely needs the depth.]`
+    );
+  }
+  return "";
+}
+
+export interface FollowupEvaluation {
+  /** True only on a confident shouldReply=yes. False means stay silent. */
+  proceed: boolean;
+  /** Raw verdict (null on classifier failure) — for decline-reason logging. */
+  decision: TurnClassification | null;
+  /** Resolved bucket; "standard" whenever the verdict is absent or timid. */
+  effort: EffortBucket;
+}
+
+/** Composes classifyTurn → decideShouldReply → decideEffort for the
+ *  follow-up path. The mention path calls classifyTurn + decideEffort
+ *  directly and never consults shouldReply. */
+export async function evaluateFollowup(
+  input: ClassifyInput,
+  deps: ClassifyDeps = {},
+): Promise<FollowupEvaluation> {
+  const decision = await classifyTurn(input, deps);
+  return {
+    proceed: decideShouldReply(decision),
+    decision,
+    effort: decideEffort(decision),
+  };
+}
+
+async function defaultCall(prompt: string): Promise<string> {
+  const resp = await anthropic.messages.create({
+    model: FAST_MODEL,
+    max_tokens: 256,
+    messages: [{ role: "user", content: prompt }],
+  });
+  return resp.content.map((b) => (b.type === "text" ? b.text : "")).join("");
+}

--- a/src/lib/effort-routing.ts
+++ b/src/lib/effort-routing.ts
@@ -83,8 +83,12 @@ export interface ClassifyInput {
 }
 
 export interface ClassifyDeps {
-  /** Injectable model call for tests. In prod defaults to a Haiku call. */
-  call?: (prompt: string) => Promise<string>;
+  /**
+   * Injectable model call for tests. In prod defaults to a Haiku call.
+   * The signal aborts when the classifier timeout fires so a slow
+   * request doesn't keep running (and billing) after we've failed closed.
+   */
+  call?: (prompt: string, signal?: AbortSignal) => Promise<string>;
   /** Logger for turn_classified / turn_classifier_error events. */
   log?: LogFn;
 }
@@ -174,13 +178,19 @@ export async function classifyTurn(
 
   let raw: string;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  const controller = new AbortController();
   try {
     raw = await Promise.race([
       // Promise.resolve().then(...) converts a synchronously-throwing
       // injected call into a rejection instead of an escaping throw.
-      Promise.resolve().then(() => call(prompt)),
+      Promise.resolve().then(() => call(prompt, controller.signal)),
       new Promise<never>((_, reject) => {
-        timer = setTimeout(() => reject(new ClassifierTimeoutError()), CLASSIFIER_TIMEOUT_MS);
+        timer = setTimeout(() => {
+          // Abort the losing request too — Promise.race alone would let
+          // the Anthropic call keep running after we fail closed.
+          controller.abort();
+          reject(new ClassifierTimeoutError());
+        }, CLASSIFIER_TIMEOUT_MS);
       }),
     ]);
   } catch (err) {
@@ -289,11 +299,14 @@ export async function evaluateFollowup(
   };
 }
 
-async function defaultCall(prompt: string): Promise<string> {
-  const resp = await anthropic.messages.create({
-    model: FAST_MODEL,
-    max_tokens: 256,
-    messages: [{ role: "user", content: prompt }],
-  });
+async function defaultCall(prompt: string, signal?: AbortSignal): Promise<string> {
+  const resp = await anthropic.messages.create(
+    {
+      model: FAST_MODEL,
+      max_tokens: 256,
+      messages: [{ role: "user", content: prompt }],
+    },
+    { signal },
+  );
   return resp.content.map((b) => (b.type === "text" ? b.text : "")).join("");
 }

--- a/src/lib/thread-filter.test.ts
+++ b/src/lib/thread-filter.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { isAddressedToOtherUser, buildConversationHistory } from "./thread-filter";
+import {
+  isAddressedToOtherUser,
+  buildConversationHistory,
+  extractTranscriptTail,
+  TRANSCRIPT_TAIL_MAX,
+} from "./thread-filter";
 
 describe("isAddressedToOtherUser", () => {
   const botId = "B001";
@@ -134,5 +139,67 @@ describe("buildConversationHistory", () => {
     const userMessages = result.filter((m) => m.role === "user");
     expect(userMessages).toHaveLength(1);
     expect(userMessages[0].content).toBe("How does auth work?");
+  });
+});
+
+describe("extractTranscriptTail", () => {
+  const botId = "B001";
+
+  it("returns empty string for no messages", () => {
+    expect(extractTranscriptTail([], botId)).toBe("");
+  });
+
+  it("labels speakers bot/user using the buildConversationHistory rule", () => {
+    const messages = [
+      { user: "U123", text: "How does auth work?", bot_id: undefined },
+      { user: "B001", text: "Auth uses JWT tokens.", bot_id: "B001" },
+    ];
+    const tail = extractTranscriptTail(messages, botId);
+    expect(tail).toBe("user: How does auth work?\nbot: Auth uses JWT tokens.");
+  });
+
+  it("labels messages with a bot_id as bot even when user differs", () => {
+    const messages = [{ user: "U999", text: "automated post", bot_id: "BOTHER" }];
+    expect(extractTranscriptTail(messages, botId)).toBe("bot: automated post");
+  });
+
+  it("strips @mentions from entries", () => {
+    const messages = [
+      { user: "U123", text: "<@B001> can you check <@U456>'s question?", bot_id: undefined },
+    ];
+    const tail = extractTranscriptTail(messages, botId);
+    expect(tail).not.toContain("<@");
+    expect(tail).toContain("can you check");
+  });
+
+  it("truncates entries at 500 chars with a trailing ellipsis", () => {
+    const messages = [{ user: "U123", text: "x".repeat(600), bot_id: undefined }];
+    const tail = extractTranscriptTail(messages, botId);
+    // "user: " prefix + 500 chars + "..."
+    expect(tail.length).toBeLessThanOrEqual("user: ".length + 500 + 3);
+    expect(tail).toMatch(/\.\.\.$/);
+  });
+
+  it("skips entries that are empty after mention stripping", () => {
+    const messages = [
+      { user: "U123", text: "<@B001>", bot_id: undefined },
+      { user: "U123", text: "real question", bot_id: undefined },
+    ];
+    expect(extractTranscriptTail(messages, botId)).toBe("user: real question");
+  });
+
+  it("keeps only the last TRANSCRIPT_TAIL_MAX entries", () => {
+    const messages = Array.from({ length: 20 }, (_, i) => ({
+      user: "U123",
+      text: `msg ${i}`,
+      bot_id: undefined,
+    }));
+    const tail = extractTranscriptTail(messages, botId);
+    const lines = tail.split("\n");
+    expect(TRANSCRIPT_TAIL_MAX).toBe(6);
+    expect(lines).toHaveLength(TRANSCRIPT_TAIL_MAX);
+    // Most recent messages survive, oldest are dropped
+    expect(lines[lines.length - 1]).toBe("user: msg 19");
+    expect(tail).not.toContain("msg 13");
   });
 });

--- a/src/lib/thread-filter.ts
+++ b/src/lib/thread-filter.ts
@@ -137,13 +137,17 @@ export function extractTranscriptTail(
   messages: ThreadMessage[],
   botUserId: string,
 ): string {
+  // Walk from the newest message backward and stop once the tail is
+  // full — long threads must not pay clean/truncate cost per message
+  // on every classification.
   const entries: string[] = [];
-  for (const m of messages) {
+  for (let i = messages.length - 1; i >= 0 && entries.length < TRANSCRIPT_TAIL_MAX; i--) {
+    const m = messages[i];
     const text = truncate(cleanText(m.text ?? ""), TRANSCRIPT_ENTRY_MAX_CHARS);
     if (!text) continue; // Skip empty messages
 
     const speaker = m.user === botUserId || m.bot_id ? "bot" : "user";
     entries.push(`${speaker}: ${text}`);
   }
-  return entries.slice(-TRANSCRIPT_TAIL_MAX).join("\n");
+  return entries.reverse().join("\n");
 }

--- a/src/lib/thread-filter.ts
+++ b/src/lib/thread-filter.ts
@@ -112,3 +112,38 @@ export function buildConversationHistory(
 
   return merged;
 }
+
+// ── Classifier transcript tail (#126) ───────────────────────────────
+
+/** Max thread entries fed to the turn classifier. The gate question is
+ *  "is THIS message addressed to the bot" — a handful of recent turns is
+ *  plenty of context, and keeping the tail small keeps the Haiku call
+ *  cheap and fast. */
+export const TRANSCRIPT_TAIL_MAX = 6;
+
+/** Per-entry char cap for the classifier transcript. Tighter than the
+ *  agent-history cap (2000) — the classifier needs gist, not detail. */
+const TRANSCRIPT_ENTRY_MAX_CHARS = 500;
+
+/**
+ * Compact "speaker: text" transcript of the most recent thread messages,
+ * for the turn classifier's <TRANSCRIPT> slot. Pure. Mention tokens are
+ * stripped (same cleanText as buildConversationHistory), entries empty
+ * after cleaning are skipped, each entry is truncated at 500 chars with
+ * a trailing "...", and the speaker is "bot" under the same rule
+ * buildConversationHistory uses for role "assistant".
+ */
+export function extractTranscriptTail(
+  messages: ThreadMessage[],
+  botUserId: string,
+): string {
+  const entries: string[] = [];
+  for (const m of messages) {
+    const text = truncate(cleanText(m.text ?? ""), TRANSCRIPT_ENTRY_MAX_CHARS);
+    if (!text) continue; // Skip empty messages
+
+    const speaker = m.user === botUserId || m.bot_id ? "bot" : "user";
+    entries.push(`${speaker}: ${text}`);
+  }
+  return entries.slice(-TRANSCRIPT_TAIL_MAX).join("\n");
+}


### PR DESCRIPTION
## Summary

Implements #126. Two changes to how the bot spends effort:

1. **Follow-up gate**: un-mentioned thread follow-ups now pass through a fast-model (Haiku) classifier that decides `shouldReply` with a confidence threshold (0.75). Errors, timeouts (3s), malformed output, and low confidence all **fail closed to silence** — and the decision happens before any Slack write, so a decline produces zero visible flicker. Explicit @-mentions never consult the classifier (the escape valve during a Haiku outage). Pending-correction and bulk-confirm replies short-circuit before the classifier and can never be muted.
2. **Per-turn budgets**: the same single classifier call buckets each turn `quick | standard | deep` → 4 / 10 / 15 tool rounds (`deep` = existing `MAX_TOOL_ROUNDS` ceiling; never raised). Answer-length steering rides the user message as a hint (`standard` = empty hint, byte-identical to today's agent input); the cached stable prompt zone is untouched. `agent_start`/`agent_complete` now log `effort` + `max_rounds`, so per-bucket token usage falls out of existing events.

## Design notes

- One combined structured call for both judgments (shared input, one failure path); pure `decideShouldReply`/`decideEffort` interpret it — fully unit-testable with an injected call (same idiom as `compaction.ts`).
- `resolveMaxRounds` clamps to [1, MAX_TOOL_ROUNDS]; absent options preserve today's behavior exactly.
- New events: `turn_classified`, `turn_classifier_error` (reasons: api_error/timeout/malformed_json/invalid_shape), `followup_reply_declined`.
- Deliberate behavior change worth reviewer attention: a confidently-`standard` (or classifier-failed) turn now gets **10 rounds, not 15** — the issue's stated intent; only `deep` retains 15.
- Also hardened prompt substitution against `$&` patterns in user content (replacer functions), with a regression test.

## Testing

- TDD: RED confirmed before implementation; 44 new unit tests (classifier failure matrix, threshold boundaries at 0.74/0.75, budget clamping at -1/0/1/99, transcript-tail extraction edges).
- New real-API eval fixtures (`should-reply.test.ts`) run only under `npm run eval`, excluded from `npm test`.
- Full suite: **569 passing**, typecheck clean.

## Docs

New `docs/features/effort-routing.md` + registration; all seven "15-round budget" doc claims updated; CLAUDE.md design decision 6, observability catalog, usage/troubleshooting sections updated.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
