### PR TITLE
feat: Idempotent issue creation + recoverable background processing (closes #125)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,8 @@ UPSTASH_REDIS_REST_TOKEN=...
 SENTRY_DSN=
 # Optional overrides (defaults work for most cases):
 # SENTRY_TRACES_SAMPLE_RATE=1
+
+# Recovery sweep auth (see docs/setup.md — Vercel Cron). Vercel sends
+# `Authorization: Bearer $CRON_SECRET` with every cron invocation;
+# /api/cron/sweep denies ALL requests when this is unset (fail closed).
+CRON_SECRET=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ npm run dev                  # http://localhost:3000
 src/
   app/
     api/slack/route.ts    — Slack webhook handler (mention, reaction, thread follow-up)
+    api/cron/sweep/route.ts — Recovery sweep (retries turns killed mid-processing)
     page.tsx              — Landing page
   lib/
     slack.ts              — Slack client, signature verification, message helpers
@@ -51,6 +52,9 @@ src/
     feedback.ts           — Feedback storage (Vercel KV) and Q&A context
     issue-batch.ts        — Pure helpers for multi-proposal formatting and bulk-confirm matching
     effort-routing.ts     — Turn classifier (follow-up shouldReply gate + effort buckets → round/answer budgets)
+    idempotency.ts        — Content-addressed idempotent execution (issue creation, #125)
+    recovery.ts           — Processing markers + sweep decisions for died turns (#125)
+    turn-runner.ts        — Mention/follow-up turn bodies (shared by webhook route + sweep)
     config.ts             — .battle-mage.json loader (path annotations with graduated trust)
     repo-index.ts         — Repository topic index (lazy rebuild on SHA change)
     auto-correct.ts       — Stale KB entry detection and doc reference flagging
@@ -84,6 +88,8 @@ docs/
     message-splitting.md  — Long-reply chunking architecture (split-reply + boundary guard)
     issue-creation.md     — Batch issue proposals + bulk-confirm flow
     effort-routing.md     — Fast-model follow-up gate + per-turn effort budgets
+TELEMETRY.md              — Incident-response event vocabulary + Sentry query recipes
+vercel.json               — Vercel Cron schedule for the recovery sweep
 ```
 
 ## Testing (TDD Required)
@@ -115,3 +121,4 @@ npm run test:watch    # Watch mode for development
 | `GITHUB_PAT_BM` | Fine-grained PAT for target repo |
 | `GITHUB_OWNER` | GitHub org/user |
 | `GITHUB_REPO` | Repository name |
+| `CRON_SECRET` | Bearer token for `/api/cron/sweep` (unset = sweep denies all requests) |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ See the [full setup guide](docs/setup.md) for Slack app creation, GitHub PAT, Ve
 | [Architecture](docs/architecture.md) | Agent loop, tools, system prompt, design decisions |
 | [Contributing](docs/contributing.md) | Fork workflow, TDD, CI, branch protection |
 | [Observability](docs/observability.md) | Structured JSON logs, Sentry integration, event catalog, debugging |
+| [Telemetry](TELEMETRY.md) | Incident response: stable event vocabulary + Sentry query recipes (failure rate, recovery funnel, duplicate suppression) |
 | [Evals](docs/evals.md) | Judge-lite output-contract rubric harness |
 | [Troubleshooting](docs/troubleshooting.md) | Common issues and fixes |
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,88 @@
+# Telemetry — incident-response reference
+
+This is the **incident-response view** of Battle Mage's telemetry: the stable event vocabulary you can build alerts and dashboards on, plus ready-made Sentry query recipes. The full event **catalog** (every event, every field) and the plumbing (Sentry setup, the `after()` tail-drop rule, KV-op schema) live in [docs/observability.md](docs/observability.md) — this file deliberately does not duplicate it.
+
+Split of responsibilities:
+
+- **docs/observability.md** — catalog + plumbing: what each event carries, how logs reach Sentry, how to debug the pipeline itself.
+- **TELEMETRY.md** (this file) — incident response: which events are load-bearing, what "healthy" looks like, and the queries to run when it isn't.
+
+All events are structured JSON logs correlated by `requestId` (see docs/observability.md). Event names containing `error` or `failed` route to `console.error` → Sentry error severity.
+
+## Stable event vocabulary
+
+These names are treated as a public contract — renaming one is a breaking change for dashboards and must be called out in the PR (the last rename wave was #125).
+
+### Turn lifecycle
+
+| Event | Meaning |
+|---|---|
+| `mention_start` | An @bm mention was accepted for processing |
+| `thread_followup_start` | A thread follow-up was accepted for processing |
+| `answer_posted` | The final answer landed in Slack |
+| `agent_turn_failed` | A mention/follow-up turn died with a handled error (`flow: mention \| thread_followup`) |
+| `webhook_handler_failed` | A reaction handler died (`flow: reaction_checkmark \| reaction_thumbsup \| reaction_thumbsdown`) |
+| `tool_call_failed` | A tool executor threw mid-agent-loop (`tool`, `round`, `errorMessage`) |
+| `turn_end` | Log-flush canary — if this appears, no earlier log in the turn was dropped |
+
+### Idempotency (issue creation, #125)
+
+| Event | Meaning |
+|---|---|
+| `idempotency_replayed` | Duplicate issue creation suppressed; recorded result reused |
+| `idempotency_in_flight` | Concurrent creation of identical content detected and refused |
+| `idempotency_degraded` | KV unreachable — creation ran unguarded (fail open) |
+
+### Recovery (processing markers + cron sweep, #125)
+
+| Event | Meaning |
+|---|---|
+| `recovery_marker_write_failed` | Turn started without crash protection |
+| `recovery_marker_clear_failed` | Marker cleanup failed (self-heals via sweep guard / 24 h TTL) |
+| `recovery_sweep_retried` | A died turn was re-run |
+| `recovery_sweep_already_answered` | Died AFTER answering — marker cleaned, no retry |
+| `recovery_sweep_gave_up` | Retry also died — user got a visible failure notice |
+| `recovery_marker_orphaned` | Index entry outlived its marker record — dropped |
+| `recovery_sweep_claim_lost` | Another sweep instance owns this member's NX claim (`processing:claim:*`, 120 s TTL) — benign skip |
+| `recovery_sweep_complete` | Sweep heartbeat (`scanned`, `retried`, `gaveUp`, `orphaned`) |
+| `recovery_sweep_failed` / `recovery_sweep_member_failed` | The sweep itself broke (whole run / one thread — state stays recoverable; the next sweep retries after the claim TTL) |
+| `recovery_sweep_unauthorized` | Cron auth rejected — check `CRON_SECRET` |
+
+## Query recipes (Sentry Logs UI)
+
+### Turn failure rate
+
+Handled failures as a share of accepted mentions:
+
+```
+count(event:agent_turn_failed flow:mention) / count(event:mention_start)
+```
+
+Healthy: low single-digit percent, dominated by transient GitHub/Anthropic errors. A spike with a constant `message` is a code bug — the Sentry Issue (captured alongside the log) has the stack trace. **Silent** failures (container death) never emit `agent_turn_failed` — they show up in the recovery funnel below instead. The follow-up variant is the same query with `flow:thread_followup` over `thread_followup_start`.
+
+### Recovery funnel
+
+How many turns died silently, and what happened to them:
+
+```
+event:recovery_sweep_retried            — died once, re-run
+event:recovery_sweep_gave_up            — died twice, user notified
+event:recovery_sweep_already_answered   — died post-answer, benign
+event:recovery_marker_orphaned          — bookkeeping cleanup, benign
+```
+
+Healthy: all four near zero; `recovery_sweep_complete` appearing every ~5 minutes with `scanned: 0`. Rising `retried` means containers are dying mid-turn (check function duration/memory). Any `gave_up` deserves a look at the thread — the same question killed two runs, which usually means a pathological input. `recovery_sweep_complete` **missing** means the cron isn't firing: check the Vercel Cron dashboard and look for `recovery_sweep_unauthorized`.
+
+### Duplicate-suppression rate
+
+How often idempotency actually saved us from a duplicate GitHub issue:
+
+```
+count(event:idempotency_replayed) + count(event:idempotency_in_flight)
+```
+
+…as a share of `event:issue_batch_confirmed`. Healthy: near zero in steady state (the del-claim + tombstone layer catches most races first). A sustained rise means duplicate confirmations are reaching the innermost layer — look for Slack event redeliveries (`x-slack-retry-num` handling) or tombstone-TTL gaps. Any nonzero `idempotency_degraded` means Upstash was unreachable during issue creation — correlate with `kv_error`.
+
+### Cross-run correlation
+
+A sweep retry logs the dead run's ID as `originalRequestId` on `recovery_sweep_retried`. To reconstruct an incident: filter the original `requestId` for the death context, then the sweep's `requestId` for the retry outcome.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,9 +81,9 @@ When a user reacts with :white_check_mark: to a bot message containing an issue 
 
 1. Fetches the message text
 2. Verifies it was posted by the bot (not by someone else)
-3. Parses the proposal title, body, and labels from the message format
-4. Creates the issue on GitHub via `octokit.rest.issues.create`
-5. Replies with a link to the new issue
+3. Atomically claims the pending batch record in KV (`kv.del` — racing confirmations lose the claim and exit); falls back to parsing the proposal from the message text for pre-#122 messages
+4. Creates each issue through the idempotency layer (`executeIdempotent` keyed on a sha256 of `{title, body, labels}`) — a duplicate confirmation replays the recorded issue instead of filing a second one; a concurrent in-flight creation is reported instead of raced (#125)
+5. Replies with a link to the new issue (or a batch summary)
 
 ### `reaction_added` with `+1` or `-1` -- Feedback
 
@@ -98,6 +98,17 @@ When a user reacts with :white_check_mark: to a bot message containing an issue 
 3. Runs auto-correction: identifies stale KB entries (keyword matching) and doc references
 4. Removes stale KB entries from Vercel KV
 5. Replies asking the user what was wrong
+
+## The Recovery Sweep — `GET /api/cron/sweep`
+
+A second entry point alongside `/api/slack`, invoked by Vercel Cron every 5 minutes (`vercel.json`) and authenticated via `Authorization: Bearer $CRON_SECRET` (exact match, fail closed). It exists because Vercel can kill the container mid-`after()` — the answer then silently dies.
+
+1. Every mention/follow-up turn writes a processing marker (`processing:{channel}:{threadTs}` + a `processing:index` zset entry) as the **first step of the `after()` body** and clears it in the `after()` `finally` — so only container death leaves a marker behind. The write stays off the ack path (KV latency must never push the 200 OK past Slack's 3-second deadline); the tiny ack→`after()` death window is an accepted trade
+2. The sweep walks the index and classifies each marker: younger than 15 minutes → wait (could still be a live invocation; the route's `maxDuration` is 300 s, so >15 min is provably dead); stale first attempt → retry; stale retry → give up with a visible failure notice in the thread; index entry without a marker → orphan cleanup
+3. Stale markers are claimed **non-destructively**: `SET NX` on `processing:claim:{channel}:{threadTs}` with a 120 s TTL — concurrent sweeps lose NX and skip (`recovery_sweep_claim_lost`). The marker and index entry are cleared only **after** the action completes (give-up notice posted before deletion; a retry overwrites the marker key in place), so a failure after a won claim leaves the turn recoverable by the next sweep once the claim expires
+4. Retries verify the bot didn't already answer after the marker was written, then re-run the turn through the **same** turn-runner code path (`src/lib/turn-runner.ts`) the webhook uses — idempotent issue creation makes this safe even for turns that had already filed issues
+
+See `src/lib/recovery.ts` for the marker/staleness model and `TELEMETRY.md` for the recovery-funnel queries.
 
 ## System Prompt Assembly
 

--- a/docs/features/effort-routing.md
+++ b/docs/features/effort-routing.md
@@ -5,7 +5,7 @@ Two per-turn decisions, one cheap Haiku call (see #126):
 1. **shouldReply** — is a thread follow-up actually addressed to the bot? The old heuristic (bot has a prior reply in the thread) made the bot answer human-to-human chatter. Now a fast-model classifier reads the recent transcript and the new message and gates the reply.
 2. **effort** — bucket the question into `quick | standard | deep`, sizing the agent's tool-round budget and answer-length target so trivial questions stop costing 15 rounds and hard ones stop being squeezed into a 3K-char answer.
 
-All logic lives in `src/lib/effort-routing.ts`; the Slack route (`src/app/api/slack/route.ts`) composes it.
+All logic lives in `src/lib/effort-routing.ts`; the turn runner (`src/lib/turn-runner.ts` — the mention/follow-up turn bodies shared by the webhook route and the recovery sweep, #125) composes it.
 
 ## The classifier call
 
@@ -55,13 +55,13 @@ The asymmetry is deliberate: a wrongly-silent bot costs one re-mention; a wrongl
 
 Two delivery mechanisms:
 
-- **Round cap** — the route passes `{ maxRounds, effort }` as `runAgent`'s optional 6th parameter. `resolveMaxRounds` (pure, exported from `claude.ts`) floors, clamps to `[1, MAX_TOOL_ROUNDS]`, and defaults to `MAX_TOOL_ROUNDS` when absent — so `claude.ts` never trusts a raw number and stays classifier-agnostic.
+- **Round cap** — the turn runner passes `{ maxRounds, effort }` as `runAgent`'s optional 6th parameter. `resolveMaxRounds` (pure, exported from `claude.ts`) floors, clamps to `[1, MAX_TOOL_ROUNDS]`, and defaults to `MAX_TOOL_ROUNDS` when absent — so `claude.ts` never trusts a raw number and stays classifier-agnostic.
 - **Answer-length steering** — `buildEffortHint(effort)` is appended to the **user message** (like `buildQuestionHints`), never the system prompt: the stable prompt zone stays byte-identical so prompt caching keeps hitting. For `standard` the hint is `""` — the default path is byte-for-byte unchanged.
 
-## Route wiring
+## Turn-runner wiring
 
 - **Mention path** (`app_mention`): `classifyTurn` runs with `invocation: "mention"` in a `Promise.all` with the topic fetch, and **shouldReply is never consulted** — an explicit @mention always gets an answer. Only `decideEffort` is used.
-- **Follow-up path** (`message` in a bot thread): after the structural checks (bot-in-thread, not addressed to another user) and AFTER the pending-correction / bulk-confirm branches short-circuit, `evaluateFollowup` runs **before** the thinking message is posted. A decline produces **zero Slack writes** — just a `followup_reply_declined` log event (`reason`: `not_addressed` | `low_confidence` | `classifier_unavailable`) and a silent return.
+- **Follow-up path** (`message` in a bot thread): after the structural checks (bot-in-thread, not addressed to another user) and AFTER the pending-correction / bulk-confirm branches short-circuit, `evaluateFollowup` runs **before** the thinking message is posted. A decline produces **zero Slack writes** — just a `followup_reply_declined` log event (`reason`: `not_addressed` | `low_confidence` | `classifier_unavailable`) and a silent return. Because the gate lives in the turn runner, a **sweep-retried** follow-up (#125) re-runs it — a message that shouldn't be answered stays silent on retry too, and the decline's clean return still lets the caller's `finally` clear the processing marker.
 
 ## Observability
 

--- a/docs/features/issue-creation.md
+++ b/docs/features/issue-creation.md
@@ -20,16 +20,21 @@ Bodies are persisted in KV so the confirmation path can create issues without ro
 3. **Slack route renders** — `formatBatchProposalMessage(proposals)` produces the Slack mrkdwn block:
    - `proposals.length === 1` → legacy single-proposal format (unchanged UX)
    - `proposals.length >= 2` → batch format (numbered list + bulk-confirm footer)
-4. **Batch persisted in KV** under two keys:
-   - `pending-issue-batch:{channel}:{firstTs}` — the canonical record (proposals, timing, requester, thread)
-   - `pending-issue-batch:thread:{channel}:{threadTs}` — pointer to `firstTs` for text-command lookup
-   - Both with a 24 h TTL.
-   - On successful claim, a third key `pending-issue-batch:done:{channel}:{firstTs}` is written with a 1 h TTL as a tombstone. Any subsequent ✅ reaction on the same message checks this key and exits silently — without it, a double-tap would fall through to the legacy parser and re-create the issue (N=1 messages still have a body in their text).
+4. **Batch persisted in KV**. Keys involved across the whole lifecycle:
+   - `pending-issue-batch:{channel}:{firstTs}` — the canonical record (proposals, timing, requester, thread). 24 h TTL.
+   - `pending-issue-batch:thread:{channel}:{threadTs}` — pointer to `firstTs` for text-command lookup. 24 h TTL.
+   - `pending-issue-batch:done:{channel}:{firstTs}` — tombstone written on successful claim, 1 h TTL. Any subsequent ✅ reaction on the same message checks this key and exits silently — without it, a double-tap would fall through to the legacy parser (N=1 messages still have a body in their text).
+   - `idem:issue:<sha256>` — per-issue idempotency record (#125), written at creation time. Content-addressed over `{title, body, labels}` (`labels: undefined` hashes identically to `[]`, order-insensitive). Held as a `pending` lock (60 s TTL) while `createIssue` runs, then replaced by a `completed` record carrying the issue number/URL (30-day TTL).
 5. **User confirms** via one of:
    - :white_check_mark: reaction on the proposal message — reaction handler calls `executeBatchCreation`
    - `"confirm all"` (or synonym) in the thread — thread-followup handler calls `executeBatchCreation`
-6. **Atomic claim** — `executeBatchCreation` reads the canonical key, then `kv.del`s it. Redis DEL is atomic: only the first caller sees `deleted === 1`; racing reactions/texts see `0` and bail. No double-creation.
-7. **Parallel creation** via `Promise.allSettled` — per-issue failures do not abort the rest.
+6. **Atomic claim** — `executeBatchCreation` reads the canonical key, then `kv.del`s it. Redis DEL is atomic: only the first caller sees `deleted === 1`; racing reactions/texts see `0` and bail. This serializes *batch* claims; the per-issue idempotency layer below catches anything that slips past it (Slack redelivery, legacy-parser re-entry, tombstone expiry).
+7. **Idempotent parallel creation** via `Promise.allSettled` — every `createIssue` call is wrapped in `executeIdempotent(issueIdempotencyKey(p), ...)`:
+   - `created` — fresh GitHub issue → success in the summary.
+   - `replayed` — an identical proposal was already created within 30 days → success in the summary, reusing the **recorded** URL. No second GitHub issue.
+   - `in_flight` — another confirmation holds the pending lock for this exact proposal right now → error-shaped outcome ("already being created by another confirmation").
+   - KV outage → fail open: the issue is created unguarded and `idempotency_degraded` is logged. A rare duplicate beats a broken confirmation flow.
+   Per-issue failures do not abort the rest, and a failed create releases its idempotency lock so a later confirmation can retry.
 8. **Summary reply** from `summarizeBatchResult(outcomes)` — lists created issues with links and any failures with error messages.
 
 ## Bulk-confirm text matching
@@ -53,20 +58,39 @@ Lifecycle events (structured logs; same shape as `kv_op`):
 | `issue_batch_reaction_after_claim` | ✅ arrived after a successful claim (tombstone hit) | `channel`, `messageTs` |
 | `issue_batch_created` | After all creations settle | `totalCount`, `successCount`, `failureCount`, `durationMs`, `numbers` |
 | `issue_create_error` | Per-issue failure | `title`, `errorClass`, `errorMessage` |
+| `idempotency_replayed` | Duplicate creation suppressed — recorded result returned | `key` |
+| `idempotency_in_flight` | Concurrent creation of the same proposal detected | `key` |
+| `idempotency_degraded` | KV unavailable — creation ran unguarded (fail open) | `key`, `phase` (`lock`/`unlock`/`record`), `errorMessage` |
+| `issue_create_in_flight` | Legacy-parser path hit an in-flight lock and stayed silent | `via`, `channel`, `messageTs` |
+| `webhook_handler_failed` | Unhandled error in the ✅ reaction handler | `flow: "reaction_checkmark"`, `message` |
 
-Per-issue failures also emit `Sentry.captureException` tagged `{flow: "issue_create", batchSize: <N>}` so a rate-limit burst on one title surfaces as a distinct Sentry issue rather than hiding under the summary.
+Per-issue failures also emit `Sentry.captureException` tagged `{flow: "issue_create", batchSize: <N>}` so a rate-limit burst on one title surfaces as a distinct Sentry issue rather than hiding under the summary. See `TELEMETRY.md` for the cross-feature event vocabulary and query recipes (including the duplicate-suppression rate).
 
 ## Edge cases
 
 - **Multi-chunk proposal messages** — the canonical record is keyed by the first chunk's ts. If a proposal splits across chunks (rare — batch mode is compact by design; single mode is under the 4 k body budget), a reaction on a later chunk will not find the batch and will fall through to the legacy parser for single-proposal back-compat.
-- **Racing confirmations** — two users react simultaneously, or one reacts while another types "confirm all". The atomic `kv.del` ensures exactly one `executeBatchCreation` call proceeds. The loser logs `issue_batch_claim_lost` and exits silently.
+- **Racing confirmations** — two users react simultaneously, or one reacts while another types "confirm all". Two independent layers prevent double-creation: (1) the atomic `kv.del` claim ensures exactly one `executeBatchCreation` call proceeds — the loser logs `issue_batch_claim_lost` and exits silently; (2) even if a duplicate slips past the claim (Slack event redelivery, tombstone expiry followed by a legacy-parser fallback), the per-issue idempotency key replays the recorded issue (`idempotency_replayed`) or detects an in-flight creation (`idempotency_in_flight`) instead of filing a second GitHub issue.
 - **Partial GitHub failures** — a rate limit or permission error on one title does not abort the rest. The summary reply lists every created issue AND every failure.
 - **Legacy single-proposal messages** — pre-#122 messages have no KV record. The reaction handler falls back to `parseProposalFromMessage` and creates exactly one issue. Natural drain via 24 h TTL.
+
+## Recovery sweep
+
+Issue-creating turns run inside `after()` callbacks, and Vercel can kill the container mid-turn (timeout, OOM, platform restart). Since #125:
+
+- Every mention/follow-up turn writes a **processing marker** (`processing:{channel}:{threadTs}`, indexed in the `processing:index` zset) as the **first step of the `after()` body**, and clears it in the `after()` `finally`. Only container death leaves a marker behind. The write is deliberately kept **off the ack path** — two KV round-trips before the 200 OK could breach Slack's 3-second deadline and trigger duplicate retries; the accepted trade is that a container death in the tiny window between the ack and the marker write loses recovery for that turn.
+- A **cron sweep** (`/api/cron/sweep`, scheduled every 5 minutes via `vercel.json`) walks the index. A marker older than 15 minutes is provably dead (the route's `maxDuration` is 300 s): a first-attempt marker is **retried once** through the same turn-runner code path — after an already-answered guard so a turn that died between posting its answer and clearing its marker isn't double-answered — and a marker whose retry also died gets a **visible failure notice** in the thread ("I hit an error processing your question — please re-ask").
+- Before acting on a stale marker, the sweep wins a **non-destructive claim**: `SET NX` on `processing:claim:{channel}:{threadTs}` with a 120 s TTL (`SWEEP_CLAIM_TTL_SEC`). A concurrent sweep loses NX and skips (`recovery_sweep_claim_lost`). The marker and index entry are cleared **only after the chosen action completes** — the give-up notice is posted *before* any deletion, and a retry *overwrites* the marker key in place — so a Slack failure mid-action leaves the turn recoverable by the next sweep once the claim TTL expires.
+- The sweep's retry can safely re-reach `executeBatchCreation`/`createIssue` because of the idempotency layer above — a re-run of a turn that already created issues replays them instead of duplicating.
+
+The sweep's cadence is correctness-independent: a slower schedule (e.g. Vercel Hobby's ~daily cron floor) only delays recovery, never breaks it.
 
 ## Code layout
 
 - `src/lib/issue-batch.ts` — pure helpers (`formatBatchProposalMessage`, `isBulkConfirmText`, `summarizeBatchResult`). No I/O; safe to import in tests.
-- `src/app/api/slack/route.ts` — `PendingIssueBatch` shape, KV key helpers, `executeBatchCreation`, and the three entry points (mention → propose, thread text → confirm, reaction → confirm).
+- `src/lib/idempotency.ts` — content-addressed idempotency (`issueIdempotencyKey`, `executeIdempotent`). See #125.
+- `src/lib/turn-runner.ts` — `PendingIssueBatch` shape, KV key helpers, `executeBatchCreation`, and the mention/follow-up turn bodies (shared by the webhook route and the recovery sweep).
+- `src/app/api/slack/route.ts` — the three entry points (mention → propose, thread text → confirm, reaction → confirm) plus processing-marker lifecycle.
+- `src/app/api/cron/sweep/route.ts` — the recovery sweep (see `src/lib/recovery.ts` for the marker/staleness model).
 - `src/tools/create-issue.ts` — `create_issue` tool schema and `parseProposalFromMessage` (legacy fallback).
 
-See #122 for the original motivation and design discussion.
+See #122 for the original motivation and design discussion, #125 for idempotency + recovery.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -37,6 +37,8 @@ The SDK's auto-flush above fires at **route-handler response time** — which ru
 
 If you add a new `after()` callback, **you must end it with `flushLogs`** or its logs will tail-drop. The unit test at `src/lib/logger.test.ts` pins the explicit-flush behavior so accidental regression fails loudly in CI.
 
+The same rule applies to the cron route: `/api/cron/sweep` does its work in the handler body (no `after()`), but its container freezes just as aggressively after the response — so it too ends with `await flushLogs(rlog, "cron_sweep")` in a `finally` block.
+
 ## Log Format
 
 Every log entry is a single JSON line:
@@ -85,6 +87,7 @@ Filter: requestId=a3f2b1c4
 |-------|------|----------|
 | `agent_start` | Agent loop begins | promptLength, question, model, effort, max_rounds |
 | `agent_tool_call` | Each tool execution | tool, round, input (truncated) |
+| `tool_call_failed` | A tool executor threw (the error is also returned to the model as a `tool_result`) | tool, round, errorMessage |
 | `agent_complete` | Agent produces final answer | rounds, refCount, hasProposal, duration_ms, effort, max_rounds |
 | `prompt_feedback_included` | System prompt assembled — fires **every** turn, even when no entries | positiveCount, negativeCount, totalEntries, promptZone |
 
@@ -150,13 +153,45 @@ Every reaction flows through this event funnel. `reaction_skipped` and `feedback
 - **Feedback feature value:** correlate `prompt_feedback_included.totalEntries > 0` turns with subsequent `feedback_saved.type = "positive"` rates — does having feedback in context correlate with higher-quality answers?
 - **Reaction latency:** bucket `feedback_saved.latencyMs` — immediate reactions (<30s) are higher signal than day-later reactions.
 
-### Error Events (all flows)
+### Idempotency Events (lib/idempotency.ts) — #125
+
+Every `createIssue` call is wrapped in `executeIdempotent` with a content-addressed key (`idem:issue:<sha256 of {title, body, labels}>`).
 
 | Event | When | Key data |
 |-------|------|----------|
-| `error` | Any unhandled error in a flow | flow, message |
+| `idempotency_replayed` | A duplicate creation was suppressed; the recorded result was returned | key |
+| `idempotency_in_flight` | A concurrent holder owns the pending lock for the same content | key |
+| `idempotency_degraded` | KV unavailable — the operation ran unguarded (fail open) | key, phase (`lock`/`unlock`/`record`), errorMessage |
+| `issue_create_in_flight` | The legacy-parser ✅ path hit an in-flight lock and stayed silent | via, channel, messageTs |
 
-The `flow` field identifies which handler failed: `mention`, `thread_followup`, `reaction_checkmark`, `reaction_thumbsup`, `reaction_thumbsdown`.
+### Recovery Events (lib/recovery.ts + /api/cron/sweep) — #125
+
+Mention and follow-up turns write a processing marker as the first step of the `after()` body (off the ack path — Slack's 3-second deadline) and clear it in the `finally`; the cron sweep retries what container death left behind. Before acting on a stale marker, the sweep wins a non-destructive `SET NX` claim on `processing:claim:{channel}:{threadTs}` (120 s TTL) — the marker is only cleared after the action completes, so post-claim failures stay recoverable.
+
+| Event | When | Key data |
+|-------|------|----------|
+| `recovery_marker_write_failed` | Marker write failed (turn proceeds unprotected) | channel, threadTs, errorMessage |
+| `recovery_marker_clear_failed` | Marker cleanup failed (sweep guard + 24 h TTL mop up) | channel, threadTs, errorMessage |
+| `recovery_marker_orphaned` | Index entry with no marker record (marker TTL expired) — dropped | channel, threadTs |
+| `recovery_sweep_retried` | A stale first-attempt turn was re-run through the turn-runner | channel, threadTs, eventType, attempt, originalRequestId |
+| `recovery_sweep_already_answered` | Stale marker, but the bot already answered after `startedAt` — no retry | channel, threadTs |
+| `recovery_sweep_gave_up` | The retry also died — visible failure notice posted to the thread | channel, threadTs, attempt, requestId |
+| `recovery_sweep_claim_lost` | Another sweep instance holds the NX claim for this member — skipped | channel, threadTs |
+| `recovery_sweep_member_failed` | One index member threw mid-sweep (sweep continues; marker + index intact — the next sweep retries after the claim TTL) | member, errorMessage |
+| `recovery_sweep_complete` | End of every sweep run | scanned, retried, gaveUp, orphaned |
+| `recovery_sweep_failed` | The whole sweep aborted | errorMessage |
+| `recovery_sweep_unauthorized` | Request without a valid `Bearer $CRON_SECRET` header | — |
+
+### Error Events (all flows)
+
+Renamed in #125 (previously a single generic `error` event) so severity routing and dashboards can distinguish agent-turn failures from webhook plumbing failures. Any event name containing `error` or `failed` is routed to `console.error` by the logger.
+
+| Event | When | Key data |
+|-------|------|----------|
+| `agent_turn_failed` | Unhandled error in a mention or thread-followup agent turn | flow (`mention` \| `thread_followup`), message |
+| `webhook_handler_failed` | Unhandled error in a reaction handler | flow (`reaction_checkmark` \| `reaction_thumbsup` \| `reaction_thumbsdown`), message |
+
+See `TELEMETRY.md` (repo root) for the incident-response view: the stable event vocabulary and ready-made Sentry query recipes (failure rate, recovery funnel, duplicate-suppression rate).
 
 ## Debugging Common Issues
 
@@ -205,6 +240,6 @@ rlog("step_two", { data: "..." });
 // Both entries have the same requestId
 ```
 
-Every call goes through one code path — `console.log` (or `console.error` for events containing "error") with a JSON payload. In prod with a DSN configured, Sentry's `consoleLoggingIntegration` captures each call and ships it to the Logs UI; in local dev/CI the integration is a silent no-op and logs only reach stdout. Either way, the application code is the same.
+Every call goes through one code path — `console.log` (or `console.error` for events containing "error" or "failed") with a JSON payload. In prod with a DSN configured, Sentry's `consoleLoggingIntegration` captures each call and ships it to the Logs UI; in local dev/CI the integration is a silent no-op and logs only reach stdout. Either way, the application code is the same.
 
 Sentry init lives in `sentry.server.config.ts` (project root) and is loaded via `instrumentation.ts` on the Node runtime. See those files for tunable options (`SENTRY_TRACES_SAMPLE_RATE`, etc.).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -156,6 +156,28 @@ The integration sets both sets of env vars — `UPSTASH_REDIS_REST_URL` / `UPSTA
 
 > **Gotcha**: If you skip this step, the bot will still work for basic Q&A -- but the knowledge base, feedback, and repo index features will silently degrade. You will see no errors, but corrections will not persist and the repo map will not be cached.
 
+### Set Up Vercel Cron (recovery sweep)
+
+The repo ships a `vercel.json` that schedules the recovery sweep — the endpoint that retries questions whose processing died mid-flight (container timeout/OOM) and posts a visible failure notice when a retry also dies:
+
+```json
+{
+  "crons": [
+    { "path": "/api/cron/sweep", "schedule": "*/5 * * * *" }
+  ]
+}
+```
+
+Vercel picks this up automatically on deploy — but the sweep authenticates every invocation, so you must set one more env var:
+
+```bash
+vercel env add CRON_SECRET   # any long random string, e.g. `openssl rand -hex 32`
+```
+
+Vercel sends `Authorization: Bearer $CRON_SECRET` with each cron invocation; the sweep **denies all requests** (401) when the variable is unset — a missing secret disables recovery rather than exposing the endpoint.
+
+> **Hobby plan note**: Hobby allows at most one cron invocation per day, so the `*/5` schedule degrades to roughly daily. Recovery stays **correct** on any cadence — the sweep's decisions depend only on marker age, never on how often it runs — you just wait longer for a stuck question to be retried. On Pro the 5-minute cadence applies as written.
+
 ### For Local Development
 
 ```bash
@@ -232,6 +254,7 @@ If the bot does not respond, check the [Troubleshooting Guide](./troubleshooting
 | `UPSTASH_REDIS_REST_TOKEN` | Auto | `AaB1Cc2...` | Injected by the Upstash Vercel integration -- do not set manually |
 | `KV_REST_API_URL` | Legacy | `https://...upstash.io` | Read as a fallback by `@upstash/redis` for projects that still provision "Vercel KV" |
 | `KV_REST_API_TOKEN` | Legacy | `AaB1Cc2...` | Read as a fallback — either pair works |
+| `CRON_SECRET` | Yes (for recovery) | `f3a9...64 hex chars` | Auth for `/api/cron/sweep` (Vercel Cron sends it as a Bearer token). Unset = sweep denies all requests, recovery disabled |
 
 ## Security Notes
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -130,10 +130,13 @@ If you see it anyway, Sentry will have a `SlackMessageOversizeError` with the of
 - **Is `reactions:read` scope granted?** Without this, the bot does not receive `reaction_added` events.
 - **Was the reaction on the bot's message?** The handler verifies that the reacted message was posted by the bot. If someone copies the proposal text into their own message and you react to that, nothing happens.
 - **Does the PAT have Issues (read/write) permission?** Creating issues requires write access. If the PAT only has read access, the API call will fail.
-- **Check Vercel logs**: The error is logged with the message "Battle Mage reaction handler error".
+- **Check Sentry/Vercel logs**: unhandled reaction-handler errors log as `webhook_handler_failed` with `flow: "reaction_checkmark"`.
+- **"already being created by another confirmation"** in the summary reply: a racing confirmation held the idempotency lock for that exact proposal. The other confirmation posts the result — if none arrives within a minute, the lock has expired (60 s TTL) and reacting again will retry safely.
+- **Stuck processing marker / dead sweep**: if the *turn itself* (not just issue creation) died mid-flight — user asked, thinking message appeared, then nothing — the recovery sweep should retry it within ~5 minutes (`recovery_sweep_retried` in the logs) or post a visible failure notice (`recovery_sweep_gave_up`). If neither appears: check that `CRON_SECRET` is set (an unset secret makes the sweep reject every invocation with `recovery_sweep_unauthorized`), that the cron shows up in the Vercel dashboard (it ships in `vercel.json`), and look for `recovery_sweep_complete` heartbeats. Full event vocabulary and the recovery-funnel queries are in [TELEMETRY.md](../TELEMETRY.md).
 
 ## Still Stuck?
 
 1. Check Vercel function logs (Dashboard > your project > Logs)
 2. Check Slack app activity logs (api.slack.com/apps > your app > App Activity Log)
-3. Open a GitHub issue with the `bug` label, including the error message and steps to reproduce
+3. Run the query recipes in [TELEMETRY.md](../TELEMETRY.md) against Sentry Logs (failure rate, recovery funnel, duplicate suppression) — most silent failures show up there
+4. Open a GitHub issue with the `bug` label, including the error message and steps to reproduce

--- a/src/app/api/cron/sweep/route.test.ts
+++ b/src/app/api/cron/sweep/route.test.ts
@@ -1,0 +1,249 @@
+// ── Sweep claim protocol tests (PR #133 review) ──────────────────────
+// The sweep's claim must be NON-DESTRUCTIVE: a failure after a won
+// claim (Slack down, thread fetch error) must leave the marker AND its
+// index entry intact so the next sweep — after the claim TTL expires —
+// can retry the decision. The previous kv.del claim destroyed the
+// marker up front, so any later throw silently lost the turn: exactly
+// the failure mode #125 exists to prevent.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const h = vi.hoisted(() => {
+  const calls: string[] = []; // cross-mock call-order journal
+  return {
+    calls,
+    store: new Map<string, unknown>(),
+    zset: new Map<string, number>(), // member -> score
+    ttls: new Map<string, number>(),
+    rlogSpy: vi.fn(),
+    replyInThread: vi.fn(async () => {
+      calls.push("replyInThread");
+    }),
+    fetchThreadMessages: vi.fn(async (): Promise<unknown[]> => {
+      calls.push("fetchThreadMessages");
+      return [];
+    }),
+    getBotUserId: vi.fn(async () => "B_BOT"),
+    runMentionTurn: vi.fn(async () => {
+      calls.push("runMentionTurn");
+    }),
+    runFollowupTurn: vi.fn(async () => {
+      calls.push("runFollowupTurn");
+    }),
+  };
+});
+
+vi.mock("@/lib/kv", () => ({
+  kv: {
+    get: vi.fn(async (key: string) => (h.store.has(key) ? h.store.get(key) : null)),
+    set: vi.fn(
+      async (key: string, value: unknown, opts?: { ex?: number; nx?: boolean }) => {
+        // Mirror Upstash SET NX semantics: null when the key exists.
+        if (opts?.nx && h.store.has(key)) return null;
+        h.store.set(key, value);
+        if (opts?.ex) h.ttls.set(key, opts.ex);
+        h.calls.push(`set:${key}`);
+        return "OK";
+      },
+    ),
+    del: vi.fn(async (key: string) => {
+      h.calls.push(`del:${key}`);
+      return h.store.delete(key) ? 1 : 0;
+    }),
+    zadd: vi.fn(async (_key: string, entry: { score: number; member: string }) => {
+      h.zset.set(entry.member, entry.score);
+      return 1;
+    }),
+    zrem: vi.fn(async (_key: string, member: string) => {
+      h.calls.push(`zrem:${member}`);
+      return h.zset.delete(member) ? 1 : 0;
+    }),
+    zrange: vi.fn(async () => [...h.zset.keys()]),
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: vi.fn(),
+  createRequestLogger: () =>
+    Object.assign(
+      (event: string, data?: Record<string, unknown>) => h.rlogSpy(event, data),
+      { requestId: "req-sweep-1" },
+    ),
+  flushLogs: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/slack", () => ({
+  replyInThread: h.replyInThread,
+  fetchThreadMessages: h.fetchThreadMessages,
+  getBotUserId: h.getBotUserId,
+}));
+
+vi.mock("@/lib/turn-runner", () => ({
+  runMentionTurn: h.runMentionTurn,
+  runFollowupTurn: h.runFollowupTurn,
+}));
+
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+
+import {
+  processingMarkerKey,
+  indexMember,
+  sweepClaimKey,
+  PROCESSING_MAX_AGE_MS,
+  type ProcessingMarker,
+} from "@/lib/recovery";
+import { GET } from "./route";
+
+// Pinned literals — never faker/random data in fixtures.
+const CHANNEL = "C0100000001";
+const THREAD_TS = "1750000000.000100";
+const MARKER_KEY = processingMarkerKey(CHANNEL, THREAD_TS);
+const MEMBER = indexMember(CHANNEL, THREAD_TS);
+
+function seedStaleMarker(
+  overrides: Partial<ProcessingMarker> = {},
+): ProcessingMarker {
+  const m: ProcessingMarker = {
+    eventType: "app_mention",
+    channel: CHANNEL,
+    threadTs: THREAD_TS,
+    user: "U0200000002",
+    text: "what does the auth module do?",
+    startedAt: Date.now() - PROCESSING_MAX_AGE_MS - 60_000,
+    attempt: 0,
+    requestId: "orig1234",
+    ...overrides,
+  };
+  h.store.set(MARKER_KEY, m);
+  h.zset.set(MEMBER, m.startedAt);
+  return m;
+}
+
+function cronRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/cron/sweep", {
+    headers: { authorization: "Bearer test-secret" },
+  });
+}
+
+function rlogEvents(): string[] {
+  return h.rlogSpy.mock.calls.map((c) => c[0] as string);
+}
+
+beforeEach(() => {
+  h.store.clear();
+  h.zset.clear();
+  h.ttls.clear();
+  h.calls.length = 0;
+  h.rlogSpy.mockClear();
+  h.replyInThread.mockClear();
+  h.fetchThreadMessages.mockClear();
+  h.runMentionTurn.mockClear();
+  h.runFollowupTurn.mockClear();
+  process.env.CRON_SECRET = "test-secret";
+});
+
+describe("sweep claim (SET NX) — losing racer", () => {
+  it("skips the member and leaves marker + index intact when another sweep holds the claim", async () => {
+    seedStaleMarker(); // attempt 0 → retry path, but…
+    h.store.set(sweepClaimKey(CHANNEL, THREAD_TS), { claimedAt: Date.now(), requestId: "other" });
+
+    const res = await GET(cronRequest());
+    expect(res.status).toBe(200);
+
+    expect(rlogEvents()).toContain("recovery_sweep_claim_lost");
+    expect(h.store.get(MARKER_KEY)).toBeDefined();
+    expect(h.zset.has(MEMBER)).toBe(true);
+    expect(h.runMentionTurn).not.toHaveBeenCalled();
+    expect(h.replyInThread).not.toHaveBeenCalled();
+  });
+});
+
+describe("give_up path", () => {
+  it("posts the failure notice BEFORE deleting the marker or index entry", async () => {
+    seedStaleMarker({ attempt: 1 });
+
+    await GET(cronRequest());
+
+    expect(h.replyInThread).toHaveBeenCalledWith(
+      CHANNEL,
+      THREAD_TS,
+      expect.stringContaining("please re-ask"),
+    );
+    // Marker + index cleared ONLY AFTER the notice succeeded.
+    expect(h.store.has(MARKER_KEY)).toBe(false);
+    expect(h.zset.has(MEMBER)).toBe(false);
+    const noticeAt = h.calls.indexOf("replyInThread");
+    const delAt = h.calls.indexOf(`del:${MARKER_KEY}`);
+    const zremAt = h.calls.indexOf(`zrem:${MEMBER}`);
+    expect(noticeAt).toBeGreaterThanOrEqual(0);
+    expect(delAt).toBeGreaterThan(noticeAt);
+    expect(zremAt).toBeGreaterThan(noticeAt);
+    expect(rlogEvents()).toContain("recovery_sweep_gave_up");
+  });
+
+  it("leaves marker + index intact when the Slack notice fails after a won claim", async () => {
+    const marker = seedStaleMarker({ attempt: 1 });
+    h.replyInThread.mockRejectedValueOnce(new Error("slack_unreachable"));
+
+    const res = await GET(cronRequest());
+    expect(res.status).toBe(200); // per-member catch keeps the sweep alive
+
+    expect(h.store.get(MARKER_KEY)).toEqual(marker);
+    expect(h.zset.has(MEMBER)).toBe(true);
+    expect(rlogEvents()).toContain("recovery_sweep_member_failed");
+    expect(rlogEvents()).not.toContain("recovery_sweep_gave_up");
+  });
+});
+
+describe("retry path", () => {
+  it("leaves the OLD marker + index intact when the already-answered check fails after a won claim", async () => {
+    const marker = seedStaleMarker({ attempt: 0 });
+    h.fetchThreadMessages.mockRejectedValueOnce(new Error("slack_unreachable"));
+
+    await GET(cronRequest());
+
+    expect(h.store.get(MARKER_KEY)).toEqual(marker);
+    expect(h.zset.has(MEMBER)).toBe(true);
+    expect(h.runMentionTurn).not.toHaveBeenCalled();
+    expect(rlogEvents()).toContain("recovery_sweep_member_failed");
+  });
+
+  it("replaces the old marker with the retry marker BEFORE dispatching the turn, then clears it", async () => {
+    seedStaleMarker({ attempt: 0 });
+
+    await GET(cronRequest());
+
+    // Crash-window invariant: the retry marker overwrites the SAME key,
+    // so at every instant EITHER the old or the new marker exists.
+    const markerWriteAt = h.calls.indexOf(`set:${MARKER_KEY}`);
+    const turnAt = h.calls.indexOf("runMentionTurn");
+    expect(markerWriteAt).toBeGreaterThanOrEqual(0);
+    expect(turnAt).toBeGreaterThan(markerWriteAt);
+    // No destructive del of the marker before the retry-marker write.
+    expect(h.calls.slice(0, markerWriteAt)).not.toContain(`del:${MARKER_KEY}`);
+
+    expect(rlogEvents()).toContain("recovery_sweep_retried");
+    // Turn completed → marker + index cleared by the finally.
+    expect(h.store.has(MARKER_KEY)).toBe(false);
+    expect(h.zset.has(MEMBER)).toBe(false);
+  });
+
+  it("clears the marker without retrying when the bot already answered after startedAt", async () => {
+    const marker = seedStaleMarker({ attempt: 0 });
+    h.fetchThreadMessages.mockResolvedValueOnce([
+      {
+        user: "B_BOT",
+        ts: String((marker.startedAt + 5_000) / 1000),
+        text: "Here is the answer.",
+      },
+    ]);
+
+    await GET(cronRequest());
+
+    expect(h.runMentionTurn).not.toHaveBeenCalled();
+    expect(rlogEvents()).toContain("recovery_sweep_already_answered");
+    expect(h.store.has(MARKER_KEY)).toBe(false);
+    expect(h.zset.has(MEMBER)).toBe(false);
+  });
+});

--- a/src/app/api/cron/sweep/route.ts
+++ b/src/app/api/cron/sweep/route.ts
@@ -1,0 +1,221 @@
+// ── Recovery sweep (#125) ─────────────────────────────────────────────
+// Vercel Cron entry point (see vercel.json — every 5 minutes). Walks
+// the processing:index zset, classifies each in-flight marker via
+// decideSweepAction, and:
+//
+//   wait    → live or recently started turn — skip.
+//   orphan  → index entry outlived its marker's 24h TTL — drop it.
+//   retry   → first-attempt turn whose invocation is provably dead
+//             (marker age > 15 min > route maxDuration): win the NX
+//             claim (losing racer skips), verify the thread wasn't
+//             already answered, then re-run the turn through the SAME
+//             turn-runner code path the webhook uses.
+//   give_up → the retry also died: post a visible failure notice so
+//             the user is never left with silence.
+//
+// Auth: Vercel Cron sends `Authorization: Bearer $CRON_SECRET`. Exact
+// match, fail closed (unset secret denies everything).
+
+import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { kv } from "@/lib/kv";
+import { createRequestLogger, flushLogs } from "@/lib/logger";
+import { fetchThreadMessages, getBotUserId, replyInThread } from "@/lib/slack";
+import { THINKING_HEADER } from "@/lib/progress";
+import {
+  processingMarkerKey,
+  parseIndexMember,
+  decideSweepAction,
+  buildRetryMarker,
+  isAuthorizedCronRequest,
+  acquireSweepClaim,
+  writeProcessingMarker,
+  clearProcessingMarker,
+  PROCESSING_INDEX_KEY,
+  type ProcessingMarker,
+} from "@/lib/recovery";
+import { runMentionTurn, runFollowupTurn } from "@/lib/turn-runner";
+
+// A retried turn is a full agent run — give the sweep the same budget
+// as the Slack route.
+export const maxDuration = 300;
+
+/**
+ * Already-answered guard: true when the bot posted a REAL message in
+ * the thread after the marker was written. Excludes leftover thinking
+ * messages — a turn that died mid-run leaves its "Thinking…" message
+ * behind (the finally that deletes it never ran), and counting it
+ * would suppress every legitimate retry.
+ */
+function hasBotAnswerAfter(
+  messages: { user?: string; text?: string; ts?: string }[],
+  botId: string | undefined,
+  startedAtMs: number,
+): boolean {
+  if (!botId) return false;
+  return messages.some(
+    (m) =>
+      m.user === botId &&
+      m.ts !== undefined &&
+      parseFloat(m.ts) * 1000 > startedAtMs &&
+      !(m.text ?? "").startsWith(THINKING_HEADER),
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const rlog = createRequestLogger();
+
+  if (
+    !isAuthorizedCronRequest(
+      request.headers.get("authorization"),
+      process.env.CRON_SECRET,
+    )
+  ) {
+    rlog("recovery_sweep_unauthorized");
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  let scanned = 0;
+  let retried = 0;
+  let gaveUp = 0;
+  let orphaned = 0;
+
+  try {
+    const members = (await kv.zrange(PROCESSING_INDEX_KEY, 0, -1)) as string[];
+    const now = Date.now();
+
+    for (const member of members) {
+      scanned++;
+      try {
+        const parsed = parseIndexMember(member);
+        if (!parsed) {
+          await kv.zrem(PROCESSING_INDEX_KEY, member);
+          rlog("recovery_marker_orphaned", { member: member.slice(0, 40), reason: "malformed" });
+          orphaned++;
+          continue;
+        }
+        const { channel, threadTs } = parsed;
+        const marker = await kv.get<ProcessingMarker>(
+          processingMarkerKey(channel, threadTs),
+        );
+        const action = decideSweepAction(marker, now);
+
+        if (action === "wait") continue;
+
+        if (action === "orphan") {
+          await kv.zrem(PROCESSING_INDEX_KEY, member);
+          rlog("recovery_marker_orphaned", { channel, threadTs });
+          orphaned++;
+          continue;
+        }
+
+        // retry / give_up require winning a NON-DESTRUCTIVE claim:
+        // SET NX on processing:claim:<channel>:<threadTs> (short TTL).
+        // A concurrently running sweep (Hobby-plan cadence drift,
+        // manual trigger) loses NX and skips. Unlike the previous
+        // del-claim, the marker survives any failure past this point —
+        // a throw below leaves marker + index intact for the next
+        // sweep (after the claim TTL expires) to retry the decision.
+        const claimed = await acquireSweepClaim(channel, threadTs, rlog.requestId);
+        if (!claimed) {
+          rlog("recovery_sweep_claim_lost", { channel, threadTs });
+          continue;
+        }
+
+        if (action === "give_up") {
+          // Notice FIRST, cleanup AFTER — if Slack fails here the
+          // marker + index survive and the next sweep re-attempts the
+          // notice instead of silently losing the turn.
+          await replyInThread(
+            channel,
+            threadTs,
+            "I hit an error processing your question — please re-ask.",
+          );
+          await clearProcessingMarker(channel, threadTs);
+          rlog("recovery_sweep_gave_up", {
+            channel,
+            threadTs,
+            attempt: marker!.attempt,
+            requestId: marker!.requestId,
+          });
+          gaveUp++;
+          continue;
+        }
+
+        // action === "retry": guard against a turn that actually
+        // finished but died between posting the answer and clearing
+        // its marker — retrying would double-answer.
+        const botId = await getBotUserId();
+        const threadMsgs = await fetchThreadMessages(channel, threadTs);
+        if (hasBotAnswerAfter(threadMsgs, botId, marker!.startedAt)) {
+          await clearProcessingMarker(channel, threadTs);
+          rlog("recovery_sweep_already_answered", { channel, threadTs });
+          continue;
+        }
+
+        // The retry marker OVERWRITES the same marker key — at every
+        // instant either the old or the new marker exists, never
+        // neither, so a crash anywhere on this path stays sweepable.
+        const retryMarker = buildRetryMarker(marker!, now);
+        await writeProcessingMarker(retryMarker);
+        rlog("recovery_sweep_retried", {
+          channel,
+          threadTs,
+          eventType: retryMarker.eventType,
+          attempt: retryMarker.attempt,
+          originalRequestId: retryMarker.requestId,
+        });
+        retried++;
+
+        try {
+          if (retryMarker.eventType === "app_mention") {
+            await runMentionTurn({
+              channel,
+              threadTs,
+              user: retryMarker.user,
+              text: retryMarker.text,
+              inThread: true,
+              rlog,
+            });
+          } else {
+            await runFollowupTurn({
+              channel,
+              threadTs,
+              user: retryMarker.user,
+              text: retryMarker.text,
+              rlog,
+            });
+          }
+        } finally {
+          // Mirrors the webhook route's finally: handled errors clear
+          // the retry marker; only container death leaves it — and the
+          // next sweep sees attempt 1 and gives up visibly.
+          await clearProcessingMarker(channel, threadTs);
+        }
+      } catch (err) {
+        // One bad member must not abort the rest of the sweep — and
+        // because the claim above is non-destructive, a failure here
+        // leaves marker + index recoverable BY DESIGN: the next sweep
+        // (after the claim TTL) retries the decision.
+        rlog("recovery_sweep_member_failed", {
+          member: member.slice(0, 60),
+          errorMessage: err instanceof Error ? err.message.slice(0, 200) : String(err),
+        });
+        Sentry.captureException(err, { tags: { flow: "cron_sweep" } });
+      }
+    }
+
+    rlog("recovery_sweep_complete", { scanned, retried, gaveUp, orphaned });
+    return NextResponse.json({ ok: true, scanned, retried, gaveUp, orphaned });
+  } catch (err) {
+    rlog("recovery_sweep_failed", {
+      errorMessage: err instanceof Error ? err.message.slice(0, 200) : String(err),
+    });
+    Sentry.captureException(err, { tags: { flow: "cron_sweep" } });
+    return NextResponse.json({ ok: false }, { status: 500 });
+  } finally {
+    // Same tail-drop rule as every after() body (#98): explicitly drain
+    // the Sentry buffer before the container freezes.
+    await flushLogs(rlog, "cron_sweep");
+  }
+}

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -6,203 +6,33 @@ import {
   replyInThread,
   fetchMessage,
   getBotUserId,
-  fetchThreadMessages,
-  updateMessage,
-  deleteMessage,
-  postReplyInChunks,
 } from "@/lib/slack";
-import { runAgent } from "@/lib/claude";
 import { createIssue } from "@/lib/github";
-import { parseProposalFromMessage, type IssueProposal } from "@/tools/create-issue";
-import {
-  formatBatchProposalMessage,
-  isBulkConfirmText,
-  summarizeBatchResult,
-  type BatchCreationOutcome,
-} from "@/lib/issue-batch";
-import { storeQAContext, getQAContext, saveFeedback, deriveReferenceTypes } from "@/lib/feedback";
-import { formatReferences, rankReferences } from "@/lib/references";
+import { executeIdempotent, issueIdempotencyKey } from "@/lib/idempotency";
+import { parseProposalFromMessage } from "@/tools/create-issue";
+import { getQAContext, saveFeedback } from "@/lib/feedback";
 import { getAllKnowledge } from "@/lib/knowledge";
 import { buildCorrectionActions } from "@/lib/auto-correct";
-import { toSlackMrkdwn } from "@/lib/mrkdwn";
-import { buildThinkingMessage, THINKING_HEADER } from "@/lib/progress";
-import { createThrottledUpdater } from "@/lib/slack-throttle";
-import { formatReplyFooter, isReplyFooterEnabled } from "@/lib/reply-footer";
+import { createRequestLogger, flushLogs } from "@/lib/logger";
+import { isAddressedToOtherUser } from "@/lib/thread-filter";
 import {
-  extractParticipantIds,
-  resolveParticipants,
-  type Participant,
-} from "@/lib/slack-users";
-import { createRequestLogger, flushLogs, type RequestLogger } from "@/lib/logger";
-import { getCachedTopics } from "@/lib/repo-index";
-import { matchTopicsToQuestion, buildQuestionHints } from "@/lib/topic-match";
+  writeProcessingMarker,
+  clearProcessingMarker,
+} from "@/lib/recovery";
 import {
-  isAddressedToOtherUser,
-  buildConversationHistory,
-  extractTranscriptTail,
-} from "@/lib/thread-filter";
-import {
-  classifyTurn,
-  decideEffort,
-  evaluateFollowup,
-  buildEffortHint,
-  EFFORT_BUDGETS,
-} from "@/lib/effort-routing";
+  runMentionTurn,
+  runFollowupTurn,
+  executeBatchCreation,
+  batchTombstoneKey,
+  type PendingCorrection,
+} from "@/lib/turn-runner";
 
-// Shape of the pending-correction record stored under
-// `pending-correction:{channel}:{threadTs}` when a user reacts 👎.
-// Read by the thread-followup handler on the user's next message to
-// save their correction to the KB. @upstash/redis auto-stringifies
-// this on set and auto-parses on get.
-interface PendingCorrection {
-  question: string;
-  references: string[];
-  flaggedKB: string[];
-  pendingAt: number;
-  answerTs: string;
-}
-
-// Shape of the pending-issue-batch record stored after the bot posts a
-// proposal message. Indexed by the proposal message's first TS. See #122.
-interface PendingIssueBatch {
-  proposals: IssueProposal[];
-  proposedAt: number;
-  requestedBy: string; // Slack user ID of the requester
-  threadTs: string;
-  messageFirstTs: string; // ts of the first chunk of the proposal message
-}
-
-const BATCH_KEY_PREFIX = "pending-issue-batch";
-const BATCH_TTL_SEC = 86400; // 24h — stale batches fall off naturally
-// Tombstone TTL: long enough to cover any plausible double-tap ✅ window
-// on a single-proposal message whose body still matches the legacy parser.
-// See PR #123 CodeRabbit finding — without this, a second reaction finds
-// the canonical record deleted, falls to parseProposalFromMessage, and
-// re-creates the issue.
-const BATCH_TOMBSTONE_TTL_SEC = 3600;
-
-function batchKey(channel: string, firstTs: string): string {
-  return `${BATCH_KEY_PREFIX}:${channel}:${firstTs}`;
-}
-function batchThreadPointerKey(channel: string, threadTs: string): string {
-  return `${BATCH_KEY_PREFIX}:thread:${channel}:${threadTs}`;
-}
-function batchTombstoneKey(channel: string, firstTs: string): string {
-  return `${BATCH_KEY_PREFIX}:done:${channel}:${firstTs}`;
-}
-
-/**
- * Atomically claim and execute a pending issue batch.
- *
- * Concurrency: the claim uses `kv.del` on the canonical key — Redis
- * DEL is atomic, so only the first caller sees `deleted === 1`. Any
- * racing handler (a second reaction, or a racing text command) sees
- * `0` and aborts without firing GitHub writes.
- *
- * Per-issue failures do not abort the rest: we use Promise.allSettled
- * and surface both creates and errors in the final summary.
- */
-async function executeBatchCreation(
-  channel: string,
-  threadTs: string,
-  firstTs: string,
-  confirmingUser: string,
-  confirmVia: "reaction" | "text",
-  rlog: RequestLogger,
-): Promise<{ claimed: boolean }> {
-  const { kv } = await import("@/lib/kv");
-  const primaryKey = batchKey(channel, firstTs);
-
-  // Read the batch before claiming so we have the data to create issues
-  // if we win the del race.
-  const batch = await kv.get<PendingIssueBatch>(primaryKey);
-  if (!batch) {
-    return { claimed: false };
-  }
-
-  const deleted = await kv.del(primaryKey);
-  if (deleted === 0) {
-    // Another handler won the race between get and del.
-    rlog("issue_batch_claim_lost", { channel, firstTs, confirmVia });
-    return { claimed: false };
-  }
-
-  // Tombstone the claim so a second ✅ on the same message can't fall
-  // through to the legacy parser and re-create the issue. The legacy
-  // fallback checks this before parsing message text. 1h is enough for
-  // any plausible double-tap; long-lived record stays under the canonical
-  // 24h TTL of the original batch.
-  try {
-    await kv.set(batchTombstoneKey(channel, firstTs), 1, {
-      ex: BATCH_TOMBSTONE_TTL_SEC,
-    });
-  } catch {
-    // Non-fatal; Sentry already captured via the kv wrapper. Worst case
-    // a racing second reaction takes the legacy path.
-  }
-
-  // Best-effort cleanup of the thread pointer. We don't care if it was
-  // already removed — TTL would catch it anyway.
-  try {
-    await kv.del(batchThreadPointerKey(channel, threadTs));
-  } catch {
-    // Non-fatal; Sentry already captured via the kv wrapper.
-  }
-
-  rlog("issue_batch_confirmed", {
-    count: batch.proposals.length,
-    confirmVia,
-    confirmingUser,
-    requestedBy: batch.requestedBy,
-    latencyMs: Date.now() - batch.proposedAt,
-    channel,
-    threadTs,
-  });
-
-  const createStart = Date.now();
-  const settled = await Promise.allSettled(
-    batch.proposals.map((p) => createIssue(p.title, p.body, p.labels)),
-  );
-
-  const outcomes: BatchCreationOutcome[] = settled.map((res, i) => {
-    const proposal = batch.proposals[i];
-    if (res.status === "fulfilled") {
-      return { status: "success", proposal, issue: res.value };
-    }
-    const errorMessage =
-      res.reason instanceof Error ? res.reason.message : String(res.reason);
-    // Per-issue Sentry capture so a rate-limit spike on one title doesn't
-    // hide under the summary event. Tagged for dashboard filtering.
-    Sentry.captureException(res.reason, {
-      tags: { flow: "issue_create", batchSize: String(batch.proposals.length) },
-      extra: { proposalTitle: proposal.title },
-    });
-    rlog("issue_create_error", {
-      title: proposal.title,
-      errorClass:
-        res.reason instanceof Error ? res.reason.constructor.name : "Unknown",
-      errorMessage: errorMessage.slice(0, 200),
-    });
-    return { status: "error", proposal, errorMessage };
-  });
-
-  const successCount = outcomes.filter((o) => o.status === "success").length;
-  const failureCount = outcomes.length - successCount;
-  rlog("issue_batch_created", {
-    totalCount: outcomes.length,
-    successCount,
-    failureCount,
-    durationMs: Date.now() - createStart,
-    numbers: outcomes
-      .filter((o) => o.status === "success")
-      .map((o) => (o as Extract<BatchCreationOutcome, { status: "success" }>).issue.number),
-    channel,
-    threadTs,
-  });
-
-  await replyInThread(channel, threadTs, summarizeBatchResult(outcomes));
-  return { claimed: true };
-}
+// Give the after() bodies the full Fluid-compute budget. Next.js reads
+// this statically, so it must be a literal — SLACK_ROUTE_MAX_DURATION_SEC
+// in src/lib/recovery.ts mirrors it and the recovery tests pin the
+// invariant PROCESSING_MAX_AGE_MS > maxDuration (a marker older than
+// max-age cannot belong to a live invocation). Keep the two in sync.
+export const maxDuration = 300;
 
 /**
  * Slack Events API webhook handler.
@@ -213,6 +43,15 @@ async function executeBatchCreation(
  *
  * Slack requires a 200 OK within 3 seconds. We ack immediately
  * and process the AI + GitHub calls asynchronously via after().
+ *
+ * Recovery (#125): the FIRST step of each after() body persists a
+ * ProcessingMarker; the after() finally clears it. A finally covers
+ * every handled error path — only container death leaves a marker
+ * behind, and the cron sweep (/api/cron/sweep) retries exactly that
+ * set via the same turn-runner code path. The write lives INSIDE
+ * after(), never on the ack path: two KV round-trips before the 200 OK
+ * could breach Slack's 3-second deadline under KV slowness, triggering
+ * Slack retries and duplicate processing (PR #133 review).
  */
 export async function POST(request: NextRequest) {
   const rlog = createRequestLogger();
@@ -260,205 +99,34 @@ export async function POST(request: NextRequest) {
     // reach Vercel's log drain — see #90. Every after() block below ends
     // with `await flushLogs(rlog, "<flow>")` inside its finally clause.
     after(async () => {
-      // Hoist thinkingTs so finally can always clean it up
-      let thinkingTs: string | undefined;
       try {
-        // Post thinking message and capture its ts for live updates
-        thinkingTs = await replyInThread(
-          channel, threadTs,
-          THINKING_HEADER,
-        );
-
-        const cleanMessage = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
-
-        // Thread participants for #80: resolve user IDs to display names
-        // so the agent can @-mention correctly. Populated for BOTH fresh
-        // mentions (participants = invoking user + anyone they mentioned)
-        // and thread follow-ups (all thread authors + anyone mentioned).
-        let mentionHistory: { role: "user" | "assistant"; content: string }[] | undefined;
-        let mentionParticipants: Participant[] | undefined;
-        // Recent-thread tail for the effort classifier — empty for fresh
-        // top-level mentions (the question alone is enough to bucket).
-        let mentionTranscript = "";
-        const botId = await getBotUserId();
-        if (event.thread_ts) {
-          const threadMsgs = await fetchThreadMessages(channel, threadTs);
-          if (botId) {
-            mentionHistory = buildConversationHistory(threadMsgs, botId);
-          }
-          mentionTranscript = extractTranscriptTail(threadMsgs, botId ?? "");
-          const ids = extractParticipantIds(threadMsgs, botId);
-          if (ids.length > 0) {
-            mentionParticipants = await resolveParticipants(ids);
-          }
-        } else {
-          // Fresh top-level mention — the only participant signal is the
-          // invoking user + anyone they mentioned in the message body.
-          const ids = extractParticipantIds(
-            [{ user: event.user, text: userMessage }],
-            botId,
-          );
-          if (ids.length > 0) {
-            mentionParticipants = await resolveParticipants(ids);
-          }
-        }
-
-        // Pre-match question against topic index for concrete file hints.
-        // The effort classifier (#126) runs in parallel — on the mention
-        // path shouldReply is NEVER consulted (the user explicitly invoked
-        // the bot); the classifier only buckets the question so the agent
-        // gets a right-sized round budget and answer target.
-        const [topics, mentionClassification] = await Promise.all([
-          getCachedTopics(),
-          classifyTurn(
-            { invocation: "mention", transcript: mentionTranscript, question: cleanMessage },
-            { log: rlog },
-          ),
-        ]);
-        const mentionEffort = decideEffort(mentionClassification);
-        const topicMatches = matchTopicsToQuestion(cleanMessage, topics);
-        const augmentedMessage =
-          buildQuestionHints(cleanMessage, topicMatches) + buildEffortHint(mentionEffort);
-        if (topicMatches.length > 0) {
-          rlog("topic_hints_injected", { topics: topicMatches.map((m) => m.topic), fileCount: topicMatches.reduce((s, m) => s + m.paths.length, 0) });
-        }
-
-        // Tool-progress updater. Per #110 review: the streaming flood
-        // from #109 was character-level text deltas, NOT tool-progress
-        // messages. Tool progress at ~1 call per tool round (debounced
-        // to coalesce parallel bursts) is 5-7 calls per turn — well
-        // under Slack's 30/min Tier 2 limit and genuinely informative
-        // for the user. Re-introducing it WITHOUT streaming.
-        const progressThrottle = createThrottledUpdater(async (text) => {
-          if (thinkingTs) {
-            await updateMessage(channel, thinkingTs, text);
-          }
-        }, 1200);
-
-        const result = await runAgent(
-          augmentedMessage,
-          mentionHistory,
-          rlog,
-          mentionParticipants,
-          (toolName, input) => {
-            progressThrottle.update(buildThinkingMessage(toolName, input));
-          },
-          { maxRounds: EFFORT_BUDGETS[mentionEffort].maxRounds, effort: mentionEffort },
-        );
-        // Drain any pending progress update before the final write so a
-        // stale progress message can't land on top of the final answer.
-        await progressThrottle.flush();
-        // `agent_complete` is already emitted by runAgent with rounds,
-        // token usage, and cache metrics — don't duplicate at route level.
-
-        const text = toSlackMrkdwn(result.text);
-        const rankedRefs = rankReferences(result.references, result.text);
-        const refsFooter = formatReferences(rankedRefs);
-        // Optional compact telemetry footer (#79). Disabled by default;
-        // enable with BM_REPLY_FOOTER=1 in the Vercel env.
-        const replyFooter = isReplyFooterEnabled(process.env)
-          ? formatReplyFooter(result.metrics, rlog.requestId)
-          : "";
-
-        if (result.issueProposals.length > 0) {
-          const proposals = result.issueProposals;
-          const proposalBlock = formatBatchProposalMessage(proposals);
-          const finalBody = [text, "", proposalBlock].join("\n") + refsFooter + replyFooter;
-
-          const posted = await postReplyInChunks({
-            channel,
-            threadTs,
-            thinkingTs,
-            text: finalBody,
-          });
-          // Only mark as finalized when we actually posted. A 0-chunk
-          // result (empty body) falls through to the finally cleanup.
-          if (posted.chunks > 0) thinkingTs = undefined;
-
-          // Persist the batch so confirmation (reaction OR thread text)
-          // can create without re-parsing Slack message text. Key is the
-          // first chunk's ts; thread pointer enables "confirm all" text.
-          if (posted.firstTs) {
-            const { kv } = await import("@/lib/kv");
-            const record: PendingIssueBatch = {
-              proposals,
-              proposedAt: Date.now(),
-              requestedBy: event.user,
-              threadTs,
-              messageFirstTs: posted.firstTs,
-            };
-            await kv.set(batchKey(channel, posted.firstTs), record, { ex: BATCH_TTL_SEC });
-            await kv.set(
-              batchThreadPointerKey(channel, threadTs),
-              posted.firstTs,
-              { ex: BATCH_TTL_SEC },
-            );
-            rlog("issue_batch_proposed", {
-              count: proposals.length,
-              threadTs,
-              channel,
-              firstTs: posted.firstTs,
-              sampleTitles: proposals.slice(0, 3).map((p) => p.title.slice(0, 80)),
-              requestingUser: event.user,
-            });
-          }
-          rlog("answer_posted", {
-            channel,
-            threadTs,
-            chunks: posted.chunks,
-            kind: "proposal",
-            proposalCount: proposals.length,
-          });
-        } else {
-          const finalBody = text + refsFooter + replyFooter;
-          const posted = await postReplyInChunks({
-            channel,
-            threadTs,
-            thinkingTs,
-            text: finalBody,
-          });
-          if (posted.chunks > 0) thinkingTs = undefined;
-          rlog("answer_posted", { channel, threadTs, chunks: posted.chunks });
-
-          // Store Q&A context for EVERY chunk ts (see #114). Reactions
-          // on any chunk resolve to the same question/answer pair.
-          if (posted.firstTs && posted.allTs.length > 0) {
-            const postedAt = Date.now();
-            const referenceTypes = deriveReferenceTypes(result.references);
-            await Promise.all(
-              posted.allTs.map((ts, chunkIndex) =>
-                storeQAContext(channel, ts, {
-                  question: cleanMessage,
-                  answer: result.text.slice(0, 500),
-                  references: result.references.map((r) => r.label),
-                  answerTs: posted.firstTs!,
-                  chunkIndex,
-                  chunkCount: posted.chunks,
-                  postedAt,
-                  referenceTypes,
-                }),
-              ),
-            );
-          }
-        }
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : "Unknown error";
-        rlog("error", { flow: "mention", message: msg });
-        // Also capture as a Sentry Issue so the stack trace surfaces
-        // in the dashboard — `rlog` alone produces a Log entry without
-        // a stack, which is how #100 stayed a mystery (we knew the
-        // error message but not what line in the after() body threw it).
-        Sentry.captureException(err, { tags: { flow: "mention" } });
-        await replyInThread(
+        // Recovery marker (#125): written best-effort as the FIRST step
+        // of the async body — kept off the ack path so KV latency can
+        // never push the 200 OK past Slack's 3-second deadline (PR #133
+        // review). Accepted trade: a container death in the tiny window
+        // between the ack and this write loses recovery for that turn.
+        await writeProcessingMarker({
+          eventType: "app_mention",
           channel,
           threadTs,
-          `Something went wrong while processing your request. Error: ${msg}`,
-        );
+          user: event.user,
+          text: userMessage,
+          startedAt: Date.now(),
+          attempt: 0,
+          requestId: rlog.requestId,
+        });
+        await runMentionTurn({
+          channel,
+          threadTs,
+          user: event.user,
+          text: userMessage,
+          inThread: !!event.thread_ts,
+          rlog,
+        });
       } finally {
-        // Safety net: delete thinking message if it wasn't cleaned up
-        if (thinkingTs) {
-          await deleteMessage(channel, thinkingTs);
-        }
+        // Handled errors reach here too — only container death skips
+        // this clear, which is exactly the set the sweep recovers.
+        await clearProcessingMarker(channel, threadTs);
         // Yield so Vercel captures the after() block's logs — see #90.
         await flushLogs(rlog, "mention");
       }
@@ -492,281 +160,29 @@ export async function POST(request: NextRequest) {
     rlog("thread_followup_start", { channel, threadTs, user: event.user, question: userMessage.slice(0, 100) });
 
     after(async () => {
-      let thinkTs: string | undefined;
       try {
-        // Check for pending correction (from a 👎 reaction)
-        const { kv } = await import("@/lib/kv");
-        const pendingKey = `pending-correction:${channel}:${threadTs}`;
-        const pending = await kv.get<PendingCorrection>(pendingKey);
-        if (pending) {
-          // This reply is a correction — save directly to KB
-          const { saveKnowledgeEntry, markKnowledgeSuperseded } = await import(
-            "@/lib/knowledge"
-          );
-
-          // Strip @-mentions and trim, matching the normalization used
-          // for questions, so raw Slack tokens don't end up in the KB.
-          const correctionText = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
-          const correctionId = await saveKnowledgeEntry(correctionText);
-
-          // Clear the pending state as soon as the correction is durably
-          // saved — everything after this point is best-effort. If a later
-          // step throws, the error reply must NOT leave pending state
-          // behind, or the user's re-reply would save a duplicate entry.
-          await kv.del(pendingKey);
-
-          // Retire the KB entries flagged at 👎 time: mark them superseded
-          // by the correction instead of leaving them visible (or deleting
-          // them and losing history). Text-matched; entries already
-          // superseded or archived in the meantime are skipped. See #124.
-          let supersededCount = 0;
-          try {
-            for (const flaggedText of pending.flaggedKB) {
-              if (await markKnowledgeSuperseded(flaggedText, correctionId)) {
-                supersededCount++;
-              }
-            }
-          } catch (err) {
-            // Correction is saved; a KV flake while retiring old entries
-            // must not fail the flow. Worst case a stale entry stays
-            // visible — observable via the count on correction_saved.
-            rlog("correction_supersede_error", {
-              channel,
-              threadTs,
-              message: err instanceof Error ? err.message : String(err),
-            });
-          }
-
-          // Save the negative feedback NOW with the actual correction text
-          await saveFeedback({
-            type: "negative",
-            question: pending.question || "",
-            detail: `Correction: "${correctionText.slice(0, 200)}"`,
-            timestamp: new Date().toISOString().split("T")[0],
-          });
-          // Close the 👎 → correction funnel with latency from the
-          // moment 👎 was registered.
-          rlog("correction_saved", {
-            channel,
-            threadTs,
-            answerTs: pending.answerTs ?? null,
-            correctionLength: correctionText.length,
-            timeSincePendingMs: Date.now() - pending.pendingAt,
-            flaggedKBCount: pending.flaggedKB.length,
-            supersededCount,
-            correctionSample: correctionText.slice(0, 100),
-          });
-
-          await replyInThread(
-            channel,
-            threadTs,
-            `:white_check_mark: Saved to knowledge base: _"${correctionText.slice(0, 100)}"_`,
-          );
-          return;
-        }
-
-        // ── Bulk-confirm interception (#122) ────────────────────────────
-        // If there's a pending issue batch in this thread AND the user's
-        // reply is a bulk-confirm phrase ("confirm all", "yes", etc.),
-        // create all issues instead of running the agent. `isBulkConfirmText`
-        // is strict (short intent-only phrases) so normal conversation is
-        // unaffected.
-        if (isBulkConfirmText(userMessage)) {
-          const pointerKey = batchThreadPointerKey(channel, threadTs);
-          const batchFirstTs = await kv.get<string>(pointerKey);
-          if (batchFirstTs) {
-            const outcome = await executeBatchCreation(
-              channel,
-              threadTs,
-              batchFirstTs,
-              event.user,
-              "text",
-              rlog,
-            );
-            if (outcome.claimed) return;
-            // Not claimed → either the batch expired or another handler
-            // consumed it. Fall through to the normal agent flow so the
-            // user still gets a response.
-          }
-        }
-
-        // Fetch thread messages — used for both participation check and context
-        const bid = botId || (await getBotUserId());
-        const threadMessages = await fetchThreadMessages(channel, threadTs);
-        const botInThread = bid ? threadMessages.some((m) => m.user === bid) : false;
-        if (!bid || !botInThread) return;
-
-        const cleanMessage = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
-
-        // Follow-up gate (#126): the structural heuristic above only says
-        // "maybe" — ask the fast-model classifier whether this message is
-        // actually addressed to the bot. Fail-closed: any classifier
-        // error/timeout/low-confidence verdict means we stay silent. Runs
-        // BEFORE the thinking message so a decline produces ZERO Slack
-        // writes — just the log event below.
-        const followupEval = await evaluateFollowup(
-          {
-            invocation: "followup",
-            transcript: extractTranscriptTail(threadMessages, bid),
-            question: cleanMessage,
-          },
-          { log: rlog },
-        );
-        if (!followupEval.proceed) {
-          rlog("followup_reply_declined", {
-            reason:
-              followupEval.decision === null
-                ? "classifier_unavailable"
-                : followupEval.decision.shouldReply
-                  ? "low_confidence"
-                  : "not_addressed",
-            confidence: followupEval.decision?.shouldReplyConfidence ?? null,
-            channel,
-            threadTs,
-          });
-          return;
-        }
-        rlog("followup_agent_start", { channel, threadTs });
-
-        thinkTs = await replyInThread(
-          channel, threadTs,
-          THINKING_HEADER,
-        );
-
-        // Build proper multi-turn conversation history from thread
-        // (uses Anthropic's native message format, not string hacking)
-        const history = buildConversationHistory(threadMessages, bid);
-
-        // Thread participants for #80 — resolve IDs now so the agent can
-        // @-mention teammates in its answer.
-        const followupParticipantIds = extractParticipantIds(threadMessages, bid);
-        const followupParticipants = followupParticipantIds.length > 0
-          ? await resolveParticipants(followupParticipantIds)
-          : undefined;
-
-        // Pre-match for thread follow-ups too; the effort hint from the
-        // classifier rides along on the user message (never the system
-        // prompt — see effort-routing.ts on prompt caching).
-        const followupTopics = await getCachedTopics();
-        const followupMatches = matchTopicsToQuestion(cleanMessage, followupTopics);
-        const followupMessage =
-          buildQuestionHints(cleanMessage, followupMatches) + buildEffortHint(followupEval.effort);
-
-        // Mirror of the mention-flow progress updater — see comment
-        // there + #110 for rationale.
-        const followupProgress = createThrottledUpdater(async (text) => {
-          if (thinkTs) {
-            await updateMessage(channel, thinkTs, text);
-          }
-        }, 1200);
-
-        const result = await runAgent(
-          followupMessage,
-          history,
-          rlog,
-          followupParticipants,
-          (toolName, input) => {
-            followupProgress.update(buildThinkingMessage(toolName, input));
-          },
-          { maxRounds: EFFORT_BUDGETS[followupEval.effort].maxRounds, effort: followupEval.effort },
-        );
-        await followupProgress.flush();
-
-        const text = toSlackMrkdwn(result.text);
-        const rankedRefs = rankReferences(result.references, result.text);
-        const refsFooter = formatReferences(rankedRefs);
-        // Optional compact telemetry footer (#79) — mirrors the mention flow.
-        const replyFooter = isReplyFooterEnabled(process.env)
-          ? formatReplyFooter(result.metrics, rlog.requestId)
-          : "";
-
-        if (result.issueProposals.length > 0) {
-          const proposals = result.issueProposals;
-          const proposalBlock = formatBatchProposalMessage(proposals);
-          const finalBody = [text, "", proposalBlock].join("\n") + refsFooter + replyFooter;
-
-          const posted = await postReplyInChunks({
-            channel,
-            threadTs,
-            thinkingTs: thinkTs,
-            text: finalBody,
-          });
-          if (posted.chunks > 0) thinkTs = undefined;
-
-          if (posted.firstTs) {
-            const record: PendingIssueBatch = {
-              proposals,
-              proposedAt: Date.now(),
-              requestedBy: event.user,
-              threadTs,
-              messageFirstTs: posted.firstTs,
-            };
-            await kv.set(batchKey(channel, posted.firstTs), record, { ex: BATCH_TTL_SEC });
-            await kv.set(
-              batchThreadPointerKey(channel, threadTs),
-              posted.firstTs,
-              { ex: BATCH_TTL_SEC },
-            );
-            rlog("issue_batch_proposed", {
-              count: proposals.length,
-              threadTs,
-              channel,
-              firstTs: posted.firstTs,
-              sampleTitles: proposals.slice(0, 3).map((p) => p.title.slice(0, 80)),
-              requestingUser: event.user,
-            });
-          }
-          rlog("answer_posted", {
-            channel,
-            threadTs,
-            chunks: posted.chunks,
-            kind: "proposal",
-            proposalCount: proposals.length,
-          });
-        } else {
-          const finalBody = text + refsFooter + replyFooter;
-          const posted = await postReplyInChunks({
-            channel,
-            threadTs,
-            thinkingTs: thinkTs,
-            text: finalBody,
-          });
-          if (posted.chunks > 0) thinkTs = undefined;
-          rlog("answer_posted", { channel, threadTs, chunks: posted.chunks });
-
-          if (posted.firstTs && posted.allTs.length > 0) {
-            const postedAt = Date.now();
-            const referenceTypes = deriveReferenceTypes(result.references);
-            await Promise.all(
-              posted.allTs.map((ts, chunkIndex) =>
-                storeQAContext(channel, ts, {
-                  question: cleanMessage,
-                  answer: result.text.slice(0, 500),
-                  references: result.references.map((r) => r.label),
-                  answerTs: posted.firstTs!,
-                  chunkIndex,
-                  chunkCount: posted.chunks,
-                  postedAt,
-                  referenceTypes,
-                }),
-              ),
-            );
-          }
-        }
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : "Unknown error";
-        rlog("error", { flow: "thread_followup", message: msg });
-        Sentry.captureException(err, { tags: { flow: "thread_followup" } });
-        await replyInThread(
+        // Recovery marker (#125) — mirrors the mention flow: first step
+        // inside after(), off the ack path (PR #133 review).
+        await writeProcessingMarker({
+          eventType: "thread_followup",
           channel,
           threadTs,
-          `Something went wrong while processing your request. Error: ${msg}`,
-        );
+          user: event.user,
+          text: userMessage,
+          startedAt: Date.now(),
+          attempt: 0,
+          requestId: rlog.requestId,
+        });
+        await runFollowupTurn({
+          channel,
+          threadTs,
+          user: event.user,
+          text: userMessage,
+          botId,
+          rlog,
+        });
       } finally {
-        // Safety net: delete thinking message if it wasn't cleaned up
-        if (thinkTs) {
-          await deleteMessage(channel, thinkTs);
-        }
+        await clearProcessingMarker(channel, threadTs);
         await flushLogs(rlog, "thread_followup");
       }
     });
@@ -831,11 +247,26 @@ export async function POST(request: NextRequest) {
         const proposal = parseProposalFromMessage(msg.text);
         if (!proposal) return; // Not a proposal message — ignore
 
-        const issue = await createIssue(
-          proposal.title,
-          proposal.body,
-          proposal.labels,
+        // Idempotency guard (#125): a double-tap ✅ past the tombstone
+        // window, or a Slack event redelivery, re-reaches this parser.
+        // The content-addressed key (labels: undefined ≡ []) replays the
+        // recorded issue instead of creating a duplicate.
+        const idem = await executeIdempotent(
+          issueIdempotencyKey({
+            title: proposal.title,
+            body: proposal.body,
+            labels: proposal.labels,
+          }),
+          () => createIssue(proposal.title, proposal.body, proposal.labels),
+          rlog,
         );
+        if (idem.outcome === "in_flight") {
+          // A racing confirmation is creating this exact issue right
+          // now — it will post the success reply. Stay silent.
+          rlog("issue_create_in_flight", { via: "legacy_parser", channel, messageTs });
+          return;
+        }
+        const issue = idem.result;
         rlog("issue_created", { number: issue.number, via: "legacy_parser" });
         await replyInThread(
           channel,
@@ -844,7 +275,7 @@ export async function POST(request: NextRequest) {
         );
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : "Unknown error";
-        rlog("error", { flow: "reaction_checkmark", message: errMsg });
+        rlog("webhook_handler_failed", { flow: "reaction_checkmark", message: errMsg });
         Sentry.captureException(err, { tags: { flow: "reaction_checkmark" } });
         // Best-effort reply — use thread_ts if available
         try {
@@ -944,7 +375,7 @@ export async function POST(request: NextRequest) {
           rlog("feedback_ack_failed", { reason, chunkTs: messageTs, errMsg: errMsg.slice(0, 120) });
         }
       } catch (err) {
-        rlog("error", { flow: "reaction_thumbsup", message: err instanceof Error ? err.message : String(err) });
+        rlog("webhook_handler_failed", { flow: "reaction_thumbsup", message: err instanceof Error ? err.message : String(err) });
         Sentry.captureException(err, { tags: { flow: "reaction_thumbsup" } });
       } finally {
         await flushLogs(rlog, "reaction_thumbsup");
@@ -1064,7 +495,7 @@ export async function POST(request: NextRequest) {
           `:thinking_face: Thanks for the feedback.${flagText}\n\nWhat was wrong? Reply here and I'll save the correction.`,
         );
       } catch (err) {
-        rlog("error", { flow: "reaction_thumbsdown", message: err instanceof Error ? err.message : String(err) });
+        rlog("webhook_handler_failed", { flow: "reaction_thumbsdown", message: err instanceof Error ? err.message : String(err) });
         Sentry.captureException(err, { tags: { flow: "reaction_thumbsdown" } });
       } finally {
         await flushLogs(rlog, "reaction_thumbsdown");

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -524,11 +524,12 @@ export type ProgressCallback = (
 
 /**
  * Per-turn agent options from the effort classifier (#126). claude.ts
- * stays classifier-agnostic — the route resolves the effort bucket via
- * effort-routing.ts and passes only the resulting numbers/label here.
- * Answer-length steering is NOT in this file either: the route appends
- * buildEffortHint() to the user message so the stable system-prompt
- * zone stays byte-identical for prompt caching.
+ * stays classifier-agnostic — the turn runner resolves the effort
+ * bucket via effort-routing.ts and passes only the resulting
+ * numbers/label here. Answer-length steering is NOT in this file
+ * either: the turn runner appends buildEffortHint() to the user
+ * message so the stable system-prompt zone stays byte-identical for
+ * prompt caching.
  */
 export interface RunAgentOptions {
   /** Per-turn tool-round cap. Floored and clamped to [1, MAX_TOOL_ROUNDS]. */
@@ -886,10 +887,19 @@ export async function executeToolsInParallel(
         const result = await exec(block.name, block.input as Record<string, unknown>);
         return { block, result, error: null as string | null };
       } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        // Previously this catch was silent — the error only surfaced to
+        // the MODEL as a tool_result, never to telemetry. #125 makes
+        // tool-dispatch failures a first-class event.
+        ctx.log("tool_call_failed", {
+          tool: block.name,
+          round: ctx.round,
+          errorMessage: errorMessage.slice(0, 200),
+        });
         return {
           block,
           result: null as ToolResult | null,
-          error: err instanceof Error ? err.message : String(err),
+          error: errorMessage,
         };
       }
     }),

--- a/src/lib/idempotency.test.ts
+++ b/src/lib/idempotency.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { logSpy } = vi.hoisted(() => ({ logSpy: vi.fn() }));
+vi.mock("./logger", () => ({
+  log: (...args: unknown[]) => logSpy(...args),
+}));
+
+// In-memory fake of the kv wrapper with real SET-NX semantics and TTL
+// bookkeeping. Mirrors @upstash/redis: set returns "OK" on success and
+// null when the NX condition loses.
+const { store, ttls } = vi.hoisted(() => ({
+  store: new Map<string, unknown>(),
+  ttls: new Map<string, number>(),
+}));
+
+vi.mock("./kv", () => ({
+  kv: {
+    get: vi.fn(async (key: string) => (store.has(key) ? store.get(key) : null)),
+    set: vi.fn(
+      async (key: string, value: unknown, opts?: { ex?: number; nx?: boolean }) => {
+        if (opts?.nx && store.has(key)) return null;
+        store.set(key, value);
+        if (opts?.ex) ttls.set(key, opts.ex);
+        return "OK";
+      },
+    ),
+    del: vi.fn(async (key: string) => (store.delete(key) ? 1 : 0)),
+  },
+}));
+
+import { kv } from "./kv";
+import {
+  stableSerialize,
+  issueIdempotencyKey,
+  executeIdempotent,
+  LOCK_TTL_SEC,
+  COMPLETED_TTL_SEC,
+} from "./idempotency";
+
+const NOW = 1_750_000_000_000; // pinned clock — never Date.now() in assertions
+const KEY = "idem:issue:" + "a".repeat(64);
+const ISSUE = { number: 7, title: "Fix flaky retry", url: "https://github.com/o/r/issues/7" };
+
+beforeEach(() => {
+  store.clear();
+  ttls.clear();
+  logSpy.mockClear();
+  vi.mocked(kv.get).mockClear();
+  vi.mocked(kv.set).mockClear();
+  vi.mocked(kv.del).mockClear();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("TTL constants (pinned — acceptance criteria of #125)", () => {
+  it("lock TTL is exactly 60 seconds", () => {
+    expect(LOCK_TTL_SEC).toBe(60);
+  });
+
+  it("completed-record TTL is exactly 30 days", () => {
+    expect(COMPLETED_TTL_SEC).toBe(2_592_000);
+  });
+});
+
+describe("stableSerialize (pure)", () => {
+  it("is insensitive to object key insertion order", () => {
+    expect(stableSerialize({ b: 1, a: 2 })).toBe(stableSerialize({ a: 2, b: 1 }));
+    expect(stableSerialize({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+  });
+
+  it("sorts keys recursively in nested objects", () => {
+    expect(stableSerialize({ z: { b: 1, a: 2 } })).toBe('{"z":{"a":2,"b":1}}');
+  });
+
+  it("omits properties whose value is undefined", () => {
+    expect(stableSerialize({ a: 1, b: undefined })).toBe('{"a":1}');
+  });
+
+  it("preserves array element order (arrays are ordered, objects are not)", () => {
+    expect(stableSerialize([2, 1])).toBe("[2,1]");
+    expect(stableSerialize(["a", "b"])).not.toBe(stableSerialize(["b", "a"]));
+  });
+
+  it("passes primitives and null through as JSON", () => {
+    expect(stableSerialize("x")).toBe('"x"');
+    expect(stableSerialize(42)).toBe("42");
+    expect(stableSerialize(null)).toBe("null");
+  });
+});
+
+describe("issueIdempotencyKey (pure)", () => {
+  const input = { title: "Fix flaky retry", body: "Steps: ...", labels: ["bug", "p1"] };
+
+  it("produces idem:issue:<64-hex> format", () => {
+    expect(issueIdempotencyKey(input)).toMatch(/^idem:issue:[0-9a-f]{64}$/);
+  });
+
+  it("keyPrefix bucket for kv_op logs is 'idem' (no payload leakage)", () => {
+    expect(issueIdempotencyKey(input).split(":")[0]).toBe("idem");
+  });
+
+  it("is stable across property insertion order", () => {
+    const reordered = { labels: ["bug", "p1"], body: "Steps: ...", title: "Fix flaky retry" };
+    expect(issueIdempotencyKey(reordered)).toBe(issueIdempotencyKey(input));
+  });
+
+  it("changes when title, body, or labels change", () => {
+    const base = issueIdempotencyKey(input);
+    expect(issueIdempotencyKey({ ...input, title: "Other" })).not.toBe(base);
+    expect(issueIdempotencyKey({ ...input, body: "different" })).not.toBe(base);
+    expect(issueIdempotencyKey({ ...input, labels: ["bug"] })).not.toBe(base);
+  });
+
+  // The legacy parser yields labels: undefined while batch records may
+  // hold []. Both paths MUST hash identically or the legacy fallback
+  // (route.ts) escapes idempotency entirely.
+  it("treats labels: undefined and labels: [] as the same key", () => {
+    const withUndefined = issueIdempotencyKey({ title: "T", body: "B" });
+    const withEmpty = issueIdempotencyKey({ title: "T", body: "B", labels: [] });
+    expect(withUndefined).toBe(withEmpty);
+  });
+
+  it("is insensitive to label order (labels are a set on GitHub)", () => {
+    expect(issueIdempotencyKey({ ...input, labels: ["p1", "bug"] })).toBe(
+      issueIdempotencyKey(input),
+    );
+  });
+});
+
+describe("executeIdempotent — first execution", () => {
+  it("invokes fn exactly once and returns {outcome: created}", async () => {
+    const fn = vi.fn(async () => ISSUE);
+    const res = await executeIdempotent(KEY, fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(res).toEqual({ outcome: "created", result: ISSUE });
+  });
+
+  it("holds the pending lock (nx, 60s TTL) WHILE fn runs", async () => {
+    let recordDuringFn: unknown;
+    let ttlDuringFn: number | undefined;
+    const fn = vi.fn(async () => {
+      recordDuringFn = store.get(KEY);
+      ttlDuringFn = ttls.get(KEY);
+      return ISSUE;
+    });
+    await executeIdempotent(KEY, fn);
+    expect(recordDuringFn).toMatchObject({ status: "pending", lockedAt: NOW });
+    expect(ttlDuringFn).toBe(LOCK_TTL_SEC);
+    // The lock write must be atomic acquisition, not a blind overwrite.
+    expect(vi.mocked(kv.set)).toHaveBeenCalledWith(
+      KEY,
+      expect.objectContaining({ status: "pending" }),
+      expect.objectContaining({ nx: true, ex: LOCK_TTL_SEC }),
+    );
+  });
+
+  it("persists a completed record with the result and the 30-day TTL", async () => {
+    await executeIdempotent(KEY, async () => ISSUE);
+    expect(store.get(KEY)).toMatchObject({
+      status: "completed",
+      result: ISSUE,
+      completedAt: NOW,
+    });
+    expect(ttls.get(KEY)).toBe(COMPLETED_TTL_SEC);
+  });
+});
+
+describe("executeIdempotent — replay (duplicate execution)", () => {
+  it("returns the original result WITHOUT invoking fn again", async () => {
+    await executeIdempotent(KEY, async () => ISSUE);
+    const fn2 = vi.fn(async () => ({ number: 999, title: "DUP", url: "https://x" }));
+    const res = await executeIdempotent(KEY, fn2);
+    expect(fn2).not.toHaveBeenCalled();
+    expect(res).toEqual({ outcome: "replayed", result: ISSUE });
+  });
+
+  it("logs idempotency_replayed", async () => {
+    await executeIdempotent(KEY, async () => ISSUE);
+    logSpy.mockClear();
+    await executeIdempotent(KEY, async () => ISSUE);
+    expect(logSpy).toHaveBeenCalledWith(
+      "idempotency_replayed",
+      expect.objectContaining({ key: KEY }),
+    );
+  });
+
+  it("invokes fn exactly once across 3 sequential executions of the same key", async () => {
+    const fn = vi.fn(async () => ISSUE);
+    await executeIdempotent(KEY, fn);
+    await executeIdempotent(KEY, fn);
+    await executeIdempotent(KEY, fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("executeIdempotent — concurrent pending lock", () => {
+  it("returns in_flight and does NOT invoke fn when another holder has the lock", async () => {
+    store.set(KEY, { status: "pending", lockedAt: NOW - 1_000 });
+    const fn = vi.fn(async () => ISSUE);
+    const res = await executeIdempotent(KEY, fn);
+    expect(fn).not.toHaveBeenCalled();
+    expect(res).toEqual({ outcome: "in_flight" });
+    expect(logSpy).toHaveBeenCalledWith(
+      "idempotency_in_flight",
+      expect.objectContaining({ key: KEY }),
+    );
+  });
+
+  // TOCTOU window: our first get misses, a competitor completes before
+  // our NX set. NX loses → the protocol MUST re-read and replay, never
+  // give up or re-create. (State re-read after the atomic op.)
+  it("re-reads after losing the NX race and replays a competitor's completed result", async () => {
+    store.set(KEY, { status: "completed", result: ISSUE, completedAt: NOW - 5_000 });
+    vi.mocked(kv.get).mockResolvedValueOnce(null); // simulate the stale first read
+    const fn = vi.fn(async () => ISSUE);
+    const res = await executeIdempotent(KEY, fn);
+    expect(fn).not.toHaveBeenCalled();
+    expect(res).toEqual({ outcome: "replayed", result: ISSUE });
+  });
+
+  it("resolves to in_flight when the NX race loser finds the competitor still pending", async () => {
+    store.set(KEY, { status: "pending", lockedAt: NOW - 2_000 });
+    vi.mocked(kv.get).mockResolvedValueOnce(null); // stale first read
+    const fn = vi.fn(async () => ISSUE);
+    const res = await executeIdempotent(KEY, fn);
+    expect(fn).not.toHaveBeenCalled();
+    expect(res).toEqual({ outcome: "in_flight" });
+  });
+});
+
+describe("executeIdempotent — fn failure", () => {
+  it("releases the lock, writes no completed record, and rethrows", async () => {
+    const boom = new Error("github 500");
+    await expect(executeIdempotent(KEY, async () => { throw boom; })).rejects.toThrow(
+      "github 500",
+    );
+    expect(store.has(KEY)).toBe(false); // lock released via del
+    expect(vi.mocked(kv.del)).toHaveBeenCalledWith(KEY);
+  });
+
+  it("a subsequent execution after failure runs fn again (retryable)", async () => {
+    await expect(
+      executeIdempotent(KEY, async () => { throw new Error("github 500"); }),
+    ).rejects.toThrow();
+    const fn = vi.fn(async () => ISSUE);
+    const res = await executeIdempotent(KEY, fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(res).toEqual({ outcome: "created", result: ISSUE });
+  });
+});
+
+describe("executeIdempotent — KV degradation (fail open)", () => {
+  it("runs fn once and returns created when the read/lock phase throws; skips record writes", async () => {
+    vi.mocked(kv.get).mockRejectedValueOnce(new Error("upstash unreachable"));
+    const fn = vi.fn(async () => ISSUE);
+    const res = await executeIdempotent(KEY, fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(res).toEqual({ outcome: "created", result: ISSUE });
+    expect(vi.mocked(kv.set)).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      "idempotency_degraded",
+      expect.objectContaining({ key: KEY }),
+    );
+  });
+
+  it("still returns created (no throw) when only the completed-record write fails", async () => {
+    vi.mocked(kv.set)
+      .mockResolvedValueOnce("OK") // lock acquisition succeeds
+      .mockRejectedValueOnce(new Error("upstash unreachable")); // completed write fails
+    const fn = vi.fn(async () => ISSUE);
+    const res = await executeIdempotent(KEY, fn);
+    expect(res).toEqual({ outcome: "created", result: ISSUE });
+    expect(logSpy).toHaveBeenCalledWith(
+      "idempotency_degraded",
+      expect.objectContaining({ key: KEY }),
+    );
+  });
+});

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -1,0 +1,184 @@
+// ── Idempotent execution for GitHub issue creation (#125) ────────────
+// Slack delivers webhook events at-least-once, and two humans can
+// confirm the same proposal in the same second. The del-claim protocol
+// in route.ts already serializes *batch* claims, but the innermost
+// createIssue call had no memory: any path that re-reached it created
+// a duplicate GitHub issue. This module gives every issue-creating call
+// a durable, content-addressed memory in KV.
+//
+// Protocol (executeIdempotent):
+//   1. GET key — completed record?  → replay the recorded result.
+//   2. SET pending {nx, ex: 60s}    → atomic lock acquisition.
+//      NX lost? RE-GET: completed   → replay (competitor finished in
+//      the TOCTOU window between our GET and SET); still pending →
+//      in_flight (competitor is running right now — do NOT create).
+//   3. Run fn. On throw: DEL the lock and rethrow — the operation is
+//      retryable, nothing was created.
+//   4. SET completed {result, ex: 30d} so any later duplicate replays.
+//
+// Failure posture: FAIL OPEN. If KV is unreachable we run fn anyway
+// and log `idempotency_degraded` — a rare duplicate issue beats a
+// broken confirmation flow. A completed-record write failure after fn
+// succeeded must NEVER throw (the issue exists; surfacing an error
+// would be a lie), so it degrades the same way.
+//
+// Events: idempotency_replayed, idempotency_in_flight,
+// idempotency_degraded. See TELEMETRY.md.
+
+import { createHash } from "node:crypto";
+import { kv } from "./kv";
+import { log, type LogFn } from "./logger";
+
+/** Pending-lock TTL. Longer than any plausible createIssue call, short
+ * enough that a crashed holder doesn't block a legitimate retry. */
+export const LOCK_TTL_SEC = 60;
+
+/** Completed-record TTL: 30 days. Covers any realistic re-confirmation
+ * window (stale Slack threads, re-delivered events). */
+export const COMPLETED_TTL_SEC = 2_592_000;
+
+type IdempotencyRecord<T> =
+  | { status: "pending"; lockedAt: number }
+  | { status: "completed"; result: T; completedAt: number };
+
+export type IdempotentOutcome<T> =
+  | { outcome: "created"; result: T }
+  | { outcome: "replayed"; result: T }
+  | { outcome: "in_flight" };
+
+/**
+ * Deterministic JSON serialization: object keys sorted recursively,
+ * `undefined` properties omitted, array order preserved (arrays are
+ * ordered; objects are not). Pure function.
+ */
+export function stableSerialize(value: unknown): string {
+  return JSON.stringify(sortDeep(value));
+}
+
+function sortDeep(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortDeep);
+  }
+  if (value !== null && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(source).sort()) {
+      if (source[key] !== undefined) {
+        out[key] = sortDeep(source[key]);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Content-addressed idempotency key for a GitHub issue proposal.
+ *
+ * Labels are normalized before hashing: `undefined` hashes identically
+ * to `[]` (the legacy message parser yields undefined where batch
+ * records hold an array), and order is ignored (labels are a set on
+ * GitHub). Pure function.
+ */
+export function issueIdempotencyKey(proposal: {
+  title: string;
+  body: string;
+  labels?: string[];
+}): string {
+  const canonical = stableSerialize({
+    title: proposal.title,
+    body: proposal.body,
+    labels: [...(proposal.labels ?? [])].sort(),
+  });
+  const digest = createHash("sha256").update(canonical).digest("hex");
+  return `idem:issue:${digest}`;
+}
+
+/**
+ * Execute `fn` at most once per idempotency key (see the protocol in
+ * the file header). Returns a discriminated outcome so callers can
+ * distinguish a fresh create from a replay and from a concurrent
+ * in-flight execution.
+ *
+ * @param key   Idempotency key (from issueIdempotencyKey).
+ * @param fn    The side-effecting operation to guard.
+ * @param logFn Logger — pass the request-scoped rlog when available.
+ */
+export async function executeIdempotent<T>(
+  key: string,
+  fn: () => Promise<T>,
+  logFn: LogFn = log,
+): Promise<IdempotentOutcome<T>> {
+  // ── Phase 1: read + lock. Any KV failure here fails open. ──────────
+  try {
+    const existing = await kv.get<IdempotencyRecord<T>>(key);
+    if (existing && existing.status === "completed") {
+      logFn("idempotency_replayed", { key });
+      return { outcome: "replayed", result: existing.result };
+    }
+
+    const acquired = await kv.set(
+      key,
+      { status: "pending", lockedAt: Date.now() },
+      { nx: true, ex: LOCK_TTL_SEC },
+    );
+    if (acquired === null) {
+      // Lost the NX race. Re-read AFTER the atomic op: a competitor may
+      // have completed in the window between our GET and our SET —
+      // replay their result rather than giving up or re-creating.
+      const current = await kv.get<IdempotencyRecord<T>>(key);
+      if (current && current.status === "completed") {
+        logFn("idempotency_replayed", { key });
+        return { outcome: "replayed", result: current.result };
+      }
+      logFn("idempotency_in_flight", { key });
+      return { outcome: "in_flight" };
+    }
+  } catch (err) {
+    // KV outage — fail open: run fn unguarded, skip all record writes.
+    logFn("idempotency_degraded", {
+      key,
+      phase: "lock",
+      errorMessage: err instanceof Error ? err.message.slice(0, 200) : String(err),
+    });
+    const result = await fn();
+    return { outcome: "created", result };
+  }
+
+  // ── Phase 2: we hold the pending lock — run fn. ─────────────────────
+  let result: T;
+  try {
+    result = await fn();
+  } catch (err) {
+    // Release the lock so a subsequent confirmation can retry; nothing
+    // was created. Best-effort — the 60s TTL is the backstop.
+    try {
+      await kv.del(key);
+    } catch (delErr) {
+      logFn("idempotency_degraded", {
+        key,
+        phase: "unlock",
+        errorMessage:
+          delErr instanceof Error ? delErr.message.slice(0, 200) : String(delErr),
+      });
+    }
+    throw err;
+  }
+
+  // ── Phase 3: persist the completed record. NEVER throw post-success:
+  // the issue exists — a KV flake here must not surface as a failure. ──
+  try {
+    await kv.set(
+      key,
+      { status: "completed", result, completedAt: Date.now() },
+      { ex: COMPLETED_TTL_SEC },
+    );
+  } catch (err) {
+    logFn("idempotency_degraded", {
+      key,
+      phase: "record",
+      errorMessage: err instanceof Error ? err.message.slice(0, 200) : String(err),
+    });
+  }
+  return { outcome: "created", result };
+}

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -57,6 +57,15 @@ describe("log", () => {
     expect(parsed.status).toBe(500);
   });
 
+  it("routes *_failed events to console.error", () => {
+    log("agent_turn_failed", { flow: "mention" });
+    expect(consoleErrorSpy).toHaveBeenCalledOnce();
+    expect(consoleSpy).not.toHaveBeenCalled();
+    const parsed = JSON.parse(consoleErrorSpy.mock.calls[0][0] as string);
+    expect(parsed.event).toBe("agent_turn_failed");
+    expect(parsed.flow).toBe("mention");
+  });
+
   it("routes non-error events to console.log", () => {
     log("agent_complete", { rounds: 3 });
     expect(consoleSpy).toHaveBeenCalledOnce();

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -40,7 +40,11 @@ import * as Sentry from "@sentry/nextjs";
 export function log(event: string, data?: Record<string, unknown>): void {
   const payload = { event, ...data, ts: Date.now() };
   const entry = JSON.stringify(payload);
-  if (event.includes("error")) {
+  // Severity routing: "error" and "failed" event names go to stderr so
+  // Sentry/Vercel classify them as errors (#125 introduced *_failed
+  // names — agent_turn_failed, webhook_handler_failed, tool_call_failed,
+  // recovery_marker_*_failed).
+  if (event.includes("error") || event.includes("failed")) {
     console.error(entry);
   } else {
     console.log(entry);

--- a/src/lib/recovery.test.ts
+++ b/src/lib/recovery.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { logSpy } = vi.hoisted(() => ({ logSpy: vi.fn() }));
+vi.mock("./logger", () => ({
+  log: (...args: unknown[]) => logSpy(...args),
+}));
+
+const { store, zset, ttls } = vi.hoisted(() => ({
+  store: new Map<string, unknown>(),
+  zset: new Map<string, number>(), // member -> score
+  ttls: new Map<string, number>(),
+}));
+
+vi.mock("./kv", () => ({
+  kv: {
+    get: vi.fn(async (key: string) => (store.has(key) ? store.get(key) : null)),
+    set: vi.fn(async (key: string, value: unknown, opts?: { ex?: number; nx?: boolean }) => {
+      // Mirror Upstash SET NX semantics: null when the key already exists.
+      if (opts?.nx && store.has(key)) return null;
+      store.set(key, value);
+      if (opts?.ex) ttls.set(key, opts.ex);
+      return "OK";
+    }),
+    del: vi.fn(async (key: string) => (store.delete(key) ? 1 : 0)),
+    zadd: vi.fn(async (_key: string, entry: { score: number; member: string }) => {
+      const isNew = !zset.has(entry.member);
+      zset.set(entry.member, entry.score);
+      return isNew ? 1 : 0;
+    }),
+    zrem: vi.fn(async (_key: string, member: string) => (zset.delete(member) ? 1 : 0)),
+    zrange: vi.fn(async () => [...zset.keys()]),
+  },
+}));
+
+import { kv } from "./kv";
+import {
+  processingMarkerKey,
+  indexMember,
+  parseIndexMember,
+  decideSweepAction,
+  buildRetryMarker,
+  isAuthorizedCronRequest,
+  writeProcessingMarker,
+  clearProcessingMarker,
+  sweepClaimKey,
+  acquireSweepClaim,
+  PROCESSING_INDEX_KEY,
+  PROCESSING_MARKER_TTL_SEC,
+  PROCESSING_MAX_AGE_MS,
+  SLACK_ROUTE_MAX_DURATION_SEC,
+  SWEEP_CLAIM_TTL_SEC,
+  type ProcessingMarker,
+} from "./recovery";
+
+// Pinned literals — never faker/random data in fixtures.
+const NOW = 1_750_000_000_000;
+const CHANNEL = "C0100000001";
+const THREAD_TS = "1750000000.000100";
+
+function marker(overrides: Partial<ProcessingMarker> = {}): ProcessingMarker {
+  return {
+    eventType: "app_mention",
+    channel: CHANNEL,
+    threadTs: THREAD_TS,
+    user: "U0200000002",
+    text: "what does the auth module do?",
+    startedAt: NOW - PROCESSING_MAX_AGE_MS - 1,
+    attempt: 0,
+    requestId: "abcd1234",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  store.clear();
+  zset.clear();
+  ttls.clear();
+  logSpy.mockClear();
+  vi.mocked(kv.set).mockClear();
+  vi.mocked(kv.del).mockClear();
+  vi.mocked(kv.zadd).mockClear();
+  vi.mocked(kv.zrem).mockClear();
+});
+
+describe("constants (pinned — acceptance criteria of #125)", () => {
+  it("marker safety TTL is 24h", () => {
+    expect(PROCESSING_MARKER_TTL_SEC).toBe(86_400);
+  });
+
+  it("max-age is 15 minutes", () => {
+    expect(PROCESSING_MAX_AGE_MS).toBe(900_000);
+  });
+
+  it("index key is the fixed discovery zset", () => {
+    expect(PROCESSING_INDEX_KEY).toBe("processing:index");
+  });
+
+  // Invariant I4: a marker older than max-age CANNOT belong to a live
+  // invocation. This is the structural guard against the sweep
+  // double-answering a still-running turn. If either constant moves,
+  // this test forces the reviewer to re-verify the invariant.
+  it("max-age strictly exceeds the Slack route maxDuration", () => {
+    expect(PROCESSING_MAX_AGE_MS).toBeGreaterThan(SLACK_ROUTE_MAX_DURATION_SEC * 1000);
+  });
+
+  // Non-destructive sweep claim (PR #133 review). 120s must comfortably
+  // cover one member's action: thread fetch + reply + marker rewrite.
+  it("sweep-claim TTL is 120 seconds", () => {
+    expect(SWEEP_CLAIM_TTL_SEC).toBe(120);
+  });
+
+  // If the claim outlived marker staleness, an abandoned claim could
+  // block recovery longer than a whole staleness cycle.
+  it("sweep-claim TTL is well below marker max-age", () => {
+    expect(SWEEP_CLAIM_TTL_SEC * 1000).toBeLessThan(PROCESSING_MAX_AGE_MS);
+  });
+});
+
+describe("sweepClaimKey (pure)", () => {
+  it("builds processing:claim:<channel>:<threadTs>", () => {
+    expect(sweepClaimKey(CHANNEL, THREAD_TS)).toBe(
+      `processing:claim:${CHANNEL}:${THREAD_TS}`,
+    );
+  });
+
+  it("kv_op log bucket (first segment) is 'processing'", () => {
+    expect(sweepClaimKey(CHANNEL, THREAD_TS).split(":")[0]).toBe("processing");
+  });
+});
+
+describe("acquireSweepClaim (NX semantics, mocked kv)", () => {
+  it("first claimer wins and the claim carries the TTL", async () => {
+    const won = await acquireSweepClaim(CHANNEL, THREAD_TS, "req-a");
+    expect(won).toBe(true);
+    expect(store.has(sweepClaimKey(CHANNEL, THREAD_TS))).toBe(true);
+    expect(ttls.get(sweepClaimKey(CHANNEL, THREAD_TS))).toBe(SWEEP_CLAIM_TTL_SEC);
+  });
+
+  it("second claimer loses while the first claim is live (NX)", async () => {
+    expect(await acquireSweepClaim(CHANNEL, THREAD_TS, "req-a")).toBe(true);
+    expect(await acquireSweepClaim(CHANNEL, THREAD_TS, "req-b")).toBe(false);
+  });
+
+  it("claims on different threads are independent", async () => {
+    expect(await acquireSweepClaim(CHANNEL, THREAD_TS, "req-a")).toBe(true);
+    expect(await acquireSweepClaim(CHANNEL, "1750000099.000200", "req-a")).toBe(true);
+  });
+
+  it("does NOT touch the marker or its index entry (non-destructive)", async () => {
+    await writeProcessingMarker(marker({ startedAt: NOW }));
+    await acquireSweepClaim(CHANNEL, THREAD_TS, "req-a");
+    expect(store.has(processingMarkerKey(CHANNEL, THREAD_TS))).toBe(true);
+    expect(zset.has(indexMember(CHANNEL, THREAD_TS))).toBe(true);
+  });
+});
+
+describe("processingMarkerKey / index member (pure)", () => {
+  it("builds processing:<channel>:<threadTs>", () => {
+    expect(processingMarkerKey(CHANNEL, THREAD_TS)).toBe(
+      `processing:${CHANNEL}:${THREAD_TS}`,
+    );
+  });
+
+  it("kv_op log bucket (first segment) is 'processing'", () => {
+    expect(processingMarkerKey(CHANNEL, THREAD_TS).split(":")[0]).toBe("processing");
+  });
+
+  it("index member round-trips channel and threadTs", () => {
+    const member = indexMember(CHANNEL, THREAD_TS);
+    expect(parseIndexMember(member)).toEqual({ channel: CHANNEL, threadTs: THREAD_TS });
+  });
+});
+
+describe("decideSweepAction (pure) — staleness boundary", () => {
+  // Stale is defined as: now - startedAt > maxAgeMs (STRICTLY greater).
+  it("returns wait just under max-age", () => {
+    const m = marker({ startedAt: NOW - PROCESSING_MAX_AGE_MS + 1 });
+    expect(decideSweepAction(m, NOW, PROCESSING_MAX_AGE_MS)).toBe("wait");
+  });
+
+  it("returns wait at exactly max-age (boundary is exclusive)", () => {
+    const m = marker({ startedAt: NOW - PROCESSING_MAX_AGE_MS });
+    expect(decideSweepAction(m, NOW, PROCESSING_MAX_AGE_MS)).toBe("wait");
+  });
+
+  it("returns retry one millisecond past max-age on the first attempt", () => {
+    const m = marker({ startedAt: NOW - PROCESSING_MAX_AGE_MS - 1, attempt: 0 });
+    expect(decideSweepAction(m, NOW, PROCESSING_MAX_AGE_MS)).toBe("retry");
+  });
+
+  it("returns give_up past max-age once a retry has been consumed", () => {
+    const m = marker({ attempt: 1 });
+    expect(decideSweepAction(m, NOW, PROCESSING_MAX_AGE_MS)).toBe("give_up");
+  });
+
+  it("returns give_up for any attempt count above 1 (defensive)", () => {
+    const m = marker({ attempt: 2 });
+    expect(decideSweepAction(m, NOW, PROCESSING_MAX_AGE_MS)).toBe("give_up");
+  });
+
+  it("returns wait when startedAt is in the future (clock skew must not trigger retries)", () => {
+    const m = marker({ startedAt: NOW + 60_000 });
+    expect(decideSweepAction(m, NOW, PROCESSING_MAX_AGE_MS)).toBe("wait");
+  });
+
+  it("returns orphan for a missing marker record (index entry outlived the 24h marker TTL)", () => {
+    expect(decideSweepAction(null, NOW, PROCESSING_MAX_AGE_MS)).toBe("orphan");
+  });
+
+  it("defaults maxAgeMs to PROCESSING_MAX_AGE_MS", () => {
+    expect(decideSweepAction(marker(), NOW)).toBe("retry");
+  });
+});
+
+describe("buildRetryMarker (pure)", () => {
+  it("increments attempt, refreshes startedAt, preserves the event payload", () => {
+    const original = marker();
+    const retry = buildRetryMarker(original, NOW);
+    expect(retry).toEqual({
+      eventType: "app_mention",
+      channel: CHANNEL,
+      threadTs: THREAD_TS,
+      user: "U0200000002",
+      text: "what does the auth module do?",
+      startedAt: NOW,
+      attempt: 1,
+      requestId: "abcd1234", // kept for cross-run correlation
+    });
+  });
+
+  it("does not mutate the input marker", () => {
+    const original = marker();
+    buildRetryMarker(original, NOW);
+    expect(original.attempt).toBe(0);
+    expect(original.startedAt).toBe(NOW - PROCESSING_MAX_AGE_MS - 1);
+  });
+});
+
+describe("isAuthorizedCronRequest (pure)", () => {
+  it("accepts the exact Bearer token", () => {
+    expect(isAuthorizedCronRequest("Bearer s3cret", "s3cret")).toBe(true);
+  });
+
+  it("rejects a wrong token", () => {
+    expect(isAuthorizedCronRequest("Bearer wrong", "s3cret")).toBe(false);
+  });
+
+  it("rejects a missing header", () => {
+    expect(isAuthorizedCronRequest(null, "s3cret")).toBe(false);
+  });
+
+  it("rejects a token without the Bearer prefix", () => {
+    expect(isAuthorizedCronRequest("s3cret", "s3cret")).toBe(false);
+  });
+
+  it("rejects a lowercase 'bearer' prefix (exact scheme match)", () => {
+    expect(isAuthorizedCronRequest("bearer s3cret", "s3cret")).toBe(false);
+  });
+
+  it("denies ALL requests when CRON_SECRET is unset (fail closed)", () => {
+    expect(isAuthorizedCronRequest("Bearer anything", undefined)).toBe(false);
+  });
+
+  it("denies ALL requests when CRON_SECRET is empty", () => {
+    expect(isAuthorizedCronRequest("Bearer ", "")).toBe(false);
+  });
+});
+
+describe("writeProcessingMarker (marker lifecycle, mocked kv)", () => {
+  it("persists the marker under its key with the 24h TTL and indexes it by startedAt", async () => {
+    const m = marker({ startedAt: NOW });
+    const ok = await writeProcessingMarker(m);
+    expect(ok).toBe(true);
+    const key = processingMarkerKey(CHANNEL, THREAD_TS);
+    expect(store.get(key)).toEqual(m);
+    expect(ttls.get(key)).toBe(PROCESSING_MARKER_TTL_SEC);
+    expect(zset.get(indexMember(CHANNEL, THREAD_TS))).toBe(NOW);
+  });
+
+  it("returns false and logs recovery_marker_write_failed on KV failure — never throws", async () => {
+    vi.mocked(kv.set).mockRejectedValueOnce(new Error("upstash unreachable"));
+    const ok = await writeProcessingMarker(marker({ startedAt: NOW }));
+    expect(ok).toBe(false);
+    expect(logSpy).toHaveBeenCalledWith(
+      "recovery_marker_write_failed",
+      expect.objectContaining({ channel: CHANNEL, threadTs: THREAD_TS }),
+    );
+  });
+});
+
+describe("clearProcessingMarker (marker lifecycle, mocked kv)", () => {
+  it("deletes the marker and removes the index member", async () => {
+    await writeProcessingMarker(marker({ startedAt: NOW }));
+    await clearProcessingMarker(CHANNEL, THREAD_TS);
+    expect(store.has(processingMarkerKey(CHANNEL, THREAD_TS))).toBe(false);
+    expect(zset.has(indexMember(CHANNEL, THREAD_TS))).toBe(false);
+  });
+
+  it("swallows KV failures and logs recovery_marker_clear_failed — a clear failure must never break the reply flow", async () => {
+    vi.mocked(kv.del).mockRejectedValueOnce(new Error("upstash unreachable"));
+    await expect(clearProcessingMarker(CHANNEL, THREAD_TS)).resolves.toBeUndefined();
+    expect(logSpy).toHaveBeenCalledWith(
+      "recovery_marker_clear_failed",
+      expect.objectContaining({ channel: CHANNEL, threadTs: THREAD_TS }),
+    );
+  });
+});

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -1,0 +1,210 @@
+// ── Recoverable background processing (#125) ─────────────────────────
+// Vercel can kill a container mid-after() (timeout, OOM, platform
+// restart) — the user's question then silently dies: no answer, no
+// error reply, no trace beyond a dangling thinking message. This module
+// makes in-flight turns durable:
+//
+// 1. The Slack route writes a ProcessingMarker as the FIRST step of
+//    each after() body (off the ack path — Slack's 3-second deadline,
+//    PR #133 review) and clears it in the after() finally. A finally
+//    covers every handled error path — only container death leaves a
+//    marker behind, which is exactly the recoverable set (minus the
+//    tiny accepted window between the ack and the marker write).
+// 2. A cron sweep (/api/cron/sweep, every 5 min) walks the discovery
+//    index, classifies each marker via decideSweepAction, wins a
+//    non-destructive NX claim per member (see acquireSweepClaim),
+//    retries stale first-attempt turns once, and posts a visible
+//    failure notice when the retry also died.
+//
+// Discovery uses a zset (processing:index, member <channel>:<threadTs>,
+// score startedAt) because the kv wrapper deliberately exposes no SCAN.
+//
+// Invariant I4: PROCESSING_MAX_AGE_MS strictly exceeds the Slack
+// route's maxDuration, so a marker older than max-age CANNOT belong to
+// a live invocation — the structural guard against the sweep
+// double-answering a still-running turn.
+
+import { kv } from "./kv";
+import { log } from "./logger";
+
+/** Safety TTL on the marker record itself: 24h. The sweep normally
+ * consumes markers long before this — the TTL is the backstop against
+ * a permanently broken sweep leaking KV records. */
+export const PROCESSING_MARKER_TTL_SEC = 86_400;
+
+/** A marker older than this is stale (its invocation is provably dead
+ * — see invariant I4 above). 15 minutes. */
+export const PROCESSING_MAX_AGE_MS = 900_000;
+
+/** Discovery zset: member `<channel>:<threadTs>`, score `startedAt`. */
+export const PROCESSING_INDEX_KEY = "processing:index";
+
+/** TTL on the sweep's per-member NX claim (PR #133 review). Must
+ * comfortably cover one member's action — thread fetch + Slack reply +
+ * marker rewrite — and stay well below PROCESSING_MAX_AGE_MS so an
+ * abandoned claim (sweep died post-claim) delays recovery by at most
+ * one cadence, never a full staleness cycle. */
+export const SWEEP_CLAIM_TTL_SEC = 120;
+
+/** The Slack route's `export const maxDuration` value. Mirrored here so
+ * the recovery tests can pin the I4 invariant against it. */
+export const SLACK_ROUTE_MAX_DURATION_SEC = 300;
+
+export interface ProcessingMarker {
+  eventType: "app_mention" | "thread_followup";
+  channel: string;
+  threadTs: string;
+  user: string;
+  text: string;
+  startedAt: number;
+  attempt: number;
+  requestId: string;
+}
+
+export type SweepAction = "wait" | "retry" | "give_up" | "orphan";
+
+/** Marker key for one in-flight turn. Pure function. */
+export function processingMarkerKey(channel: string, threadTs: string): string {
+  return `processing:${channel}:${threadTs}`;
+}
+
+/** Discovery-index member for one in-flight turn. Pure function. */
+export function indexMember(channel: string, threadTs: string): string {
+  return `${channel}:${threadTs}`;
+}
+
+/** Sweep-claim key for one in-flight turn. Pure function. */
+export function sweepClaimKey(channel: string, threadTs: string): string {
+  return `processing:claim:${channel}:${threadTs}`;
+}
+
+/**
+ * Parse an index member back into channel + threadTs. Returns null for
+ * malformed members (the sweep treats those as orphans). Splits on the
+ * FIRST colon — Slack channel IDs never contain one. Pure function.
+ */
+export function parseIndexMember(
+  member: string,
+): { channel: string; threadTs: string } | null {
+  const idx = member.indexOf(":");
+  if (idx <= 0 || idx === member.length - 1) return null;
+  return { channel: member.slice(0, idx), threadTs: member.slice(idx + 1) };
+}
+
+/**
+ * Classify a marker for the sweep. Pure function.
+ *
+ * - null marker (index entry outlived the 24h marker TTL) → "orphan"
+ * - age <= maxAgeMs (including a FUTURE startedAt — clock skew must
+ *   never trigger a retry)                                → "wait"
+ * - stale (age STRICTLY > maxAgeMs), attempt 0            → "retry"
+ * - stale, attempt >= 1 (retry already consumed)          → "give_up"
+ */
+export function decideSweepAction(
+  marker: ProcessingMarker | null,
+  now: number,
+  maxAgeMs: number = PROCESSING_MAX_AGE_MS,
+): SweepAction {
+  if (!marker) return "orphan";
+  const age = now - marker.startedAt;
+  if (age <= maxAgeMs) return "wait";
+  return marker.attempt >= 1 ? "give_up" : "retry";
+}
+
+/**
+ * Derive the marker for a sweep-initiated retry: attempt incremented,
+ * startedAt refreshed, event payload (including requestId, kept for
+ * cross-run correlation) preserved. Does not mutate the input. Pure.
+ */
+export function buildRetryMarker(
+  marker: ProcessingMarker,
+  now: number,
+): ProcessingMarker {
+  return { ...marker, startedAt: now, attempt: marker.attempt + 1 };
+}
+
+/**
+ * Exact-match check for Vercel Cron's `Authorization: Bearer <secret>`
+ * header. Fails closed: an unset or empty CRON_SECRET denies ALL
+ * requests (a misconfigured deploy must not expose the sweep). Pure.
+ */
+export function isAuthorizedCronRequest(
+  header: string | null,
+  secret: string | undefined,
+): boolean {
+  if (!secret) return false;
+  return header === `Bearer ${secret}`;
+}
+
+/**
+ * Non-destructive sweep claim (PR #133 review): SET NX with a short TTL
+ * on a SEPARATE key instead of deleting the marker up front. The marker
+ * and index entry survive any failure after a won claim — the next
+ * sweep (once the claim TTL expires) simply retries the decision. The
+ * losing racer gets false and skips the member.
+ *
+ * KV errors propagate deliberately: the sweep's per-member catch skips
+ * the member with all state intact.
+ */
+export async function acquireSweepClaim(
+  channel: string,
+  threadTs: string,
+  requestId: string,
+): Promise<boolean> {
+  const result = await kv.set(
+    sweepClaimKey(channel, threadTs),
+    { claimedAt: Date.now(), requestId },
+    { nx: true, ex: SWEEP_CLAIM_TTL_SEC },
+  );
+  // Upstash SET NX returns null when the key already exists.
+  return result !== null;
+}
+
+/**
+ * Persist a marker + its discovery-index entry. Best-effort: returns
+ * false and logs `recovery_marker_write_failed` on KV failure — a KV
+ * flake must never block the actual turn from running.
+ */
+export async function writeProcessingMarker(
+  marker: ProcessingMarker,
+): Promise<boolean> {
+  try {
+    await kv.set(processingMarkerKey(marker.channel, marker.threadTs), marker, {
+      ex: PROCESSING_MARKER_TTL_SEC,
+    });
+    await kv.zadd(PROCESSING_INDEX_KEY, {
+      score: marker.startedAt,
+      member: indexMember(marker.channel, marker.threadTs),
+    });
+    return true;
+  } catch (err) {
+    log("recovery_marker_write_failed", {
+      channel: marker.channel,
+      threadTs: marker.threadTs,
+      errorMessage: err instanceof Error ? err.message.slice(0, 200) : String(err),
+    });
+    return false;
+  }
+}
+
+/**
+ * Delete a marker + its index entry. Swallows KV failures (logging
+ * `recovery_marker_clear_failed`) — a clear failure must never break
+ * the reply flow; the sweep's already-answered guard and the 24h TTL
+ * mop up anything left behind.
+ */
+export async function clearProcessingMarker(
+  channel: string,
+  threadTs: string,
+): Promise<void> {
+  try {
+    await kv.del(processingMarkerKey(channel, threadTs));
+    await kv.zrem(PROCESSING_INDEX_KEY, indexMember(channel, threadTs));
+  } catch (err) {
+    log("recovery_marker_clear_failed", {
+      channel,
+      threadTs,
+      errorMessage: err instanceof Error ? err.message.slice(0, 200) : String(err),
+    });
+  }
+}

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -204,6 +204,9 @@ export interface ThreadMessage {
   user?: string;
   text?: string;
   bot_id?: string;
+  /** Slack message timestamp ("<epoch-sec>.<seq>"). Used by the
+   * recovery sweep's already-answered guard (#125). */
+  ts?: string;
 }
 
 export async function fetchThreadMessages(
@@ -220,6 +223,7 @@ export async function fetchThreadMessages(
       user: m.user,
       text: m.text ?? "",
       bot_id: m.bot_id,
+      ts: m.ts,
     }));
   } catch {
     return [];

--- a/src/lib/turn-runner.ts
+++ b/src/lib/turn-runner.ts
@@ -1,0 +1,767 @@
+// ── Turn runner: the agent-turn bodies behind /api/slack (#125) ──────
+// Behavior-preserving extraction of the mention and thread-followup
+// after() bodies out of route.ts, so the recovery sweep
+// (/api/cron/sweep) can re-run a died turn through the EXACT same code
+// path the webhook uses. The route stays a thin entry point: parse +
+// guard + marker lifecycle + call a runner.
+//
+// flushLogs deliberately stays with the CALLER (route after() finally /
+// end of sweep) — the sweep flushes once per sweep, not once per turn.
+
+import * as Sentry from "@sentry/nextjs";
+import {
+  replyInThread,
+  getBotUserId,
+  fetchThreadMessages,
+  updateMessage,
+  deleteMessage,
+  postReplyInChunks,
+} from "@/lib/slack";
+import { runAgent } from "@/lib/claude";
+import { createIssue } from "@/lib/github";
+import { executeIdempotent, issueIdempotencyKey } from "@/lib/idempotency";
+import { type IssueProposal } from "@/tools/create-issue";
+import {
+  formatBatchProposalMessage,
+  isBulkConfirmText,
+  summarizeBatchResult,
+  type BatchCreationOutcome,
+} from "@/lib/issue-batch";
+import { storeQAContext, saveFeedback, deriveReferenceTypes } from "@/lib/feedback";
+import { formatReferences, rankReferences } from "@/lib/references";
+import { toSlackMrkdwn } from "@/lib/mrkdwn";
+import { buildThinkingMessage, THINKING_HEADER } from "@/lib/progress";
+import { createThrottledUpdater } from "@/lib/slack-throttle";
+import { formatReplyFooter, isReplyFooterEnabled } from "@/lib/reply-footer";
+import {
+  extractParticipantIds,
+  resolveParticipants,
+  type Participant,
+} from "@/lib/slack-users";
+import { type RequestLogger } from "@/lib/logger";
+import { getCachedTopics } from "@/lib/repo-index";
+import { matchTopicsToQuestion, buildQuestionHints } from "@/lib/topic-match";
+import {
+  buildConversationHistory,
+  extractTranscriptTail,
+} from "@/lib/thread-filter";
+import {
+  classifyTurn,
+  decideEffort,
+  evaluateFollowup,
+  buildEffortHint,
+  EFFORT_BUDGETS,
+} from "@/lib/effort-routing";
+
+// Shape of the pending-correction record stored under
+// `pending-correction:{channel}:{threadTs}` when a user reacts 👎.
+// Read by the thread-followup handler on the user's next message to
+// save their correction to the KB. @upstash/redis auto-stringifies
+// this on set and auto-parses on get.
+export interface PendingCorrection {
+  question: string;
+  references: string[];
+  flaggedKB: string[];
+  pendingAt: number;
+  answerTs: string;
+}
+
+// Shape of the pending-issue-batch record stored after the bot posts a
+// proposal message. Indexed by the proposal message's first TS. See #122.
+export interface PendingIssueBatch {
+  proposals: IssueProposal[];
+  proposedAt: number;
+  requestedBy: string; // Slack user ID of the requester
+  threadTs: string;
+  messageFirstTs: string; // ts of the first chunk of the proposal message
+}
+
+const BATCH_KEY_PREFIX = "pending-issue-batch";
+const BATCH_TTL_SEC = 86400; // 24h — stale batches fall off naturally
+// Tombstone TTL: long enough to cover any plausible double-tap ✅ window
+// on a single-proposal message whose body still matches the legacy parser.
+// See PR #123 CodeRabbit finding — without this, a second reaction finds
+// the canonical record deleted, falls to parseProposalFromMessage, and
+// re-creates the issue.
+const BATCH_TOMBSTONE_TTL_SEC = 3600;
+
+export function batchKey(channel: string, firstTs: string): string {
+  return `${BATCH_KEY_PREFIX}:${channel}:${firstTs}`;
+}
+export function batchThreadPointerKey(channel: string, threadTs: string): string {
+  return `${BATCH_KEY_PREFIX}:thread:${channel}:${threadTs}`;
+}
+export function batchTombstoneKey(channel: string, firstTs: string): string {
+  return `${BATCH_KEY_PREFIX}:done:${channel}:${firstTs}`;
+}
+
+/**
+ * Atomically claim and execute a pending issue batch.
+ *
+ * Concurrency: the claim uses `kv.del` on the canonical key — Redis
+ * DEL is atomic, so only the first caller sees `deleted === 1`. Any
+ * racing handler (a second reaction, or a racing text command) sees
+ * `0` and aborts without firing GitHub writes.
+ *
+ * Per-issue failures do not abort the rest: we use Promise.allSettled
+ * and surface both creates and errors in the final summary.
+ */
+export async function executeBatchCreation(
+  channel: string,
+  threadTs: string,
+  firstTs: string,
+  confirmingUser: string,
+  confirmVia: "reaction" | "text",
+  rlog: RequestLogger,
+): Promise<{ claimed: boolean }> {
+  const { kv } = await import("@/lib/kv");
+  const primaryKey = batchKey(channel, firstTs);
+
+  // Read the batch before claiming so we have the data to create issues
+  // if we win the del race.
+  const batch = await kv.get<PendingIssueBatch>(primaryKey);
+  if (!batch) {
+    return { claimed: false };
+  }
+
+  const deleted = await kv.del(primaryKey);
+  if (deleted === 0) {
+    // Another handler won the race between get and del.
+    rlog("issue_batch_claim_lost", { channel, firstTs, confirmVia });
+    return { claimed: false };
+  }
+
+  // Tombstone the claim so a second ✅ on the same message can't fall
+  // through to the legacy parser and re-create the issue. The legacy
+  // fallback checks this before parsing message text. 1h is enough for
+  // any plausible double-tap; long-lived record stays under the canonical
+  // 24h TTL of the original batch.
+  try {
+    await kv.set(batchTombstoneKey(channel, firstTs), 1, {
+      ex: BATCH_TOMBSTONE_TTL_SEC,
+    });
+  } catch {
+    // Non-fatal; Sentry already captured via the kv wrapper. Worst case
+    // a racing second reaction takes the legacy path.
+  }
+
+  // Best-effort cleanup of the thread pointer. We don't care if it was
+  // already removed — TTL would catch it anyway.
+  try {
+    await kv.del(batchThreadPointerKey(channel, threadTs));
+  } catch {
+    // Non-fatal; Sentry already captured via the kv wrapper.
+  }
+
+  rlog("issue_batch_confirmed", {
+    count: batch.proposals.length,
+    confirmVia,
+    confirmingUser,
+    requestedBy: batch.requestedBy,
+    latencyMs: Date.now() - batch.proposedAt,
+    channel,
+    threadTs,
+  });
+
+  const createStart = Date.now();
+  // Innermost idempotency guard (#125): the del-claim above serializes
+  // batch claims, but Slack's at-least-once delivery and the legacy
+  // parser fallback can still re-reach createIssue. Content-addressed
+  // keys make every duplicate a replay (recorded URL) instead of a
+  // second GitHub issue.
+  const settled = await Promise.allSettled(
+    batch.proposals.map((p) =>
+      executeIdempotent(
+        issueIdempotencyKey({ title: p.title, body: p.body, labels: p.labels }),
+        () => createIssue(p.title, p.body, p.labels),
+        rlog,
+      ),
+    ),
+  );
+
+  const outcomes: BatchCreationOutcome[] = settled.map((res, i) => {
+    const proposal = batch.proposals[i];
+    if (res.status === "fulfilled") {
+      if (res.value.outcome === "in_flight") {
+        // Another confirmation holds the pending lock for this exact
+        // proposal right now — surface as an error-shaped outcome so
+        // the summary doesn't claim success for an issue we can't see.
+        return {
+          status: "error",
+          proposal,
+          errorMessage: "already being created by another confirmation",
+        };
+      }
+      // created and replayed both carry the (recorded) issue.
+      return { status: "success", proposal, issue: res.value.result };
+    }
+    const errorMessage =
+      res.reason instanceof Error ? res.reason.message : String(res.reason);
+    // Per-issue Sentry capture so a rate-limit spike on one title doesn't
+    // hide under the summary event. Tagged for dashboard filtering.
+    Sentry.captureException(res.reason, {
+      tags: { flow: "issue_create", batchSize: String(batch.proposals.length) },
+      extra: { proposalTitle: proposal.title },
+    });
+    rlog("issue_create_error", {
+      title: proposal.title,
+      errorClass:
+        res.reason instanceof Error ? res.reason.constructor.name : "Unknown",
+      errorMessage: errorMessage.slice(0, 200),
+    });
+    return { status: "error", proposal, errorMessage };
+  });
+
+  const successCount = outcomes.filter((o) => o.status === "success").length;
+  const failureCount = outcomes.length - successCount;
+  rlog("issue_batch_created", {
+    totalCount: outcomes.length,
+    successCount,
+    failureCount,
+    durationMs: Date.now() - createStart,
+    numbers: outcomes
+      .filter((o) => o.status === "success")
+      .map((o) => (o as Extract<BatchCreationOutcome, { status: "success" }>).issue.number),
+    channel,
+    threadTs,
+  });
+
+  await replyInThread(channel, threadTs, summarizeBatchResult(outcomes));
+  return { claimed: true };
+}
+
+// ── Mention turn ──────────────────────────────────────────────────────
+
+export interface MentionTurnParams {
+  channel: string;
+  threadTs: string;
+  /** Slack user ID of the mentioning user. */
+  user: string;
+  /** Raw message text (bot mention token still present). */
+  text: string;
+  /** Whether the mention arrived inside an existing thread. The sweep
+   * passes true — a died turn always has its thread rooted at threadTs
+   * by then, and fetching it is a safe superset of the fresh-mention
+   * participant derivation. */
+  inThread: boolean;
+  rlog: RequestLogger;
+}
+
+/**
+ * The full @bm mention turn: thinking message → context assembly →
+ * agent loop → answer/proposal post → Q&A context storage. Extracted
+ * verbatim from the route's after() body so the recovery sweep can
+ * re-run it. Handles its own errors (visible error reply); the caller
+ * owns marker cleanup and flushLogs.
+ */
+export async function runMentionTurn(params: MentionTurnParams): Promise<void> {
+  const { channel, threadTs, user, text: userMessage, inThread, rlog } = params;
+  // Hoist thinkingTs so finally can always clean it up
+  let thinkingTs: string | undefined;
+  try {
+    // Post thinking message and capture its ts for live updates
+    thinkingTs = await replyInThread(
+      channel, threadTs,
+      THINKING_HEADER,
+    );
+
+    const cleanMessage = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
+
+    // Thread participants for #80: resolve user IDs to display names
+    // so the agent can @-mention correctly. Populated for BOTH fresh
+    // mentions (participants = invoking user + anyone they mentioned)
+    // and thread follow-ups (all thread authors + anyone mentioned).
+    let mentionHistory: { role: "user" | "assistant"; content: string }[] | undefined;
+    let mentionParticipants: Participant[] | undefined;
+    // Recent-thread tail for the effort classifier — empty for fresh
+    // top-level mentions (the question alone is enough to bucket).
+    let mentionTranscript = "";
+    const botId = await getBotUserId();
+    if (inThread) {
+      const threadMsgs = await fetchThreadMessages(channel, threadTs);
+      if (botId) {
+        mentionHistory = buildConversationHistory(threadMsgs, botId);
+      }
+      mentionTranscript = extractTranscriptTail(threadMsgs, botId ?? "");
+      const ids = extractParticipantIds(threadMsgs, botId);
+      if (ids.length > 0) {
+        mentionParticipants = await resolveParticipants(ids);
+      }
+    } else {
+      // Fresh top-level mention — the only participant signal is the
+      // invoking user + anyone they mentioned in the message body.
+      const ids = extractParticipantIds(
+        [{ user, text: userMessage }],
+        botId,
+      );
+      if (ids.length > 0) {
+        mentionParticipants = await resolveParticipants(ids);
+      }
+    }
+
+    // Pre-match question against topic index for concrete file hints.
+    // The effort classifier (#126) runs in parallel — on the mention
+    // path shouldReply is NEVER consulted (the user explicitly invoked
+    // the bot); the classifier only buckets the question so the agent
+    // gets a right-sized round budget and answer target.
+    const [topics, mentionClassification] = await Promise.all([
+      getCachedTopics(),
+      classifyTurn(
+        { invocation: "mention", transcript: mentionTranscript, question: cleanMessage },
+        { log: rlog },
+      ),
+    ]);
+    const mentionEffort = decideEffort(mentionClassification);
+    const topicMatches = matchTopicsToQuestion(cleanMessage, topics);
+    const augmentedMessage =
+      buildQuestionHints(cleanMessage, topicMatches) + buildEffortHint(mentionEffort);
+    if (topicMatches.length > 0) {
+      rlog("topic_hints_injected", { topics: topicMatches.map((m) => m.topic), fileCount: topicMatches.reduce((s, m) => s + m.paths.length, 0) });
+    }
+
+    // Tool-progress updater. Per #110 review: the streaming flood
+    // from #109 was character-level text deltas, NOT tool-progress
+    // messages. Tool progress at ~1 call per tool round (debounced
+    // to coalesce parallel bursts) is 5-7 calls per turn — well
+    // under Slack's 30/min Tier 2 limit and genuinely informative
+    // for the user. Re-introducing it WITHOUT streaming.
+    const progressThrottle = createThrottledUpdater(async (text) => {
+      if (thinkingTs) {
+        await updateMessage(channel, thinkingTs, text);
+      }
+    }, 1200);
+
+    const result = await runAgent(
+      augmentedMessage,
+      mentionHistory,
+      rlog,
+      mentionParticipants,
+      (toolName, input) => {
+        progressThrottle.update(buildThinkingMessage(toolName, input));
+      },
+      { maxRounds: EFFORT_BUDGETS[mentionEffort].maxRounds, effort: mentionEffort },
+    );
+    // Drain any pending progress update before the final write so a
+    // stale progress message can't land on top of the final answer.
+    await progressThrottle.flush();
+    // `agent_complete` is already emitted by runAgent with rounds,
+    // token usage, and cache metrics — don't duplicate at route level.
+
+    const text = toSlackMrkdwn(result.text);
+    const rankedRefs = rankReferences(result.references, result.text);
+    const refsFooter = formatReferences(rankedRefs);
+    // Optional compact telemetry footer (#79). Disabled by default;
+    // enable with BM_REPLY_FOOTER=1 in the Vercel env.
+    const replyFooter = isReplyFooterEnabled(process.env)
+      ? formatReplyFooter(result.metrics, rlog.requestId)
+      : "";
+
+    if (result.issueProposals.length > 0) {
+      const proposals = result.issueProposals;
+      const proposalBlock = formatBatchProposalMessage(proposals);
+      const finalBody = [text, "", proposalBlock].join("\n") + refsFooter + replyFooter;
+
+      const posted = await postReplyInChunks({
+        channel,
+        threadTs,
+        thinkingTs,
+        text: finalBody,
+      });
+      // Only mark as finalized when we actually posted. A 0-chunk
+      // result (empty body) falls through to the finally cleanup.
+      if (posted.chunks > 0) thinkingTs = undefined;
+
+      // Persist the batch so confirmation (reaction OR thread text)
+      // can create without re-parsing Slack message text. Key is the
+      // first chunk's ts; thread pointer enables "confirm all" text.
+      if (posted.firstTs) {
+        const { kv } = await import("@/lib/kv");
+        const record: PendingIssueBatch = {
+          proposals,
+          proposedAt: Date.now(),
+          requestedBy: user,
+          threadTs,
+          messageFirstTs: posted.firstTs,
+        };
+        await kv.set(batchKey(channel, posted.firstTs), record, { ex: BATCH_TTL_SEC });
+        await kv.set(
+          batchThreadPointerKey(channel, threadTs),
+          posted.firstTs,
+          { ex: BATCH_TTL_SEC },
+        );
+        rlog("issue_batch_proposed", {
+          count: proposals.length,
+          threadTs,
+          channel,
+          firstTs: posted.firstTs,
+          sampleTitles: proposals.slice(0, 3).map((p) => p.title.slice(0, 80)),
+          requestingUser: user,
+        });
+      }
+      rlog("answer_posted", {
+        channel,
+        threadTs,
+        chunks: posted.chunks,
+        kind: "proposal",
+        proposalCount: proposals.length,
+      });
+    } else {
+      const finalBody = text + refsFooter + replyFooter;
+      const posted = await postReplyInChunks({
+        channel,
+        threadTs,
+        thinkingTs,
+        text: finalBody,
+      });
+      if (posted.chunks > 0) thinkingTs = undefined;
+      rlog("answer_posted", { channel, threadTs, chunks: posted.chunks });
+
+      // Store Q&A context for EVERY chunk ts (see #114). Reactions
+      // on any chunk resolve to the same question/answer pair.
+      if (posted.firstTs && posted.allTs.length > 0) {
+        const postedAt = Date.now();
+        const referenceTypes = deriveReferenceTypes(result.references);
+        await Promise.all(
+          posted.allTs.map((ts, chunkIndex) =>
+            storeQAContext(channel, ts, {
+              question: cleanMessage,
+              answer: result.text.slice(0, 500),
+              references: result.references.map((r) => r.label),
+              answerTs: posted.firstTs!,
+              chunkIndex,
+              chunkCount: posted.chunks,
+              postedAt,
+              referenceTypes,
+            }),
+          ),
+        );
+      }
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    rlog("agent_turn_failed", { flow: "mention", message: msg });
+    // Also capture as a Sentry Issue so the stack trace surfaces
+    // in the dashboard — `rlog` alone produces a Log entry without
+    // a stack, which is how #100 stayed a mystery (we knew the
+    // error message but not what line in the after() body threw it).
+    Sentry.captureException(err, { tags: { flow: "mention" } });
+    await replyInThread(
+      channel,
+      threadTs,
+      `Something went wrong while processing your request. Error: ${msg}`,
+    );
+  } finally {
+    // Safety net: delete thinking message if it wasn't cleaned up
+    if (thinkingTs) {
+      await deleteMessage(channel, thinkingTs);
+    }
+  }
+}
+
+// ── Thread-followup turn ──────────────────────────────────────────────
+
+export interface FollowupTurnParams {
+  channel: string;
+  threadTs: string;
+  /** Slack user ID of the replying user. */
+  user: string;
+  /** Raw message text. */
+  text: string;
+  /** Bot user ID if the caller already resolved it (the webhook route
+   * does, for its mention-skip guard). The runner re-resolves when
+   * absent — e.g. on a sweep re-run. */
+  botId?: string;
+  rlog: RequestLogger;
+}
+
+/**
+ * The full thread-followup turn: pending-correction intake →
+ * bulk-confirm interception → participation check → follow-up
+ * classifier gate (#126, fail-closed) → agent loop → answer/proposal
+ * post. Extracted from the route's after() body so the recovery sweep
+ * can re-run it. Handles its own errors;
+ * the caller owns marker cleanup and flushLogs.
+ */
+export async function runFollowupTurn(params: FollowupTurnParams): Promise<void> {
+  const { channel, threadTs, user, text: userMessage, botId, rlog } = params;
+  let thinkTs: string | undefined;
+  try {
+    // Check for pending correction (from a 👎 reaction)
+    const { kv } = await import("@/lib/kv");
+    const pendingKey = `pending-correction:${channel}:${threadTs}`;
+    const pending = await kv.get<PendingCorrection>(pendingKey);
+    if (pending) {
+      // This reply is a correction — save directly to KB
+      const { saveKnowledgeEntry, markKnowledgeSuperseded } = await import(
+        "@/lib/knowledge"
+      );
+
+      // Strip @-mentions and trim, matching the normalization used
+      // for questions, so raw Slack tokens don't end up in the KB.
+      const correctionText = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
+      const correctionId = await saveKnowledgeEntry(correctionText);
+
+      // Clear the pending state as soon as the correction is durably
+      // saved — everything after this point is best-effort. If a later
+      // step throws, the error reply must NOT leave pending state
+      // behind, or the user's re-reply would save a duplicate entry.
+      await kv.del(pendingKey);
+
+      // Retire the KB entries flagged at 👎 time: mark them superseded
+      // by the correction instead of leaving them visible (or deleting
+      // them and losing history). Text-matched; entries already
+      // superseded or archived in the meantime are skipped. See #124.
+      let supersededCount = 0;
+      try {
+        for (const flaggedText of pending.flaggedKB) {
+          if (await markKnowledgeSuperseded(flaggedText, correctionId)) {
+            supersededCount++;
+          }
+        }
+      } catch (err) {
+        // Correction is saved; a KV flake while retiring old entries
+        // must not fail the flow. Worst case a stale entry stays
+        // visible — observable via the count on correction_saved.
+        rlog("correction_supersede_error", {
+          channel,
+          threadTs,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      // Save the negative feedback NOW with the actual correction text
+      await saveFeedback({
+        type: "negative",
+        question: pending.question || "",
+        detail: `Correction: "${correctionText.slice(0, 200)}"`,
+        timestamp: new Date().toISOString().split("T")[0],
+      });
+      // Close the 👎 → correction funnel with latency from the
+      // moment 👎 was registered.
+      rlog("correction_saved", {
+        channel,
+        threadTs,
+        answerTs: pending.answerTs ?? null,
+        correctionLength: correctionText.length,
+        timeSincePendingMs: Date.now() - pending.pendingAt,
+        flaggedKBCount: pending.flaggedKB.length,
+        supersededCount,
+        correctionSample: correctionText.slice(0, 100),
+      });
+
+      await replyInThread(
+        channel,
+        threadTs,
+        `:white_check_mark: Saved to knowledge base: _"${correctionText.slice(0, 100)}"_`,
+      );
+      return;
+    }
+
+    // ── Bulk-confirm interception (#122) ────────────────────────────
+    // If there's a pending issue batch in this thread AND the user's
+    // reply is a bulk-confirm phrase ("confirm all", "yes", etc.),
+    // create all issues instead of running the agent. `isBulkConfirmText`
+    // is strict (short intent-only phrases) so normal conversation is
+    // unaffected.
+    if (isBulkConfirmText(userMessage)) {
+      const pointerKey = batchThreadPointerKey(channel, threadTs);
+      const batchFirstTs = await kv.get<string>(pointerKey);
+      if (batchFirstTs) {
+        const outcome = await executeBatchCreation(
+          channel,
+          threadTs,
+          batchFirstTs,
+          user,
+          "text",
+          rlog,
+        );
+        if (outcome.claimed) return;
+        // Not claimed → either the batch expired or another handler
+        // consumed it. Fall through to the normal agent flow so the
+        // user still gets a response.
+      }
+    }
+
+    // Fetch thread messages — used for both participation check and context
+    const bid = botId || (await getBotUserId());
+    const threadMessages = await fetchThreadMessages(channel, threadTs);
+    const botInThread = bid ? threadMessages.some((m) => m.user === bid) : false;
+    if (!bid || !botInThread) return;
+
+    const cleanMessage = userMessage.replace(/<@[A-Z0-9]+>/g, "").trim();
+
+    // Follow-up gate (#126): the structural heuristic above only says
+    // "maybe" — ask the fast-model classifier whether this message is
+    // actually addressed to the bot. Fail-closed: any classifier
+    // error/timeout/low-confidence verdict means we stay silent. Runs
+    // BEFORE the thinking message so a decline produces ZERO Slack
+    // writes — just the log event below. The decline returns from
+    // inside the caller's try, so marker cleanup (route after()
+    // finally / sweep finally) still runs — a sweep-retried follow-up
+    // re-runs this gate, and a declined retry cleans up its marker
+    // instead of dangling into give_up.
+    const followupEval = await evaluateFollowup(
+      {
+        invocation: "followup",
+        transcript: extractTranscriptTail(threadMessages, bid),
+        question: cleanMessage,
+      },
+      { log: rlog },
+    );
+    if (!followupEval.proceed) {
+      rlog("followup_reply_declined", {
+        reason:
+          followupEval.decision === null
+            ? "classifier_unavailable"
+            : followupEval.decision.shouldReply
+              ? "low_confidence"
+              : "not_addressed",
+        confidence: followupEval.decision?.shouldReplyConfidence ?? null,
+        channel,
+        threadTs,
+      });
+      return;
+    }
+    rlog("followup_agent_start", { channel, threadTs });
+
+    thinkTs = await replyInThread(
+      channel, threadTs,
+      THINKING_HEADER,
+    );
+
+    // Build proper multi-turn conversation history from thread
+    // (uses Anthropic's native message format, not string hacking)
+    const history = buildConversationHistory(threadMessages, bid);
+
+    // Thread participants for #80 — resolve IDs now so the agent can
+    // @-mention teammates in its answer.
+    const followupParticipantIds = extractParticipantIds(threadMessages, bid);
+    const followupParticipants = followupParticipantIds.length > 0
+      ? await resolveParticipants(followupParticipantIds)
+      : undefined;
+
+    // Pre-match for thread follow-ups too; the effort hint from the
+    // classifier rides along on the user message (never the system
+    // prompt — see effort-routing.ts on prompt caching).
+    const followupTopics = await getCachedTopics();
+    const followupMatches = matchTopicsToQuestion(cleanMessage, followupTopics);
+    const followupMessage =
+      buildQuestionHints(cleanMessage, followupMatches) + buildEffortHint(followupEval.effort);
+
+    // Mirror of the mention-flow progress updater — see comment
+    // there + #110 for rationale.
+    const followupProgress = createThrottledUpdater(async (text) => {
+      if (thinkTs) {
+        await updateMessage(channel, thinkTs, text);
+      }
+    }, 1200);
+
+    const result = await runAgent(
+      followupMessage,
+      history,
+      rlog,
+      followupParticipants,
+      (toolName, input) => {
+        followupProgress.update(buildThinkingMessage(toolName, input));
+      },
+      { maxRounds: EFFORT_BUDGETS[followupEval.effort].maxRounds, effort: followupEval.effort },
+    );
+    await followupProgress.flush();
+
+    const text = toSlackMrkdwn(result.text);
+    const rankedRefs = rankReferences(result.references, result.text);
+    const refsFooter = formatReferences(rankedRefs);
+    // Optional compact telemetry footer (#79) — mirrors the mention flow.
+    const replyFooter = isReplyFooterEnabled(process.env)
+      ? formatReplyFooter(result.metrics, rlog.requestId)
+      : "";
+
+    if (result.issueProposals.length > 0) {
+      const proposals = result.issueProposals;
+      const proposalBlock = formatBatchProposalMessage(proposals);
+      const finalBody = [text, "", proposalBlock].join("\n") + refsFooter + replyFooter;
+
+      const posted = await postReplyInChunks({
+        channel,
+        threadTs,
+        thinkingTs: thinkTs,
+        text: finalBody,
+      });
+      if (posted.chunks > 0) thinkTs = undefined;
+
+      if (posted.firstTs) {
+        const record: PendingIssueBatch = {
+          proposals,
+          proposedAt: Date.now(),
+          requestedBy: user,
+          threadTs,
+          messageFirstTs: posted.firstTs,
+        };
+        await kv.set(batchKey(channel, posted.firstTs), record, { ex: BATCH_TTL_SEC });
+        await kv.set(
+          batchThreadPointerKey(channel, threadTs),
+          posted.firstTs,
+          { ex: BATCH_TTL_SEC },
+        );
+        rlog("issue_batch_proposed", {
+          count: proposals.length,
+          threadTs,
+          channel,
+          firstTs: posted.firstTs,
+          sampleTitles: proposals.slice(0, 3).map((p) => p.title.slice(0, 80)),
+          requestingUser: user,
+        });
+      }
+      rlog("answer_posted", {
+        channel,
+        threadTs,
+        chunks: posted.chunks,
+        kind: "proposal",
+        proposalCount: proposals.length,
+      });
+    } else {
+      const finalBody = text + refsFooter + replyFooter;
+      const posted = await postReplyInChunks({
+        channel,
+        threadTs,
+        thinkingTs: thinkTs,
+        text: finalBody,
+      });
+      if (posted.chunks > 0) thinkTs = undefined;
+      rlog("answer_posted", { channel, threadTs, chunks: posted.chunks });
+
+      if (posted.firstTs && posted.allTs.length > 0) {
+        const postedAt = Date.now();
+        const referenceTypes = deriveReferenceTypes(result.references);
+        await Promise.all(
+          posted.allTs.map((ts, chunkIndex) =>
+            storeQAContext(channel, ts, {
+              question: cleanMessage,
+              answer: result.text.slice(0, 500),
+              references: result.references.map((r) => r.label),
+              answerTs: posted.firstTs!,
+              chunkIndex,
+              chunkCount: posted.chunks,
+              postedAt,
+              referenceTypes,
+            }),
+          ),
+        );
+      }
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    rlog("agent_turn_failed", { flow: "thread_followup", message: msg });
+    Sentry.captureException(err, { tags: { flow: "thread_followup" } });
+    await replyInThread(
+      channel,
+      threadTs,
+      `Something went wrong while processing your request. Error: ${msg}`,
+    );
+  } finally {
+    // Safety net: delete thinking message if it wasn't cleaned up
+    if (thinkTs) {
+      await deleteMessage(channel, thinkTs);
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/sweep",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements #125 — closes the two reliability gaps in issue creation and background processing.

**Phase A — idempotent `createIssue`.** Every creation path (batch confirm, legacy parser fallback) runs through `executeIdempotent` keyed by a sha256 of the stable-serialized proposal (`labels: undefined ≡ []`, order-insensitive — both paths for the same proposal hash identically). Protocol: replay a completed record (original issue URL, no second GitHub call), SET-NX 60s lock against concurrent execution with a mandatory re-read on a lost race, 30-day completed TTL, lock release + rethrow on failure. A KV outage **fails open** (`idempotency_degraded`) — availability over strict idempotency. The existing batch del-claim + tombstone protocol is unchanged; idempotency wraps the innermost call.

**Phase B — recoverable turns.** Accepted mention/follow-up events write a `processing:` marker before `after()` work and clear it in `finally`, so only true container death (timeout/OOM/deploy kill) leaves one behind. A `CRON_SECRET`-gated `/api/cron/sweep` (every 5 min) claims stale markers atomically, verifies the thread wasn't actually answered (thinking messages excluded — a mid-run death always leaves one behind), retries once via the extracted `turn-runner.ts`, and posts a visible failure notice after a second death. `PROCESSING_MAX_AGE_MS` (15m) strictly exceeds the route's `maxDuration` (300s) — pinned by a test — so the sweep can structurally never double-answer a live turn.

**Telemetry**: stable event vocabulary (`agent_turn_failed`, `webhook_handler_failed`, `tool_call_failed`, `idempotency_*`, `recovery_*`), the logger severity predicate now routes `*_failed` to error level, and a new root `TELEMETRY.md` carries incident-response query recipes (linked from README/troubleshooting; observability.md remains the event catalog).

## Notes for review

- `route.ts` shrank to guards + marker lifecycle; the two `after()` bodies moved verbatim-where-possible into `src/lib/turn-runner.ts` (shared by route and sweep).
- On a Hobby plan the `*/5` cron degrades to ~daily; recovery correctness is cadence-independent (documented in setup.md).
- Beyond-spec hardening: per-member try/catch in the sweep (`recovery_sweep_member_failed`) so one bad thread can't abort the run; `recovery_sweep_unauthorized` on bad/missing bearer.

## Testing

TDD: both spec files confirmed RED (module-not-found) before implementation. +55 new tests (idempotency protocol incl. NX-race re-read and fail-open matrix; sweep decision boundaries at exactly max-age; cron auth fail-closed matrix; marker lifecycle). Full suite **580 passing**, typecheck clean, `next build` clean (shows the new cron route).

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
