### PR TITLE
feat: Hybrid lexical + semantic retrieval via Upstash Vector (closes #127)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,17 @@ GITHUB_REPO=your-repo
 UPSTASH_REDIS_REST_URL=https://...
 UPSTASH_REDIS_REST_TOKEN=...
 
+# Upstash Vector (optional — hybrid lexical + semantic retrieval, #127)
+# Provision an Upstash Vector index created WITH a built-in embedding
+# model: the app upserts and queries raw text (the SDK's `data` field)
+# and the index embeds server-side. An index without an embedding model
+# will reject raw-text operations.
+# If unset, the bot degrades gracefully to lexical-only retrieval:
+# search_repo returns code results only and KB recall runs keyword
+# matching only (logged as vector_unavailable — expected, not an error).
+UPSTASH_VECTOR_REST_URL=https://...
+UPSTASH_VECTOR_REST_TOKEN=...
+
 # Sentry (optional — for structured log capture + error tracking)
 # Without SENTRY_DSN the SDK is a silent no-op. With it, structured
 # events (agent_start, agent_complete, token usage, errors) flow to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ A Slack agent with Claude AI intelligence and full GitHub repo access — reads 
 
 - **Runtime**: Vercel (Next.js serverless functions)
 - **Slack**: Webhook mode via Next.js API route (`/api/slack`), ack-then-process via `after()`
-- **AI**: Anthropic Claude API with tool use (7 tools, adaptive per-turn round budget: quick 4 / standard 10 / deep 15)
+- **AI**: Anthropic Claude API with tool use (8 tools, adaptive per-turn round budget: quick 4 / standard 10 / deep 15)
 - **GitHub**: Octokit REST API (fine-grained PAT, read-only for code/PRs, read-write for issues)
-- **Knowledge**: Vercel KV (corrections, feedback, repo index cache)
+- **Knowledge**: Vercel KV (corrections, feedback, repo index cache) + Upstash Vector (semantic recall for KB + docs, graceful lexical-only degradation)
 - **Context**: CLAUDE.md + KB + feedback + repo index + source hierarchy + search strategy + recency/brevity rules
 - **Progress**: Live thinking messages with contextual emoji, deleted on answer
 - **Formatting**: Markdown-to-Slack mrkdwn conversion, typed references with emoji (📄📖🎫🔀📜), ranked by source-of-truth hierarchy, capped at 7
@@ -64,9 +64,12 @@ src/
     references.ts         — Typed references: ranking, dedup, emoji formatting
     split-reply.ts        — Pure splitter for long Slack replies (paragraph/line/word/fence-aware)
     kv.ts                 — @upstash/redis wrapper with Sentry observability (kv_op + kv_error events)
+    vector.ts             — @upstash/vector wrapper (non-throwing, vector_op/vector_error events, 2s timeout)
+    retrieval.ts          — Pure hybrid-retrieval primitives (RRF fusion, age boost, lexical ranking)
   tools/
     index.ts              — Tool registry and executor
     search-code.ts        — GitHub code search tool
+    search-repo.ts        — Hybrid code + docs search (lexical + semantic, RRF-fused)
     read-file.ts          — GitHub file/directory read tool
     list-issues.ts        — GitHub issue list/lookup tool
     list-commits.ts       — Recent commits on main (with dates)
@@ -88,6 +91,7 @@ docs/
     message-splitting.md  — Long-reply chunking architecture (split-reply + boundary guard)
     issue-creation.md     — Batch issue proposals + bulk-confirm flow
     effort-routing.md     — Fast-model follow-up gate + per-turn effort budgets
+    hybrid-retrieval.md   — Lexical + semantic retrieval (Upstash Vector, RRF fusion, degradation)
 TELEMETRY.md              — Incident-response event vocabulary + Sentry query recipes
 vercel.json               — Vercel Cron schedule for the recovery sweep
 ```
@@ -122,3 +126,5 @@ npm run test:watch    # Watch mode for development
 | `GITHUB_OWNER` | GitHub org/user |
 | `GITHUB_REPO` | Repository name |
 | `CRON_SECRET` | Bearer token for `/api/cron/sweep` (unset = sweep denies all requests) |
+| `UPSTASH_VECTOR_REST_URL` | Optional — Upstash Vector index (built-in embedding model) for hybrid retrieval |
+| `UPSTASH_VECTOR_REST_TOKEN` | Optional — Vector index token; unset pair degrades to lexical-only |

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ See the [full setup guide](docs/setup.md) for Slack app creation, GitHub PAT, Ve
 | Source-of-Truth Hierarchy | [docs/features/source-hierarchy.md](docs/features/source-hierarchy.md) |
 | Auto-Correction on 👎 | [docs/features/auto-correction.md](docs/features/auto-correction.md) |
 | Live Progress Updates | [docs/features/progress-ux.md](docs/features/progress-ux.md) |
+| Hybrid Retrieval (lexical + semantic) | [docs/features/hybrid-retrieval.md](docs/features/hybrid-retrieval.md) |
 | Path Annotations (.battle-mage.json) | [docs/features/config.md](docs/features/config.md) |
 | Adaptive Effort Routing | [docs/features/effort-routing.md](docs/features/effort-routing.md) |
 
@@ -65,6 +66,8 @@ See the [full setup guide](docs/setup.md) for Slack app creation, GitHub PAT, Ve
 | `GITHUB_PAT_BM` | Fine-grained PAT scoped to your target repo |
 | `GITHUB_OWNER` | GitHub org or username |
 | `GITHUB_REPO` | Repository name |
+| `UPSTASH_VECTOR_REST_URL` | Optional — Upstash Vector index (built-in embedding model) for hybrid retrieval |
+| `UPSTASH_VECTOR_REST_TOKEN` | Optional — token for the Vector index; without the pair, search degrades to lexical-only |
 
 ## How It Works
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Battle Mage is a Slack agent that runs as a Next.js serverless function on Vercel. It receives webhook events from Slack, processes them with Claude AI and 9 GitHub tools (code search, file read, issues, PRs, commits, issue creation, knowledge base), and replies in-thread with cited references.
+Battle Mage is a Slack agent that runs as a Next.js serverless function on Vercel. It receives webhook events from Slack, processes them with Claude AI and 8 tools (code search, hybrid code+docs search, file read, issues, PRs, commits, issue creation, knowledge base), and replies in-thread with cited references.
 
 ## High-Level Flow
 
@@ -120,7 +120,7 @@ The function `assembleSystemPrompt()` takes these inputs:
 |-------|--------|-------------|------|
 | `owner` / `repo` | Environment variables | Target GitHub repository | both |
 | `claudeMd` | `CLAUDE.md` in the target repo | Project-specific context (cached per cold start) | volatile |
-| `knowledge` | Vercel KV | Knowledge base entries (corrections from users) | volatile |
+| `knowledge` | Vercel KV + Upstash Vector | Top-k KB recall — the ≤5 entries most relevant to the current question (hybrid lexical + semantic retrieval, see [Hybrid Retrieval](./features/hybrid-retrieval.md)), not the full KB | volatile |
 | `feedback` | Vercel KV | Recent thumbs up/down feedback summaries | volatile |
 | `repoIndex` | Vercel KV (lazy-rebuilt) | Auto-generated topic map of the repository | volatile |
 | `pathAnnotations` | `.battle-mage.json` in target repo | Per-path trust annotations | volatile |
@@ -130,7 +130,7 @@ The function `assembleSystemPrompt()` takes these inputs:
 1. `<identity>` — who the bot is (Battle Mage), where it runs (Slack), which repo it reads
 2. `<core-principles>` — verify before asserting, cite specifically, thread-only, confirm issue creation
 3. `<source-hierarchy>` — code > tests > docs > KB > feedback, with conflict-detection rules (see [Source Hierarchy](./features/source-hierarchy.md))
-4. `<tools>` — canonical names of the 7 GitHub tools
+4. `<tools>` — canonical names of the 8 tools
 5. `<search-strategy>` — budget tool rounds, repo map first, read 2–3 files max, synthesize early
 6. `<knowledge-base-usage>` — when and how to save corrections via `save_knowledge`
 7. `<output-contract>` — Slack mrkdwn format, anti-narration bans, brevity, recency (see below)
@@ -141,10 +141,12 @@ The function `assembleSystemPrompt()` takes these inputs:
 - `## Project Context (from CLAUDE.md)` — the target repo's CLAUDE.md if present
 - `## Repository Map (auto-generated index)` — the topic index if rebuilt
 - `## Path Annotations (from .battle-mage.json)` — trust annotations if configured
-- `## Knowledge Base (learned corrections)` — KB entries from Vercel KV if non-empty
+- `## Knowledge Base (learned corrections)` — top-k KB recall for the current question, if any entries match
 - `## User Feedback (from 👍/👎 reactions)` — feedback summary if non-empty
 
 Each volatile section is omitted when its data is null, so a fresh repo with no KB/feedback/index produces a compact prompt.
+
+Because KB recall is computed per turn from the user's question, the knowledge section lives in the volatile zone by construction — per-turn recall keeps the KB out of the stable cache zone, so a changing question can never invalidate the cached stable prompt.
 
 ### Output contract (what makes replies Slack-native)
 
@@ -165,7 +167,7 @@ The zoning enables Anthropic prompt caching. A single `cache_control: {type: "ep
 
 `assembleSystemBlocks()` returns an `Anthropic.TextBlockParam[]` rather than a plain string. The first block carries `cache_control: {type: "ephemeral"}` — Anthropic caches every block up through that marker. The second block (volatile data) has no cache_control and is processed uncached on every turn.
 
-The `tools` array in `src/tools/index.ts` is similarly cached: the last tool (`save_knowledge`) carries the cache_control marker so all seven tool definitions cache together.
+The `tools` array in `src/tools/index.ts` is similarly cached: the last tool (`save_knowledge`) carries the cache_control marker so all eight tool definitions cache together. New tools register BEFORE `save_knowledge` so the marker stays on the last element.
 
 Cache metrics are logged in the `agent_complete` event per turn:
 
@@ -253,7 +255,7 @@ The `finally` block still deletes the thinking message as a safety net if the tu
 
 ## Tool System
 
-Seven tools are registered with Claude's tool-use API:
+Eight tools are registered with Claude's tool-use API:
 
 | Tool | GitHub API | Returns References? |
 |------|-----------|-------------------|
@@ -263,7 +265,8 @@ Seven tools are registered with Claude's tool-use API:
 | `list_commits` | `repos.listCommits` | Yes — typed as `commit`, includes SHA + message |
 | `list_prs` | `pulls.list` | Yes — typed as `pr`, includes number + title |
 | `create_issue` | None (proposal only) | No |
-| `save_knowledge` | None (Vercel KV) | No |
+| `search_repo` | `search.code` + Upstash Vector | No (discovery only) — hybrid code + docs search, see [Hybrid Retrieval](./features/hybrid-retrieval.md) |
+| `save_knowledge` | None (Vercel KV + Upstash Vector) | No |
 
 The tool registry is in `src/tools/index.ts`. Each tool is a separate file that exports:
 - A `Tool` definition (name, description, input schema) for Claude's API
@@ -355,9 +358,11 @@ src/
     slack.ts              -- Slack client, signature verification, message helpers
     claude.ts             -- Anthropic client, system prompt assembly, agent loop
     github.ts             -- Octokit client (search, read, issues, PRs, commits, tree)
-    knowledge.ts          -- Knowledge base (Vercel KV sorted set)
+    knowledge.ts          -- Knowledge base (Vercel KV sorted set + vector embedding)
     feedback.ts           -- Feedback storage (Vercel KV) and Q&A context
-    repo-index.ts         -- Repository topic index (lazy rebuild on SHA change)
+    repo-index.ts         -- Repository topic index (lazy rebuild on SHA change) + doc chunk embedding
+    vector.ts             -- Upstash Vector wrapper (non-throwing, observability, timeout)
+    retrieval.ts          -- Pure RRF fusion, age boost, lexical ranking
     auto-correct.ts       -- Stale KB entry detection and doc reference flagging
     progress.ts           -- Progress message formatter (tool name to emoji + status)
     mrkdwn.ts             -- Markdown to Slack mrkdwn converter
@@ -366,6 +371,7 @@ src/
   tools/
     index.ts              -- Tool registry and executor
     search-code.ts        -- GitHub code search
+    search-repo.ts        -- Hybrid code + docs search (lexical + semantic, RRF-fused)
     read-file.ts          -- GitHub file/directory read
     list-issues.ts        -- GitHub issue list and lookup
     list-commits.ts       -- Recent commits on main

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -198,6 +198,7 @@ src/
   tools/
     index.ts              -- Tool registry + executor
     search-code.ts        -- search_code tool
+    search-repo.ts        -- search_repo tool (hybrid code + docs)
     read-file.ts          -- read_file tool
     list-issues.ts        -- list_issues tool
     list-commits.ts       -- list_commits tool

--- a/docs/features/hybrid-retrieval.md
+++ b/docs/features/hybrid-retrieval.md
@@ -16,7 +16,7 @@ Both are powered by [Upstash Vector](https://upstash.com/docs/vector) with a **b
 
 ### Doc chunks (write path: `src/lib/repo-index.ts`)
 
-Doc embedding runs **only inside the SHA-changed branch** of `getOrRebuildIndex()`, after the topic-index KV writes:
+Doc embedding runs **only inside the SHA-changed branch** of `getOrRebuildIndex()`, after the topic-index KV writes, and is **fire-and-forget**: the rebuild returns its summary immediately and the embed (content fetches + upsert) completes in the background within the invocation window, so it never delays the agent's turn. Tradeoff: a container killed mid-embed leaves the docs pointer on the previous SHA's namespace until the next SHA change — the doc arm serves slightly stale chunks, never a half-written namespace.
 
 1. `chunkMarkdownByHeadings(path, content)` splits each `docs/**/*.md` on `#`/`##`/`###` headings (`####` stays inside its parent section). Preamble content before the first heading becomes a chunk titled from the path. Sections over `MAX_CHUNK_CHARS` (1500) are re-split on paragraph boundaries. Ids are deterministic `${path}#${ordinal}`; metadata carries `{path, heading, excerpt}`.
 2. Content fetches are capped at `MAX_DOCS_TO_EMBED` (50) per rebuild — the same GitHub fan-out lesson as #108. Exceeding the cap logs `docs_embed_capped`.
@@ -32,7 +32,7 @@ upsert chunks into {owner}/{repo}:docs:{newSha}     (1)
        └─ best-effort deleteNamespace(previous)      (3)
 ```
 
-If the upsert fails, the pointer is untouched — queries keep serving the previous generation — and `docs_embed_failed` records the gap. The index rebuild itself still succeeds; embedding is never a hard dependency.
+If the upsert fails, the pointer is untouched — queries keep serving the previous generation — and `docs_embed_failed` records the gap. Likewise, an **empty chunk set** (every doc read failed, or all docs were empty) aborts before any pointer/namespace mutation with `docs_embed_empty` — the pointer must never swap to an empty namespace. The index rebuild itself always succeeds; embedding is never a hard dependency.
 
 ## Retrieval and Fusion (`src/lib/retrieval.ts`)
 
@@ -48,6 +48,8 @@ Both retrieval surfaces fuse two ranked arms with **Reciprocal Rank Fusion**: ea
 The age boost is deliberately smaller than the smallest adjacent-rank RRF gap a single arm can produce, so freshness only ever breaks ties between effectively-equal candidates — it never overrides relevance. Exact ties keep enumeration order: lexical-arm candidates first.
 
 ### KB recall (`getKnowledgeRecallAsMarkdown(question)`)
+
+Recall keys off the user's **clean question**: the turn runner passes it as `recallQuestion` in `RunAgentOptions`, because the `userMessage` the model receives is augmented with topic/effort hints that would pollute both the lexical tokens and the embedding query.
 
 - 0 visible entries → section omitted (null).
 - ≤ `RECALL_TOP_K` entries → render all; **no vector call** (the full KB already fits).
@@ -74,6 +76,7 @@ All Upstash Vector access flows through one chokepoint mirroring `kv.ts` (#117),
 | Vector op error or >2s timeout | `vector_error` (op, namespace, durationMs, errorClass, errorMessage) + Sentry tagged `vector.op` | Same as above for that one call; saves/rebuilds still succeed |
 | Docs never embedded (no pointer) | none — `getDocsVectorNamespace()` returns null | `search_repo` lexical-only; vector store never queried |
 | Doc upsert failure during rebuild | `docs_embed_failed` | Pointer untouched — previous generation keeps serving; rebuild succeeds |
+| Rebuild produces zero chunks | `docs_embed_empty` | Pointer/namespace untouched — previous generation keeps serving |
 | > 50 docs in repo | `docs_embed_capped` | Only the first 50 docs are embedded |
 
 The bot always keeps working lexically — the vector layer is an accelerator, never a dependency.
@@ -85,6 +88,7 @@ The bot always keeps working lexically — the vector layer is an accelerator, n
 - `vector_error` — `{op, namespace, durationMs, errorClass, errorMessage}` + Sentry tag `vector.op`
 - `docs_embedded` — `{sha, docCount, chunkCount, duration_ms}`
 - `docs_embed_capped` — `{totalDocs, cap}`
+- `docs_embed_empty` — `{sha, docCount}` (zero chunks — pointer untouched)
 - `docs_embed_failed` — `{sha, ...}`
 
 See [Observability](../observability.md) for the full catalog.

--- a/docs/features/hybrid-retrieval.md
+++ b/docs/features/hybrid-retrieval.md
@@ -1,0 +1,101 @@
+# Hybrid Retrieval
+
+Hybrid lexical + semantic retrieval (#127) gives the bot two things:
+
+1. **`search_repo` tool** — a hybrid search across code AND docs. A lexical GitHub code-search arm is fused with a semantic (meaning-based) doc-chunk arm, so conceptual questions ("how does message splitting work?") find the right material even when no keyword matches.
+2. **Per-turn KB recall** — instead of dumping the entire knowledge base into every system prompt, only the top entries relevant to the *current question* are loaded (top matches, not the full KB), keeping the prompt bounded as the KB grows.
+
+Both are powered by [Upstash Vector](https://upstash.com/docs/vector) with a **built-in embedding model** — the app sends raw text, the index embeds server-side. No embedding API calls from our code.
+
+## Embedding Pipeline
+
+### KB entries (write path: `src/lib/knowledge.ts`)
+
+- `saveKnowledgeEntry` embeds each new entry into the **KB namespace** — `{owner}/{repo}:kb` — keyed by the entry's id, with the timestamp as metadata. The upsert is **best-effort**: KV remains the source of truth, and a vector failure never fails the save.
+- Retire flows (`supersedeKnowledgeEntry`, `markKnowledgeSuperseded`, `archiveKnowledgeEntry`) best-effort delete the retired entry's vector. Legacy id-less entries were never embedded, so they are skipped.
+
+### Doc chunks (write path: `src/lib/repo-index.ts`)
+
+Doc embedding runs **only inside the SHA-changed branch** of `getOrRebuildIndex()`, after the topic-index KV writes:
+
+1. `chunkMarkdownByHeadings(path, content)` splits each `docs/**/*.md` on `#`/`##`/`###` headings (`####` stays inside its parent section). Preamble content before the first heading becomes a chunk titled from the path. Sections over `MAX_CHUNK_CHARS` (1500) are re-split on paragraph boundaries. Ids are deterministic `${path}#${ordinal}`; metadata carries `{path, heading, excerpt}`.
+2. Content fetches are capped at `MAX_DOCS_TO_EMBED` (50) per rebuild — the same GitHub fan-out lesson as #108. Exceeding the cap logs `docs_embed_capped`.
+3. Chunks are upserted into a **SHA-scoped namespace** — `{owner}/{repo}:docs:{sha}`.
+
+## Namespace / Pointer Lifecycle (docs)
+
+The KV key `index:vector_docs_ns` points at the docs namespace currently serving queries. The generation swap is ordered so readers never see a half-populated namespace:
+
+```
+upsert chunks into {owner}/{repo}:docs:{newSha}     (1)
+  └─ on success → set index:vector_docs_ns pointer  (2)
+       └─ best-effort deleteNamespace(previous)      (3)
+```
+
+If the upsert fails, the pointer is untouched — queries keep serving the previous generation — and `docs_embed_failed` records the gap. The index rebuild itself still succeeds; embedding is never a hard dependency.
+
+## Retrieval and Fusion (`src/lib/retrieval.ts`)
+
+Both retrieval surfaces fuse two ranked arms with **Reciprocal Rank Fusion**: each arm contributes `1/(RRF_K + rank)` per candidate (`RRF_K = 60`, ranks 1-based, within-arm duplicates keep their best rank), so items ranked well in both arms win without the arms' raw scores needing to be comparable.
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `RRF_K` | 60 | RRF dampening constant |
+| `RECALL_TOP_K` | 5 | KB entries surfaced into the prompt per turn |
+| `MAX_ARM_RESULTS` | 10 | Cap per arm before fusion |
+| `AGE_TIER_BOOSTS` | 7d: +0.00015, 30d: +0.0001, 90d: +0.00005 | Freshness tie-breaker (KB recall only) |
+
+The age boost is deliberately smaller than the smallest adjacent-rank RRF gap a single arm can produce, so freshness only ever breaks ties between effectively-equal candidates — it never overrides relevance. Exact ties keep enumeration order: lexical-arm candidates first.
+
+### KB recall (`getKnowledgeRecallAsMarkdown(question)`)
+
+- 0 visible entries → section omitted (null).
+- ≤ `RECALL_TOP_K` entries → render all; **no vector call** (the full KB already fits).
+- Otherwise: lexical arm = `lexicalRank` (distinct question tokens substring-matching entry text, ties to newer timestamps) + semantic arm = `vectorQuery` on the KB namespace; fuse with timestamps, cap at 5, no padding when fewer match.
+- **K1 invariant**: vector ids are mapped back through the visible entry set fetched in the same call — retired (superseded/archived) or unknown ids can never resurface through a stale embedding.
+- Both arms empty → fall back to the newest `RECALL_TOP_K` entries.
+
+### `search_repo` (`src/tools/search-repo.ts`)
+
+- Lexical arm: existing `searchCode` with tooling paths filtered, ids `code:${path}`.
+- Semantic arm: `index:vector_docs_ns` pointer → `vectorQuery`, ids `doc:${chunkId}`.
+- Both arms run in parallel; fusion is untimestamped (repo freshness is per-SHA, not per-result).
+- Results render as typed lines — `[code]` with path/score/URL, `[doc]` with path, heading, and excerpt — and produce **no references** (search results are discovery aids).
+
+## The Vector Wrapper (`src/lib/vector.ts`)
+
+All Upstash Vector access flows through one chokepoint mirroring `kv.ts` (#117), with a **non-throwing public API**: `vectorUpsert`/`vectorDelete`/`vectorDeleteNamespace` return booleans, `vectorQuery` returns `VectorMatch[] | null` (`null` = degraded, `[]` = available but no matches). Every op is raced against `VECTOR_OP_TIMEOUT_MS` (2s) so recall can never stall a turn. The SDK client is constructed lazily and only when configured. Query and entry text are **never logged**.
+
+## Degradation Matrix
+
+| Condition | Signal | What degrades |
+|-----------|--------|---------------|
+| `UPSTASH_VECTOR_REST_*` unset | `vector_unavailable` (op, reason: `not_configured`) — expected state, no Sentry | KB recall runs lexical-only; `search_repo` doc arm empty; doc embedding skipped entirely (no GitHub content fan-out) |
+| Vector op error or >2s timeout | `vector_error` (op, namespace, durationMs, errorClass, errorMessage) + Sentry tagged `vector.op` | Same as above for that one call; saves/rebuilds still succeed |
+| Docs never embedded (no pointer) | none — `getDocsVectorNamespace()` returns null | `search_repo` lexical-only; vector store never queried |
+| Doc upsert failure during rebuild | `docs_embed_failed` | Pointer untouched — previous generation keeps serving; rebuild succeeds |
+| > 50 docs in repo | `docs_embed_capped` | Only the first 50 docs are embedded |
+
+The bot always keeps working lexically — the vector layer is an accelerator, never a dependency.
+
+## Event Names
+
+- `vector_op` — `{op, namespace, durationMs, count}` per successful op
+- `vector_unavailable` — `{op, reason: "not_configured"}` (NOT an error)
+- `vector_error` — `{op, namespace, durationMs, errorClass, errorMessage}` + Sentry tag `vector.op`
+- `docs_embedded` — `{sha, docCount, chunkCount, duration_ms}`
+- `docs_embed_capped` — `{totalDocs, cap}`
+- `docs_embed_failed` — `{sha, ...}`
+
+See [Observability](../observability.md) for the full catalog.
+
+## Relationship to the Topic Index
+
+The [repo index](./repo-index.md) and the docs vector index are complementary and share the same rebuild trigger (HEAD SHA change):
+
+- The **topic index** is a path-classified map rendered into the system prompt — it tells the model *where areas of the repo live* before any tool call.
+- The **docs vector index** is a queryable store of doc *content* chunks — it answers `search_repo` calls at tool time.
+
+## Provisioning
+
+Create an Upstash Vector index **with a built-in embedding model** (raw-text upsert/query via the `data` field) and set `UPSTASH_VECTOR_REST_URL` / `UPSTASH_VECTOR_REST_TOKEN`. See [Setup](../setup.md). Without them, everything above degrades gracefully.

--- a/docs/features/knowledge-base.md
+++ b/docs/features/knowledge-base.md
@@ -23,6 +23,8 @@ Entries are never deleted when corrected — they carry lifecycle fields instead
 
 Entries with either marker are hidden from the prompt but preserved in the sorted set, so the history of what was believed and why it changed survives. Legacy entries written before ids existed still parse and can be superseded by matching their text.
 
+Each entry is also embedded into an Upstash Vector namespace on save (best-effort — KV remains the source of truth), and retire flows delete the retired entry's vector. This powers semantic recall; see [Hybrid Retrieval](./hybrid-retrieval.md).
+
 ## How Entries Are Saved
 
 ### Via the `save_knowledge` Tool
@@ -50,7 +52,16 @@ When a user reacts with :thumbsdown: and then replies with a correction, the fla
 
 ## How Entries Flow Into the System Prompt
 
-The function `getKnowledgeAsMarkdown()` fetches the *visible* entries (not superseded, not archived) from KV and formats them as a timestamped list ending with a stale-context footer:
+Since #127 the prompt carries **top-k recall, not a full dump**. Each turn, `getKnowledgeRecallAsMarkdown(question)` selects the `RECALL_TOP_K` (5) *visible* entries most relevant to the current question:
+
+- **Small KB** (≤5 visible entries): all entries render — no retrieval runs, no vector call.
+- **Larger KB**: a lexical arm (distinct question tokens matching entry text, ties broken toward newer entries) and a semantic arm (Upstash Vector similarity over the embedded entries) are fused with Reciprocal Rank Fusion plus a tiny freshness tie-breaker. Only ids present in the visible set fetched in the same call can surface — a retired entry's leftover embedding can never resurrect it.
+- **No matches in either arm**: the newest 5 entries render as a fallback.
+- **Vector layer unconfigured or degraded**: recall silently runs lexical-only.
+
+See [Hybrid Retrieval](./hybrid-retrieval.md) for the fusion math and degradation matrix. This keeps the prompt bounded as the KB grows — 500 saved corrections still cost at most 5 lines per turn.
+
+The selected entries are formatted as a timestamped list ending with a stale-context footer:
 
 ```text
 - [2026-03-28] The auth module lives in app/Services/Auth, not app/Http/Auth
@@ -99,13 +110,14 @@ The `knowledge.ts` module exports these functions:
 
 | Function | Description |
 |----------|-------------|
-| `saveKnowledgeEntry(entry)` | Add a new entry; returns its id |
-| `supersedeKnowledgeEntry(oldIdOrText, newText)` | Save a replacement and mark the old entry superseded by it |
-| `markKnowledgeSuperseded(idOrText, newId)` | Mark an existing entry superseded by an already-saved entry |
-| `archiveKnowledgeEntry(idOrText, reason)` | Soft-delete an entry with a reason |
+| `saveKnowledgeEntry(entry)` | Add a new entry; returns its id. Also embeds the entry into the KB vector namespace (best-effort) |
+| `supersedeKnowledgeEntry(oldIdOrText, newText)` | Save a replacement and mark the old entry superseded by it (old vector deleted best-effort) |
+| `markKnowledgeSuperseded(idOrText, newId)` | Mark an existing entry superseded by an already-saved entry (vector deleted best-effort) |
+| `archiveKnowledgeEntry(idOrText, reason)` | Soft-delete an entry with a reason (vector deleted best-effort) |
 | `getAllKnowledge()` | Get visible entries (not superseded/archived), newest first |
 | `getKnowledgeHistory()` | Get every entry including superseded and archived, newest first |
-| `getKnowledgeAsMarkdown()` | Format visible entries as markdown (with stale-context footer) for the prompt |
+| `getKnowledgeAsMarkdown()` | Format ALL visible entries as markdown (with stale-context footer) |
+| `getKnowledgeRecallAsMarkdown(question)` | Format the top-5 entries relevant to the question (hybrid recall) — what the prompt uses per turn |
 
 ### Retiring a Stale Entry
 
@@ -117,7 +129,7 @@ If you need to retire a KB entry:
 
 ## Graceful Degradation
 
-If Vercel KV is not configured (common during local development without KV credentials), `getKnowledgeAsMarkdown()` catches the error silently and returns `null`. The bot works normally without a knowledge base -- it just does not have persistent memory.
+If Vercel KV is not configured (common during local development without KV credentials), `getKnowledgeRecallAsMarkdown()` (and `getKnowledgeAsMarkdown()`) catches the error silently and returns `null`. The bot works normally without a knowledge base -- it just does not have persistent memory. If only the *vector* layer is unconfigured, saves and recall still work — recall just runs lexical-only (see [Hybrid Retrieval](./hybrid-retrieval.md)).
 
 The knowledge base section is simply omitted from the system prompt when there are no entries.
 

--- a/docs/features/progress-ux.md
+++ b/docs/features/progress-ux.md
@@ -54,6 +54,7 @@ Each tool has its own emoji and message format:
 | `thinking` | 🧠 | _Thinking about your question..._ |
 | `index` | 🗂️ | _Checking repo index..._ |
 | `search_code` | 🔍 | _Searching for "authentication middleware"..._ |
+| `search_repo` | 🧭 | _Searching code + docs for "message splitting"..._ |
 | `read_file` | 👓 | _Reading src/middleware/auth.ts..._ |
 | `list_issues` | 🎫 | _Looking up issues..._ |
 | `list_commits` | 📜 | _Checking recent commits..._ |

--- a/docs/features/repo-index.md
+++ b/docs/features/repo-index.md
@@ -2,6 +2,8 @@
 
 The repository index is an auto-generated topic map of your codebase. It helps the bot jump directly to relevant files instead of searching blind.
 
+> **Topic index vs. vector index**: this doc covers the *topic index* — a path-classified map rendered into the system prompt so the model knows where areas of the repo live. Since #127, the same SHA-changed rebuild also chunks and embeds `docs/**/*.md` content into a SHA-scoped Upstash Vector namespace, which serves the `search_repo` tool's semantic doc arm at tool time. The two are complementary: the topic index guides navigation before any tool call, the vector index answers content queries. See [Hybrid Retrieval](./hybrid-retrieval.md) for the embedding pipeline, the `index:vector_docs_ns` pointer lifecycle, and the degradation matrix.
+
 ## How It Works
 
 When the bot starts processing a question, it calls `getOrRebuildIndex()` which:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -108,6 +108,9 @@ The `effort` / `max_rounds` fields on `agent_start` and `agent_complete` come fr
 | `config_loaded` | .battle-mage.json read from repo | hasConfig, pathCount |
 | `index_rebuilt` | Index rebuilt after SHA change | sha, topicCount, fileCount, duration_ms |
 | `index_build_error` | Index build failed | message |
+| `docs_embedded` | Doc chunks embedded into the new SHA namespace after a rebuild (#127) | sha, docCount, chunkCount, duration_ms |
+| `docs_embed_capped` | More docs than `MAX_DOCS_TO_EMBED` (50) — only the first 50 were fetched/embedded | totalDocs, cap |
+| `docs_embed_failed` | Chunk upsert (or the embed pipeline) failed — namespace pointer left untouched, rebuild still succeeded | sha, docCount, chunkCount (or message) |
 
 ### Response Events (route.ts)
 
@@ -129,6 +132,16 @@ Every persistent-state operation flows through `src/lib/kv.ts`, which wraps the 
 | `kv_error` | Every failed op (also `Sentry.captureException`) | op, keyPrefix, durationMs, errorClass, errorMessage (sliced to 200 chars). Sentry tags: `kv.op`, `kv.keyPrefix`. |
 
 **Why `keyPrefix`, not the full key:** full keys contain channel IDs and message timestamps (`feedback:context:C01ABCDEF:1234.5678`) — not privacy-sensitive per se, but cardinality-hostile for aggregation. The first segment (`feedback`, `knowledge`, `pending-correction`, `repo-index`, `slack-users`) combined with `op` gives clean bucketing (e.g., `{op: get, keyPrefix: feedback}` for context lookups vs. `{op: zrange, keyPrefix: feedback}` for entry-list reads).
+
+### Vector Events (lib/vector.ts) — #127
+
+Every Upstash Vector operation flows through `src/lib/vector.ts`, mirroring the `kv_op` pattern above with one difference: the wrapper is **non-throwing** — degradation is a return value, and "not configured" is an expected state, not an error. Query and entry text are never logged.
+
+| Event | When | Key data |
+|-------|------|----------|
+| `vector_op` | Every successful op | op (`upsert`/`query`/`delete`/`deleteNamespace`), namespace, durationMs, count (items/matches/ids) |
+| `vector_unavailable` | Op attempted while `UPSTASH_VECTOR_REST_*` is unset — expected degradation, NOT an error, no Sentry | op, reason (`not_configured`) |
+| `vector_error` | Op failed or exceeded `VECTOR_OP_TIMEOUT_MS` (2s) (also `Sentry.captureException`) | op, namespace, durationMs, errorClass (`VectorTimeoutError` on timeout), errorMessage (sliced to 200 chars). Sentry tags: `vector.op`, `vector.namespace`. |
 
 ### Feedback Events (route.ts) — #114
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -110,6 +110,7 @@ The `effort` / `max_rounds` fields on `agent_start` and `agent_complete` come fr
 | `index_build_error` | Index build failed | message |
 | `docs_embedded` | Doc chunks embedded into the new SHA namespace after a rebuild (#127) | sha, docCount, chunkCount, duration_ms |
 | `docs_embed_capped` | More docs than `MAX_DOCS_TO_EMBED` (50) — only the first 50 were fetched/embedded | totalDocs, cap |
+| `docs_embed_empty` | The rebuild produced zero chunks (every doc read failed or all docs were empty) — pointer/namespace left untouched so the previous generation keeps serving | sha, docCount |
 | `docs_embed_failed` | Chunk upsert (or the embed pipeline) failed — namespace pointer left untouched, rebuild still succeeded | sha, docCount, chunkCount (or message) |
 
 ### Response Events (route.ts)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -137,7 +137,7 @@ vercel --prod
 
 1. Go to [vercel.com/new](https://vercel.com/new)
 2. Import your fork of the battle-mage repo
-3. Add all six environment variables in the **Environment Variables** section before deploying
+3. Add the six required environment variables — plus `CRON_SECRET` (for the recovery sweep) and the optional Upstash Vector pair, if you provisioned it — in the **Environment Variables** section before deploying
 4. Click **Deploy**
 
 ### Set Up Upstash Redis
@@ -155,6 +155,16 @@ The integration sets both sets of env vars — `UPSTASH_REDIS_REST_URL` / `UPSTA
 > **Legacy note**: Older deployments provisioned "Vercel KV" (which was a thin wrapper over Upstash Redis). Those still work — `KV_REST_API_*` env vars are read as a fallback by `@upstash/redis`. New projects should use the Upstash Marketplace integration directly.
 
 > **Gotcha**: If you skip this step, the bot will still work for basic Q&A -- but the knowledge base, feedback, and repo index features will silently degrade. You will see no errors, but corrections will not persist and the repo map will not be cached.
+
+### Set Up Upstash Vector (Optional — Hybrid Retrieval)
+
+Battle Mage uses Upstash Vector for semantic retrieval (#127): the `search_repo` tool's doc-search arm and the knowledge base's semantic recall arm. See [Hybrid Retrieval](./features/hybrid-retrieval.md).
+
+1. In the Upstash console (or via the Vercel Marketplace integration), create a **Vector index**
+2. **Important**: create the index WITH a built-in embedding model (e.g. one of Upstash's hosted models) — the app upserts and queries **raw text** via the SDK's `data` field and relies on the index to embed server-side. An index without an embedding model will reject raw-text operations.
+3. Set `UPSTASH_VECTOR_REST_URL` and `UPSTASH_VECTOR_REST_TOKEN` on your Vercel project
+
+> **This is optional.** Without these variables the bot degrades gracefully: `search_repo` returns lexical code results only, and KB recall runs keyword-matching only. You'll see `vector_unavailable` log events (expected, not errors). See [Troubleshooting](./troubleshooting.md#vector-not-configured-semantic-search-degraded).
 
 ### Set Up Vercel Cron (recovery sweep)
 
@@ -252,6 +262,8 @@ If the bot does not respond, check the [Troubleshooting Guide](./troubleshooting
 | `GITHUB_REPO` | Yes | `backend` | Repository name |
 | `UPSTASH_REDIS_REST_URL` | Auto | `https://...upstash.io` | Injected by the Upstash Vercel integration -- do not set manually |
 | `UPSTASH_REDIS_REST_TOKEN` | Auto | `AaB1Cc2...` | Injected by the Upstash Vercel integration -- do not set manually |
+| `UPSTASH_VECTOR_REST_URL` | Optional | `https://...upstash.io` | Upstash Vector index (with built-in embedding model) for hybrid retrieval -- omit to degrade to lexical-only |
+| `UPSTASH_VECTOR_REST_TOKEN` | Optional | `ABcD3...` | Token for the Vector index -- both must be set or neither |
 | `KV_REST_API_URL` | Legacy | `https://...upstash.io` | Read as a fallback by `@upstash/redis` for projects that still provision "Vercel KV" |
 | `KV_REST_API_TOKEN` | Legacy | `AaB1Cc2...` | Read as a fallback — either pair works |
 | `CRON_SECRET` | Yes (for recovery) | `f3a9...64 hex chars` | Auth for `/api/cron/sweep` (Vercel Cron sends it as a Bearer token). Unset = sweep denies all requests, recovery disabled |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,7 @@ Common issues and how to fix them.
 
 4. **Is the deployment healthy?** Check your Vercel dashboard for deployment errors. Look at the function logs for the `/api/slack` route.
 
-5. **Are environment variables set?** In Vercel dashboard > Settings > Environment Variables, verify all six required variables are present: `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `ANTHROPIC_API_KEY`, `GITHUB_PAT_BM`, `GITHUB_OWNER`, `GITHUB_REPO`.
+5. **Are environment variables set?** In Vercel dashboard > Settings > Environment Variables, verify all six required variables are present: `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `ANTHROPIC_API_KEY`, `GITHUB_PAT_BM`, `GITHUB_OWNER`, `GITHUB_REPO`. (`UPSTASH_VECTOR_REST_URL` / `UPSTASH_VECTOR_REST_TOKEN` are optional — see "Vector not configured" below.)
 
 6. **Is signature verification failing?** Check Vercel function logs for "Invalid signature" 401 responses. This means the `SLACK_SIGNING_SECRET` does not match the signing secret from your Slack app's Basic Information page.
 
@@ -38,6 +38,20 @@ Common issues and how to fix them.
 If the error message is `An API error occurred: msg_too_long`, Slack rejected an oversized `chat.postMessage` or `chat.update` call. With the split-reply architecture (see [Message Splitting](./features/message-splitting.md)), this should be architecturally unreachable on the happy path — a single message should never approach Slack's 40,000-char limit because the splitter chops long bodies into multiple thread replies first.
 
 If you see it anyway, Sentry will have a `SlackMessageOversizeError` with the offending length and action. That indicates a splitter bug, not a prompt-budget issue. Widen the splitter's test matrix rather than raising the limit.
+
+## Vector Not Configured (Semantic Search Degraded)
+
+**Symptom**: Logs show `vector_unavailable` events with `reason: "not_configured"`, or conceptual questions don't surface doc content the way you expect.
+
+This is an **expected degradation state**, not an error — the bot keeps working lexically without Upstash Vector. What degrades when `UPSTASH_VECTOR_REST_URL` / `UPSTASH_VECTOR_REST_TOKEN` are unset:
+
+- **`search_repo` doc arm** — the tool returns lexical code-search results only; no semantic doc chunks.
+- **KB semantic recall arm** — knowledge-base recall runs lexical keyword matching only, so a question phrased with no keyword overlap may miss a relevant KB entry.
+- **Doc embedding** — index rebuilds skip the chunk/embed pipeline entirely (no wasted GitHub content fetches).
+
+Nothing else is affected: saves, corrections, the topic index, and every other tool work normally.
+
+**To enable**: create an Upstash Vector index **with a built-in embedding model** and set both env vars — see [Setup](./setup.md). `vector_error` events (as opposed to `vector_unavailable`) indicate a provisioned index that is failing or timing out — check the Upstash console and the Sentry `vector.op` tag.
 
 ## Bot Cannot Read the Repository
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,11 +47,12 @@ The bot checks whether it has already replied in the thread. If it has, a fast-m
 
 ## What Kinds of Questions Work Well
 
-Battle Mage has access to seven tools for exploring your codebase:
+Battle Mage has access to eight tools for exploring your codebase:
 
 | Tool | What it does |
 |------|-------------|
 | `search_code` | Find functions, classes, patterns, keywords across the repo |
+| `search_repo` | Hybrid search across code AND docs — best for conceptual "how does X work" questions |
 | `read_file` | Read file contents or list directory entries |
 | `list_issues` | List open/closed issues, look up specific issues by number |
 | `list_commits` | Show recent commits on main with dates |

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@slack/bolt": "^4.2.0",
         "@slack/web-api": "^7.9.0",
         "@upstash/redis": "^1.37.0",
+        "@upstash/vector": "^1.2.3",
         "next": "^15.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -4354,6 +4355,12 @@
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
+    },
+    "node_modules/@upstash/vector": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@upstash/vector/-/vector-1.2.3.tgz",
+      "integrity": "sha512-yXsWKeuHNYyH72BcSZd3bV5ZD5MybAoTvKxkMaeV2UzuGfNzbHBVh5eO+ysTWTFAf8I9XcOueF4tZfAGjCa4Iw==",
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@slack/bolt": "^4.2.0",
     "@slack/web-api": "^7.9.0",
     "@upstash/redis": "^1.37.0",
+    "@upstash/vector": "^1.2.3",
     "next": "^15.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -1036,3 +1036,44 @@ describe("resolveMaxRounds", () => {
     expect(resolveMaxRounds({ maxRounds: Number.POSITIVE_INFINITY })).toBe(MAX_TOOL_ROUNDS);
   });
 });
+
+describe("hybrid retrieval prompt copy (#127)", () => {
+  const args = {
+    owner: "acme",
+    repo: "backend",
+    claudeMd: null,
+    knowledge: null,
+    feedback: null,
+    repoIndex: null,
+    pathAnnotations: null,
+  };
+
+  it("lists search_repo in the tools section", () => {
+    const prompt = assembleSystemPrompt(args);
+    const toolsSection = prompt.slice(
+      prompt.indexOf("<tools>"),
+      prompt.indexOf("</tools>"),
+    );
+    expect(toolsSection).toContain("*search_repo*");
+  });
+
+  it("search strategy routes conceptual questions to search_repo and exact identifiers to search_code", () => {
+    const prompt = assembleSystemPrompt(args);
+    const strategy = prompt.slice(
+      prompt.indexOf("<search-strategy>"),
+      prompt.indexOf("</search-strategy>"),
+    );
+    expect(strategy).toContain("search_repo");
+    expect(strategy).toMatch(/conceptual/i);
+    expect(strategy).toContain("search_code");
+  });
+
+  it("KB usage copy says the most relevant entries are loaded, not the full KB", () => {
+    const prompt = assembleSystemPrompt(args);
+    const kbSection = prompt.slice(
+      prompt.indexOf("<knowledge-base-usage>"),
+      prompt.indexOf("</knowledge-base-usage>"),
+    );
+    expect(kbSection).toMatch(/relevant/i);
+  });
+});

--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -1,4 +1,42 @@
 import { describe, it, expect, vi } from "vitest";
+
+// ── #127 review: mocks for the runAgent recall-question tests ─────────
+// The Anthropic client is replaced with a stub that ends the turn
+// immediately; the knowledge boundary is mocked so the tests can assert
+// WHICH question string reaches KB recall. importOriginal keeps every
+// other export (buildDocCatalogSection etc.) real for the prompt tests.
+const { recallSpy, anthropicCreateSpy } = vi.hoisted(() => ({
+  recallSpy: vi.fn(async (_q: string) => null),
+  anthropicCreateSpy: vi.fn(async (..._a: unknown[]) => ({
+    content: [{ type: "text", text: "stub answer" }],
+    stop_reason: "end_turn",
+    usage: { input_tokens: 1, output_tokens: 1 },
+  })),
+}));
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class AnthropicMock {
+    messages = { create: (...a: unknown[]) => anthropicCreateSpy(...a) };
+  },
+}));
+vi.mock("@/lib/knowledge", () => ({
+  getKnowledgeRecallAsMarkdown: (q: string) => recallSpy(q),
+}));
+vi.mock("@/lib/feedback", () => ({
+  getFeedbackSummary: vi.fn(async () => null),
+}));
+vi.mock("@/lib/repo-index", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getOrRebuildIndex: vi.fn(async () => ""),
+  getCachedConfig: vi.fn(async () => ({ paths: {} })),
+  getDocCatalog: vi.fn(async () => []),
+}));
+vi.mock("@/lib/github", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  readFile: vi.fn(async () => {
+    throw new Error("no repo in tests");
+  }),
+}));
+
 import {
   assembleSystemPrompt,
   assembleSystemBlocks,
@@ -6,6 +44,7 @@ import {
   estimateMessagesTokens,
   executeToolsInParallel,
   resolveMaxRounds,
+  runAgent,
   FAST_MODEL,
   MAX_TOOL_ROUNDS,
   TOOL_RESULT_MAX_CHARS,
@@ -1075,5 +1114,29 @@ describe("hybrid retrieval prompt copy (#127)", () => {
       prompt.indexOf("</knowledge-base-usage>"),
     );
     expect(kbSection).toMatch(/relevant/i);
+  });
+});
+
+describe("runAgent — KB recall uses the clean question (#127 review)", () => {
+  it("passes options.recallQuestion to recall, not the augmented userMessage", async () => {
+    recallSpy.mockClear();
+    await runAgent(
+      "[topic hints...] where is the redis wrapper [effort: quick]",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { recallQuestion: "where is the redis wrapper" },
+    );
+    expect(recallSpy).toHaveBeenCalledWith("where is the redis wrapper");
+    expect(recallSpy).not.toHaveBeenCalledWith(
+      "[topic hints...] where is the redis wrapper [effort: quick]",
+    );
+  });
+
+  it("falls back to the raw userMessage when recallQuestion is absent", async () => {
+    recallSpy.mockClear();
+    await runAgent("plain question");
+    expect(recallSpy).toHaveBeenCalledWith("plain question");
   });
 });

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -537,6 +537,14 @@ export interface RunAgentOptions {
   maxRounds?: number;
   /** Effort bucket label — observability only (agent_start/agent_complete). */
   effort?: string;
+  /**
+   * The user's CLEAN question for KB recall (#127). The `userMessage`
+   * the route passes is augmented with topic/effort hints, which would
+   * pollute the lexical tokens and the embedding query — recall must
+   * key off what the user actually asked. Falls back to `userMessage`
+   * when absent.
+   */
+  recallQuestion?: string;
 }
 
 // Pure resolver for the per-turn round cap: floor → clamp to
@@ -603,7 +611,10 @@ export async function runAgent(
   const issueProposals: IssueProposal[] = [];
   const allReferences: Reference[] = [];
   const startTime = Date.now();
-  const { blocks: systemBlocks, feedbackMeta } = await buildSystemBlocks(participants, userMessage);
+  const { blocks: systemBlocks, feedbackMeta } = await buildSystemBlocks(
+    participants,
+    options?.recallQuestion ?? userMessage,
+  );
   const promptLength = systemBlocks.reduce((n, b) => n + b.text.length, 0);
 
   _log("agent_start", {

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -2,7 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { tools, executeTool, type ToolResult, type Reference } from "@/tools";
 import type { IssueProposal } from "@/tools/create-issue";
 import { readFile } from "@/lib/github";
-import { getKnowledgeAsMarkdown } from "@/lib/knowledge";
+import { getKnowledgeRecallAsMarkdown } from "@/lib/knowledge";
 import { getFeedbackSummary } from "@/lib/feedback";
 import {
   getOrRebuildIndex,
@@ -147,11 +147,6 @@ async function getClaudeMd(): Promise<string | null> {
   return cachedClaudeMd;
 }
 
-async function getKnowledge(): Promise<string | null> {
-  // Served by Vercel KV — no GitHub write access needed
-  return getKnowledgeAsMarkdown();
-}
-
 // ── System prompt (pure function — exported for testing) ──────────────
 
 export interface PromptInputs {
@@ -257,6 +252,7 @@ Available GitHub tools (do not invent names):
 - *list_commits*: List recent commits on main — newest first, with dates
 - *list_prs*: List recent pull requests — shows merged/open status with dates
 - *create_issue*: Propose a new GitHub issue (requires user confirmation)
+- *search_repo*: Hybrid search across code AND docs — lexical code search fused with semantic (meaning-based) doc search. Best for conceptual questions
 - *save_knowledge*: Save a correction or fact to the persistent knowledge base
 </tools>`;
 }
@@ -269,7 +265,7 @@ You have a maximum of ${MAX_TOOL_ROUNDS} tool rounds per question. Budget them w
 
 *Step 1: Check the Repository Map FIRST* — Look at the Repository Map section in this prompt. It lists the key areas of the repo by topic (authentication, deployment, security, etc.). If the question maps to a topic, go directly to the listed files with \`read_file\`. Do NOT search if the map already tells you where to look.
 
-*Step 2: Search only as fallback* — Use \`search_code\` ONLY if the repo map doesn't cover the topic, or if you need to find a specific function/class name. A search returns 10 results — don't read all of them.
+*Step 2: Search only as fallback* — Search ONLY if the repo map doesn't cover the topic. Pick the right search tool: for a conceptual question ("how does X work", "where do we handle Y") use \`search_repo\` — it fuses code search with semantic doc search; for an exact identifier (a specific function/class/keyword) use \`search_code\`. A search returns up to 10 results — don't read all of them.
 
 *Step 3: Read 2-3 files maximum* — For most questions, 2-3 files from the relevant topic is enough. If you've read 3 files and have enough to answer, stop reading and synthesize.
 
@@ -306,7 +302,7 @@ You have a persistent knowledge base stored in Vercel KV (not in the GitHub repo
 - Bad: "User said auth is somewhere else"
 
 *When reading:*
-- Your knowledge base is loaded into this prompt below. It can become stale — always check the code first for code-level questions.
+- The most relevant KB entries for the current question are loaded below (top matches, not the full KB). They can become stale — always check the code first for code-level questions.
 - If a knowledge entry conflicts with what you see in the code, the code is authoritative — flag the discrepancy.
 </knowledge-base-usage>`;
 }
@@ -447,8 +443,13 @@ export function assembleSystemBlocks(inputs: PromptInputs): Anthropic.TextBlockP
 }
 
 // ── Async wrapper that fetches data then assembles ────────────────────
+// `question` drives per-turn KB recall (#127): only the top matching KB
+// entries are rendered into the volatile zone instead of the full KB.
+// PromptInputs is unchanged and the KB stays in the volatile zone, so
+// the stable-zone cache breakpoint is unaffected.
 async function buildSystemBlocks(
   participants?: Participant[],
+  question?: string,
 ): Promise<{ blocks: Anthropic.TextBlockParam[]; feedbackMeta: { positiveCount: number; negativeCount: number; totalEntries: number } }> {
   // Fetch index + doc catalog in parallel. Both are KV-reads on the warm
   // path; rebuild on cold path is already time-bounded inside
@@ -467,7 +468,7 @@ async function buildSystemBlocks(
     owner: process.env.GITHUB_OWNER,
     repo: process.env.GITHUB_REPO,
     claudeMd: await getClaudeMd(),
-    knowledge: await getKnowledge(),
+    knowledge: await getKnowledgeRecallAsMarkdown(question ?? ""),
     feedback: feedbackSummary?.markdown ?? null,
     repoIndex,
     pathAnnotations: Object.keys(config.paths).length > 0 ? config : null,
@@ -602,7 +603,7 @@ export async function runAgent(
   const issueProposals: IssueProposal[] = [];
   const allReferences: Reference[] = [];
   const startTime = Date.now();
-  const { blocks: systemBlocks, feedbackMeta } = await buildSystemBlocks(participants);
+  const { blocks: systemBlocks, feedbackMeta } = await buildSystemBlocks(participants, userMessage);
   const promptLength = systemBlocks.reduce((n, b) => n + b.text.length, 0);
 
   _log("agent_start", {

--- a/src/lib/knowledge.test.ts
+++ b/src/lib/knowledge.test.ts
@@ -49,6 +49,19 @@ vi.mock("./kv", () => ({
   },
 }));
 
+// ── #127: mock the vector layer (knowledge.ts must treat it as best-effort) ──
+const { vectorUpsertSpy, vectorDeleteSpy, vectorQuerySpy } = vi.hoisted(() => ({
+  vectorUpsertSpy: vi.fn(),
+  vectorDeleteSpy: vi.fn(),
+  vectorQuerySpy: vi.fn(),
+}));
+vi.mock("./vector", () => ({
+  vectorUpsert: (...a: unknown[]) => vectorUpsertSpy(...a),
+  vectorDelete: (...a: unknown[]) => vectorDeleteSpy(...a),
+  vectorQuery: (...a: unknown[]) => vectorQuerySpy(...a),
+  kbNamespace: () => "acme/backend:kb",
+}));
+
 import {
   saveKnowledgeEntry,
   supersedeKnowledgeEntry,
@@ -57,6 +70,7 @@ import {
   getAllKnowledge,
   getKnowledgeHistory,
   getKnowledgeAsMarkdown,
+  getKnowledgeRecallAsMarkdown,
   STALE_CONTEXT_FOOTER,
 } from "./knowledge";
 
@@ -71,6 +85,9 @@ import { kv } from "./kv";
 beforeEach(() => {
   store.clear();
   logSpy.mockClear();
+  vectorUpsertSpy.mockReset().mockResolvedValue(true);
+  vectorDeleteSpy.mockReset().mockResolvedValue(true);
+  vectorQuerySpy.mockReset().mockResolvedValue(null); // default: vector unavailable
 });
 
 describe("saveKnowledgeEntry", () => {
@@ -296,5 +313,162 @@ describe("getKnowledgeAsMarkdown", () => {
 
   it("returns null when the KB is empty", async () => {
     expect(await getKnowledgeAsMarkdown()).toBeNull();
+  });
+});
+
+describe("saveKnowledgeEntry — vector embedding (#127)", () => {
+  it("upserts the entry into the KB namespace keyed by its id, with text and timestamp metadata", async () => {
+    const id = await saveKnowledgeEntry("Auth lives in src/lib/auth.ts");
+    expect(vectorUpsertSpy).toHaveBeenCalledWith("acme/backend:kb", [
+      expect.objectContaining({
+        id,
+        text: "Auth lives in src/lib/auth.ts",
+        metadata: expect.objectContaining({
+          timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        }),
+      }),
+    ]);
+  });
+
+  it("save succeeds and returns the id when embedding reports failure", async () => {
+    vectorUpsertSpy.mockResolvedValue(false);
+    const id = await saveKnowledgeEntry("fact survives embed failure");
+    expect(id.length).toBeGreaterThan(0);
+    expect((await getAllKnowledge()).map((e) => e.entry)).toContain(
+      "fact survives embed failure",
+    );
+  });
+
+  it("save succeeds even if the vector layer rejects (contract-violation guard)", async () => {
+    vectorUpsertSpy.mockRejectedValue(new Error("should never happen"));
+    const id = await saveKnowledgeEntry("fact survives embed crash");
+    expect(id.length).toBeGreaterThan(0);
+    expect(await getAllKnowledge()).toHaveLength(1);
+  });
+});
+
+describe("retire flows remove KB vectors (#127)", () => {
+  it("supersedeKnowledgeEntry best-effort-deletes the OLD entry's vector", async () => {
+    const oldId = await saveKnowledgeEntry("stale fact");
+    await supersedeKnowledgeEntry(oldId, "fresh fact");
+    expect(vectorDeleteSpy).toHaveBeenCalledWith("acme/backend:kb", [oldId]);
+  });
+
+  it("archiveKnowledgeEntry best-effort-deletes the entry's vector", async () => {
+    const id = await saveKnowledgeEntry("obsolete fact");
+    await archiveKnowledgeEntry(id, "cleanup");
+    expect(vectorDeleteSpy).toHaveBeenCalledWith("acme/backend:kb", [id]);
+  });
+
+  it("retire still succeeds when vector delete fails", async () => {
+    vectorDeleteSpy.mockResolvedValue(false);
+    const id = await saveKnowledgeEntry("fact");
+    expect(await archiveKnowledgeEntry(id, "reason")).toBe(true);
+    expect(await getAllKnowledge()).toHaveLength(0);
+  });
+});
+
+describe("getKnowledgeRecallAsMarkdown (#127)", () => {
+  // Deterministic fixture: 6 visible entries injected with explicit
+  // scores (1000 oldest → 6000 newest) and pinned timestamps.
+  function injectSixEntries(): void {
+    const rows = [
+      { id: "e1", entry: "The Redis KV wrapper lives in src/lib/kv.ts", timestamp: "2026-06-01" },
+      { id: "e2", entry: "Deploys go through Vercel only", timestamp: "2026-06-02" },
+      { id: "e3", entry: "Issue creation requires a confirmation reaction", timestamp: "2026-06-03" },
+      { id: "e4", entry: "The redis client is @upstash/redis behind the kv wrapper", timestamp: "2026-06-04" },
+      { id: "e5", entry: "Progress messages are deleted when the answer posts", timestamp: "2026-06-05" },
+      { id: "e6", entry: "Slack replies are thread-only, never channel root", timestamp: "2026-06-06" },
+    ];
+    rows.forEach((r, i) => injectRawMember(JSON.stringify(r), (i + 1) * 1000));
+  }
+
+  it("returns null for an empty KB", async () => {
+    expect(await getKnowledgeRecallAsMarkdown("anything")).toBeNull();
+  });
+
+  it("KB at or below RECALL_TOP_K renders ALL entries and never queries the vector store", async () => {
+    await saveKnowledgeEntry("fact a");
+    await saveKnowledgeEntry("fact b");
+    await saveKnowledgeEntry("fact c");
+    const md = await getKnowledgeRecallAsMarkdown("unrelated question");
+    expect(md).toContain("fact a");
+    expect(md).toContain("fact b");
+    expect(md).toContain("fact c");
+    expect(vectorQuerySpy).not.toHaveBeenCalled();
+    expect(md!.trimEnd().endsWith(STALE_CONTEXT_FOOTER)).toBe(true);
+  });
+
+  it("queries the vector arm with the question and MAX_ARM_RESULTS when KB exceeds RECALL_TOP_K", async () => {
+    injectSixEntries();
+    await getKnowledgeRecallAsMarkdown("where is the redis wrapper");
+    expect(vectorQuerySpy).toHaveBeenCalledWith(
+      "acme/backend:kb",
+      "where is the redis wrapper",
+      10, // MAX_ARM_RESULTS
+    );
+  });
+
+  it("vector unavailable (null) → lexical-only recall still returns the matching entries", async () => {
+    injectSixEntries();
+    vectorQuerySpy.mockResolvedValue(null);
+    const md = await getKnowledgeRecallAsMarkdown("where is the redis wrapper");
+    expect(md).toContain("kv.ts");            // e1
+    expect(md).toContain("@upstash/redis");   // e4
+    expect(md).not.toContain("thread-only");  // e6: no lexical match, no vector arm
+    // Only the 2 lexical matches render — no padding.
+    expect(md!.match(/^- \[/gm)).toHaveLength(2);
+  });
+
+  it("vector-only recall works when the question shares no keywords (semantic hit)", async () => {
+    injectSixEntries();
+    vectorQuerySpy.mockResolvedValue([
+      { id: "e5", score: 0.9 },
+      { id: "e2", score: 0.8 },
+    ]);
+    const md = await getKnowledgeRecallAsMarkdown("zzzq wwwk"); // no lexical overlap
+    const lines = md!.match(/^- \[.*$/gm)!;
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("Progress messages"); // e5 ranked first
+    expect(lines[1]).toContain("Vercel only");       // e2 second
+  });
+
+  it("K1 invariant: retired and unknown ids from the vector arm never surface", async () => {
+    injectSixEntries();
+    injectRawMember(
+      JSON.stringify({ id: "dead", entry: "superseded ghost fact", timestamp: "2026-01-01", supersededById: "e1" }),
+      500,
+    );
+    vectorQuerySpy.mockResolvedValue([
+      { id: "dead", score: 0.99 },     // superseded — must be filtered
+      { id: "ghost-404", score: 0.98 }, // not in KV at all — must be filtered
+      { id: "e3", score: 0.9 },
+    ]);
+    const md = await getKnowledgeRecallAsMarkdown("zzzq wwwk");
+    expect(md).not.toContain("ghost fact");
+    expect(md).toContain("confirmation reaction"); // e3 survives
+    expect(md!.match(/^- \[/gm)).toHaveLength(1);
+  });
+
+  it("both arms empty → falls back to the newest RECALL_TOP_K entries", async () => {
+    injectSixEntries();
+    vectorQuerySpy.mockResolvedValue([]); // available, zero matches
+    const md = await getKnowledgeRecallAsMarkdown("zzzq wwwk");
+    const lines = md!.match(/^- \[.*$/gm)!;
+    expect(lines).toHaveLength(5);
+    expect(lines[0]).toContain("thread-only");     // e6, newest by score
+    expect(md).not.toContain("src/lib/kv.ts");     // e1, oldest, dropped
+  });
+
+  it("prompt-size bound: 50 matching entries still render exactly RECALL_TOP_K lines", async () => {
+    for (let i = 0; i < 50; i++) {
+      injectRawMember(
+        JSON.stringify({ id: `v${i}`, entry: `vercel deployment note ${i}`, timestamp: "2026-06-01" }),
+        1000 + i,
+      );
+    }
+    const md = await getKnowledgeRecallAsMarkdown("vercel deployment");
+    expect(md!.match(/^- \[/gm)).toHaveLength(5);
+    expect(md!.trimEnd().endsWith(STALE_CONTEXT_FOOTER)).toBe(true);
   });
 });

--- a/src/lib/knowledge.ts
+++ b/src/lib/knowledge.ts
@@ -1,6 +1,14 @@
 import { randomUUID } from "crypto";
 import { kv } from "./kv";
 import { log } from "./logger";
+import { vectorUpsert, vectorDelete, vectorQuery, kbNamespace } from "./vector";
+import {
+  RECALL_TOP_K,
+  MAX_ARM_RESULTS,
+  fuseRankedLists,
+  lexicalRank,
+  type RecallCandidate,
+} from "./retrieval";
 
 /**
  * Knowledge Base — Vercel KV storage
@@ -77,12 +85,37 @@ function toMemberString(raw: unknown): string {
 /**
  * Save a correction or fact to the knowledge base.
  * Returns the new entry's id so callers can link supersessions to it.
+ *
+ * Also embeds the entry into the KB vector namespace (best-effort, #127):
+ * vectorUpsert is non-throwing by contract, but the guard below means
+ * even a contract violation can never lose the save — KV is the source
+ * of truth, the vector index is only a recall accelerator.
  */
 export async function saveKnowledgeEntry(entry: string): Promise<string> {
   const id = randomUUID();
-  const value = JSON.stringify({ id, entry, timestamp: todayISO() });
+  const timestamp = todayISO();
+  const value = JSON.stringify({ id, entry, timestamp });
   await kv.zadd(KNOWLEDGE_KEY, { score: Date.now(), member: value });
+  try {
+    await vectorUpsert(kbNamespace(), [{ id, text: entry, metadata: { timestamp } }]);
+  } catch {
+    // Best-effort — the KV save above already succeeded.
+  }
   return id;
+}
+
+/**
+ * Best-effort removal of a retired entry's vector so it can never
+ * resurface through semantic recall. Legacy id-less entries were never
+ * embedded (embedding is keyed by id at save time), so they are skipped.
+ */
+async function removeKnowledgeVector(id: string | undefined): Promise<void> {
+  if (!id) return;
+  try {
+    await vectorDelete(kbNamespace(), [id]);
+  } catch {
+    // Best-effort — recall filters retired ids anyway (K1 invariant).
+  }
 }
 
 /**
@@ -94,6 +127,9 @@ export async function saveKnowledgeEntry(entry: string): Promise<string> {
  * shadow a later visible one. Returns false if no acceptable match
  * exists or the member disappeared between read and remove.
  *
+ * On success, returns the rewritten entry's id (when it has one) so
+ * retire flows can clean up the entry's vector embedding (#127).
+ *
  * Concurrency: zscore→zrem→zadd is not atomic. The zrem-count guard
  * ensures we never resurrect a member a concurrent writer already
  * rewrote — if zrem removes nothing, we abort instead of zadd-ing a
@@ -103,7 +139,7 @@ export async function saveKnowledgeEntry(entry: string): Promise<string> {
 async function updateEntry(
   idOrText: string,
   mutate: (e: KnowledgeEntry) => KnowledgeEntry | null,
-): Promise<boolean> {
+): Promise<{ updated: boolean; id?: string }> {
   const raw = await kv.zrange(KNOWLEDGE_KEY, 0, -1);
   for (const rawMember of raw) {
     const parsed = toEntry(rawMember);
@@ -115,13 +151,13 @@ async function updateEntry(
 
     const member = toMemberString(rawMember);
     const score = await kv.zscore(KNOWLEDGE_KEY, member);
-    if (score === null) return false;
+    if (score === null) return { updated: false };
     const removed = await kv.zrem(KNOWLEDGE_KEY, member);
-    if (removed === 0) return false;
+    if (removed === 0) return { updated: false };
     await kv.zadd(KNOWLEDGE_KEY, { score, member: JSON.stringify(updated) });
-    return true;
+    return { updated: true, id: parsed.id };
   }
-  return false;
+  return { updated: false };
 }
 
 /**
@@ -135,11 +171,13 @@ export async function markKnowledgeSuperseded(
   idOrText: string,
   supersededById: string,
 ): Promise<boolean> {
-  return updateEntry(idOrText, (e) =>
+  const result = await updateEntry(idOrText, (e) =>
     // The id guard prevents self-supersession when a correction's text
     // exactly matches the flagged entry text it replaces.
     isVisible(e) && e.id !== supersededById ? { ...e, supersededById } : null,
   );
+  if (result.updated) await removeKnowledgeVector(result.id);
+  return result.updated;
 }
 
 /**
@@ -180,9 +218,11 @@ export async function archiveKnowledgeEntry(
   idOrText: string,
   reason: string,
 ): Promise<boolean> {
-  return updateEntry(idOrText, (e) =>
+  const result = await updateEntry(idOrText, (e) =>
     isVisible(e) ? { ...e, archivedAt: todayISO(), archivedReason: reason } : null,
   );
+  if (result.updated) await removeKnowledgeVector(result.id);
+  return result.updated;
 }
 
 /**
@@ -210,10 +250,83 @@ export async function getKnowledgeAsMarkdown(): Promise<string | null> {
   try {
     const entries = await getAllKnowledge();
     if (entries.length === 0) return null;
-    const lines = entries.map((e) => `- [${e.timestamp}] ${e.entry}`).join("\n");
-    return `${lines}\n\n${STALE_CONTEXT_FOOTER}`;
+    return renderEntries(entries);
   } catch {
     // KV not configured (local dev without Vercel KV) — skip silently
+    return null;
+  }
+}
+
+function renderEntries(entries: KnowledgeEntry[]): string {
+  const lines = entries.map((e) => `- [${e.timestamp}] ${e.entry}`).join("\n");
+  return `${lines}\n\n${STALE_CONTEXT_FOOTER}`;
+}
+
+// Recall key for an entry: real id when present, entry text for legacy
+// id-less members. The vector arm only ever returns real ids (embedding
+// is keyed by id at save time), so the text fallback only feeds the
+// lexical arm.
+function recallId(e: KnowledgeEntry): string {
+  return e.id ?? e.entry;
+}
+
+/**
+ * Hybrid top-k recall (#127): render the RECALL_TOP_K visible entries
+ * most relevant to `question` instead of dumping the whole KB into the
+ * prompt.
+ *
+ * - 0 visible entries → null.
+ * - ≤ RECALL_TOP_K entries → render all; neither arm runs (no vector
+ *   call — the full KB already fits the budget).
+ * - Otherwise fuse a lexical arm (lexicalRank over visible entries)
+ *   with a semantic arm (vectorQuery on the KB namespace) via RRF with
+ *   freshness tie-breaks, capped at RECALL_TOP_K. No padding when the
+ *   fused set is smaller.
+ * - K1 invariant: vector ids are mapped back through the visible set
+ *   fetched in THIS call — retired (superseded/archived) or unknown ids
+ *   never surface, even if their embeddings still exist.
+ * - Both arms empty → fall back to the newest RECALL_TOP_K entries.
+ * - Non-throwing: any failure degrades to null (section omitted).
+ */
+export async function getKnowledgeRecallAsMarkdown(question: string): Promise<string | null> {
+  try {
+    const entries = await getAllKnowledge(); // visible only, newest first
+    if (entries.length === 0) return null;
+    if (entries.length <= RECALL_TOP_K) return renderEntries(entries);
+
+    const byId = new Map<string, KnowledgeEntry>();
+    for (const e of entries) byId.set(recallId(e), e);
+
+    const candidates: RecallCandidate[] = entries.map((e) => ({
+      id: recallId(e),
+      text: e.entry,
+      timestamp: e.timestamp,
+    }));
+    const lexicalIds = lexicalRank(question, candidates);
+
+    const matches = await vectorQuery(kbNamespace(), question, MAX_ARM_RESULTS);
+    // K1: only ids present in the visible set may surface.
+    const semanticIds = (matches ?? [])
+      .map((m) => m.id)
+      .filter((id) => byId.has(id));
+
+    if (lexicalIds.length === 0 && semanticIds.length === 0) {
+      return renderEntries(entries.slice(0, RECALL_TOP_K));
+    }
+
+    const timestamps: Record<string, string> = {};
+    for (const [id, e] of byId) timestamps[id] = e.timestamp;
+    const fused = fuseRankedLists(lexicalIds, semanticIds, {
+      timestamps,
+      topK: RECALL_TOP_K,
+    });
+    const selected = fused
+      .map((f) => byId.get(f.id))
+      .filter((e): e is KnowledgeEntry => e !== undefined);
+    return renderEntries(selected);
+  } catch {
+    // KV not configured or arm failure — omit the section rather than
+    // break the turn.
     return null;
   }
 }

--- a/src/lib/progress.test.ts
+++ b/src/lib/progress.test.ts
@@ -92,3 +92,12 @@ describe("buildThinkingMessage", () => {
     expect(header1).toBe(header2);
   });
 });
+
+describe("search_repo progress (#127)", () => {
+  it("formats search_repo with the query and its own emoji", () => {
+    const msg = formatProgressMessage("search_repo", { query: "auth flow" });
+    expect(msg).toContain("🧭");
+    expect(msg).toContain("auth flow");
+    expect(msg).toMatch(/^.+_.*_$/); // italic like every other status line
+  });
+});

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -22,6 +22,10 @@ const TOOL_FORMATS: Record<string, (input: ToolInput) => string> = {
     const query = (input.query as string) || "code";
     return `🔍 _Searching for "${query}"..._`;
   },
+  search_repo: (input) => {
+    const query = (input.query as string) || "code + docs";
+    return `🧭 _Searching code + docs for "${query}"..._`;
+  },
   read_file: (input) => {
     const path = truncatePath((input.path as string) || "file");
     return `👓 _Reading ${path}..._`;

--- a/src/lib/repo-index.test.ts
+++ b/src/lib/repo-index.test.ts
@@ -544,6 +544,32 @@ describe("chunkMarkdownByHeadings (#127)", () => {
       expect(c.metadata.excerpt.length).toBeGreaterThan(0);
     }
   });
+
+  it("does not treat # lines inside fenced code blocks as headings (#127 review)", () => {
+    const content = [
+      "# Real Heading",
+      "intro text",
+      "```bash",
+      "# not a heading",
+      "echo hi",
+      "```",
+      "tail text",
+    ].join("\n");
+    const chunks = chunkMarkdownByHeadings("docs/x.md", content);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.heading).toBe("Real Heading");
+    expect(chunks.map((c) => c.metadata.heading)).not.toContain("not a heading");
+    // The fenced content stays inside the section body, un-split.
+    expect(chunks[0].text).toContain("# not a heading");
+    expect(chunks[0].text).toContain("tail text");
+  });
+
+  it("tracks ~~~ fences the same way", () => {
+    const content = ["# Top", "~~~", "## fenced pseudo-heading", "~~~", "after"].join("\n");
+    const chunks = chunkMarkdownByHeadings("docs/x.md", content);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.heading).toBe("Top");
+  });
 });
 
 describe("getOrRebuildIndex — doc embedding hook (#127)", () => {
@@ -578,6 +604,11 @@ describe("getOrRebuildIndex — doc embedding hook (#127)", () => {
     });
 
     await getOrRebuildIndex();
+    // Embedding is fire-and-forget (#127 review) — wait for the
+    // background pipeline to finish before asserting on its effects.
+    await vi.waitFor(() =>
+      expect(logSpy).toHaveBeenCalledWith("docs_embedded", expect.anything()),
+    );
 
     expect(vectorUpsertSpy).toHaveBeenCalledWith("acme/backend:docs:new-sha", [
       expect.objectContaining({ id: "docs/setup.md#0" }),
@@ -616,15 +647,69 @@ describe("getOrRebuildIndex — doc embedding hook (#127)", () => {
     });
 
     const summary = await getOrRebuildIndex();
+    await vi.waitFor(() =>
+      expect(logSpy).toHaveBeenCalledWith(
+        "docs_embed_failed",
+        expect.objectContaining({ sha: "new-sha" }),
+      ),
+    );
 
     expect(kvData.get("index:vector_docs_ns")).toBe("acme/backend:docs:old-sha");
     expect(vectorDeleteNamespaceSpy).not.toHaveBeenCalled();
-    expect(logSpy).toHaveBeenCalledWith(
-      "docs_embed_failed",
-      expect.objectContaining({ sha: "new-sha" }),
-    );
     expect(logSpy).toHaveBeenCalledWith("index_rebuilt", expect.anything());
     expect(typeof summary).toBe("string");
+  });
+
+  it("empty chunk set (all doc reads fail) → docs_embed_empty, pointer untouched, previous namespace NOT deleted (#127 review)", async () => {
+    kvData.set("index:sha", "old-sha");
+    kvData.set("index:vector_docs_ns", "acme/backend:docs:old-sha");
+    getHeadShaSpy.mockResolvedValue("new-sha");
+    getRepoTreeSpy.mockResolvedValue([
+      treeBlob("docs/a.md"),
+      treeBlob("docs/b.md"),
+    ]);
+    // Every content read fails — chunks come out empty. Swapping the
+    // pointer to an empty namespace would silently kill the doc arm.
+    readFileSpy.mockRejectedValue(new Error("read failed"));
+
+    await getOrRebuildIndex();
+    await vi.waitFor(() =>
+      expect(logSpy).toHaveBeenCalledWith(
+        "docs_embed_empty",
+        expect.objectContaining({ sha: "new-sha" }),
+      ),
+    );
+
+    expect(vectorUpsertSpy).not.toHaveBeenCalled();
+    expect(kvData.get("index:vector_docs_ns")).toBe("acme/backend:docs:old-sha");
+    expect(vectorDeleteNamespaceSpy).not.toHaveBeenCalled();
+  });
+
+  it("a hung embed does NOT delay getOrRebuildIndex's return (#127 review)", async () => {
+    kvData.set("index:sha", "old-sha");
+    getHeadShaSpy.mockResolvedValue("new-sha");
+    getRepoTreeSpy.mockResolvedValue([treeBlob("docs/setup.md")]);
+    readFileSpy.mockImplementation(async (path: string) => {
+      if (path === "docs/setup.md") {
+        return { path, content: "# Setup\n\nbody" };
+      }
+      throw new Error(`unexpected read: ${path}`);
+    });
+    // The upsert never resolves — embedding is stuck.
+    vectorUpsertSpy.mockImplementation(() => {
+      callOrder.push("vectorUpsert");
+      return new Promise(() => {});
+    });
+
+    // Must resolve promptly with the summary while the embed promise is
+    // still pending (the test itself would time out otherwise).
+    const summary = await getOrRebuildIndex();
+    expect(typeof summary).toBe("string");
+    expect(logSpy).toHaveBeenCalledWith("index_rebuilt", expect.anything());
+    // Embed was INITIATED but has not completed.
+    await vi.waitFor(() => expect(vectorUpsertSpy).toHaveBeenCalled());
+    expect(logSpy).not.toHaveBeenCalledWith("docs_embedded", expect.anything());
+    expect(kvData.get("index:vector_docs_ns")).toBeUndefined();
   });
 
   it("caps content fetches at MAX_DOCS_TO_EMBED and logs docs_embed_capped (the #108 fan-out lesson)", async () => {
@@ -640,6 +725,9 @@ describe("getOrRebuildIndex — doc embedding hook (#127)", () => {
     });
 
     await getOrRebuildIndex();
+    await vi.waitFor(() =>
+      expect(logSpy).toHaveBeenCalledWith("docs_embedded", expect.anything()),
+    );
 
     const docReads = readFileSpy.mock.calls.filter(([p]) =>
       String(p).startsWith("docs/"),

--- a/src/lib/repo-index.test.ts
+++ b/src/lib/repo-index.test.ts
@@ -1,4 +1,56 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── #127 mocks: kv / github / vector / logger for the rebuild-hook tests ──
+// The pure-function tests below never touch these; the mocks only feed
+// getOrRebuildIndex / getDocsVectorNamespace.
+const {
+  logSpy,
+  kvData,
+  callOrder,
+  vectorUpsertSpy,
+  vectorDeleteNamespaceSpy,
+  getHeadShaSpy,
+  getRepoTreeSpy,
+  readFileSpy,
+} = vi.hoisted(() => ({
+  logSpy: vi.fn(),
+  kvData: new Map<string, unknown>(),
+  callOrder: [] as string[],
+  vectorUpsertSpy: vi.fn(),
+  vectorDeleteNamespaceSpy: vi.fn(),
+  getHeadShaSpy: vi.fn(),
+  getRepoTreeSpy: vi.fn(),
+  readFileSpy: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: (...args: unknown[]) => logSpy(...args),
+}));
+
+vi.mock("./kv", () => ({
+  kv: {
+    get: vi.fn(async (key: string) => kvData.get(key) ?? null),
+    set: vi.fn(async (key: string, value: unknown) => {
+      callOrder.push(`kv.set:${key}`);
+      kvData.set(key, value);
+      return "OK";
+    }),
+  },
+}));
+
+vi.mock("./vector", () => ({
+  isVectorConfigured: () => true,
+  docsNamespace: (sha: string) => `acme/backend:docs:${sha}`,
+  vectorUpsert: (...a: unknown[]) => vectorUpsertSpy(...a),
+  vectorDeleteNamespace: (...a: unknown[]) => vectorDeleteNamespaceSpy(...a),
+}));
+
+vi.mock("@/lib/github", () => ({
+  getHeadSha: (...a: unknown[]) => getHeadShaSpy(...a),
+  getRepoTree: (...a: unknown[]) => getRepoTreeSpy(...a),
+  readFile: (...a: unknown[]) => readFileSpy(...a),
+}));
+
 import {
   classifyTopics,
   isIndexStale,
@@ -6,8 +58,30 @@ import {
   extractDocTitle,
   filterDocPaths,
   buildDocCatalogSection,
+  chunkMarkdownByHeadings,
+  getOrRebuildIndex,
+  getDocsVectorNamespace,
   MAX_DOC_CATALOG_ENTRIES,
+  MAX_CHUNK_CHARS,
+  MAX_DOCS_TO_EMBED,
 } from "./repo-index";
+
+beforeEach(() => {
+  kvData.clear();
+  callOrder.length = 0;
+  logSpy.mockClear();
+  vectorUpsertSpy.mockReset().mockImplementation(async () => {
+    callOrder.push("vectorUpsert");
+    return true;
+  });
+  vectorDeleteNamespaceSpy.mockReset().mockImplementation(async () => {
+    callOrder.push("vectorDeleteNamespace");
+    return true;
+  });
+  getHeadShaSpy.mockReset();
+  getRepoTreeSpy.mockReset().mockResolvedValue([]);
+  readFileSpy.mockReset().mockRejectedValue(new Error("no such file"));
+});
 
 describe("classifyTopics", () => {
   it("classifies auth-related files", () => {
@@ -385,5 +459,203 @@ describe("buildDocCatalogSection", () => {
     );
     const section = buildDocCatalogSection(entries);
     expect(section).not.toContain("more docs");
+  });
+});
+
+describe("chunkMarkdownByHeadings (#127)", () => {
+  it("empty or whitespace content → []", () => {
+    expect(chunkMarkdownByHeadings("docs/x.md", "")).toEqual([]);
+    expect(chunkMarkdownByHeadings("docs/x.md", "  \n\n  ")).toEqual([]);
+  });
+
+  it("content without headings → a single chunk titled from the path", () => {
+    const chunks = chunkMarkdownByHeadings(
+      "docs/repo-index.md",
+      "Just a paragraph.\n\nAnother one.",
+    );
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].id).toBe("docs/repo-index.md#0");
+    expect(chunks[0].metadata.heading).toBe("Repo Index");
+    expect(chunks[0].metadata.path).toBe("docs/repo-index.md");
+    expect(chunks[0].text).toContain("Just a paragraph.");
+  });
+
+  it("splits on #, ##, and ### headings; #### does NOT split", () => {
+    const content = [
+      "# Title",
+      "intro",
+      "## Section A",
+      "body a",
+      "### Sub B",
+      "body b",
+      "#### Deep",
+      "still in sub b",
+    ].join("\n");
+    const chunks = chunkMarkdownByHeadings("docs/x.md", content);
+    expect(chunks.map((c) => c.metadata.heading)).toEqual([
+      "Title",
+      "Section A",
+      "Sub B",
+    ]);
+    // #### stays inside the ### chunk instead of opening a new one.
+    expect(chunks[2].text).toContain("#### Deep");
+    expect(chunks[2].text).toContain("still in sub b");
+  });
+
+  it("stores heading text without # marks and assigns sequential path#ordinal ids", () => {
+    const chunks = chunkMarkdownByHeadings("docs/x.md", "# One\na\n## Two\nb");
+    expect(chunks.map((c) => c.id)).toEqual(["docs/x.md#0", "docs/x.md#1"]);
+    expect(chunks.map((c) => c.metadata.heading)).toEqual(["One", "Two"]);
+    expect(chunks[0].metadata.heading).not.toContain("#");
+  });
+
+  it("keeps a preamble before the first heading as its own path-titled chunk", () => {
+    const chunks = chunkMarkdownByHeadings(
+      "docs/setup.md",
+      "Intro paragraph.\n\n# Install\nsteps",
+    );
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].metadata.heading).toBe("Setup");
+    expect(chunks[0].text).toContain("Intro paragraph.");
+    expect(chunks[1].metadata.heading).toBe("Install");
+  });
+
+  it("re-splits an oversize section on paragraph boundaries; every sub-chunk ≤ MAX_CHUNK_CHARS and shares the heading", () => {
+    const para = "x".repeat(400);
+    const content = `# Big\n\n${[para, para, para, para, para, para].join("\n\n")}`;
+    const chunks = chunkMarkdownByHeadings("docs/big.md", content);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.text.length).toBeLessThanOrEqual(MAX_CHUNK_CHARS);
+      expect(c.metadata.heading).toBe("Big");
+    }
+    // No content is lost across the sub-chunks.
+    const joined = chunks.map((c) => c.text).join("\n");
+    expect(joined.match(/x{400}/g)).toHaveLength(6);
+  });
+
+  it("every chunk carries a non-empty excerpt", () => {
+    const chunks = chunkMarkdownByHeadings(
+      "docs/x.md",
+      "# A\nsome body text\n## B\nmore text",
+    );
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const c of chunks) {
+      expect(c.metadata.excerpt.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("getOrRebuildIndex — doc embedding hook (#127)", () => {
+  function treeBlob(path: string): { path: string; type: string } {
+    return { path, type: "blob" };
+  }
+
+  it("SHA unchanged → serves the cache and never touches the vector store", async () => {
+    kvData.set("index:sha", "same-sha");
+    kvData.set("index:summary", "- *api*: src/a.ts");
+    getHeadShaSpy.mockResolvedValue("same-sha");
+
+    const summary = await getOrRebuildIndex();
+    expect(summary).toBe("- *api*: src/a.ts");
+    expect(vectorUpsertSpy).not.toHaveBeenCalled();
+    expect(vectorDeleteNamespaceSpy).not.toHaveBeenCalled();
+  });
+
+  it("SHA changed → upserts chunks into the new SHA namespace, THEN repoints, THEN deletes the previous namespace (N1 order)", async () => {
+    kvData.set("index:sha", "old-sha");
+    kvData.set("index:vector_docs_ns", "acme/backend:docs:old-sha");
+    getHeadShaSpy.mockResolvedValue("new-sha");
+    getRepoTreeSpy.mockResolvedValue([
+      treeBlob("docs/setup.md"),
+      treeBlob("src/a.ts"),
+    ]);
+    readFileSpy.mockImplementation(async (path: string) => {
+      if (path === "docs/setup.md") {
+        return { path, content: "# Setup\n\nInstall the app." };
+      }
+      throw new Error(`unexpected read: ${path}`);
+    });
+
+    await getOrRebuildIndex();
+
+    expect(vectorUpsertSpy).toHaveBeenCalledWith("acme/backend:docs:new-sha", [
+      expect.objectContaining({ id: "docs/setup.md#0" }),
+    ]);
+    expect(kvData.get("index:vector_docs_ns")).toBe("acme/backend:docs:new-sha");
+    expect(vectorDeleteNamespaceSpy).toHaveBeenCalledWith(
+      "acme/backend:docs:old-sha",
+    );
+    // N1: upsert → pointer swap → old-namespace cleanup, in that order.
+    const upsertIdx = callOrder.indexOf("vectorUpsert");
+    const pointerIdx = callOrder.indexOf("kv.set:index:vector_docs_ns");
+    const deleteIdx = callOrder.indexOf("vectorDeleteNamespace");
+    expect(upsertIdx).toBeGreaterThanOrEqual(0);
+    expect(pointerIdx).toBeGreaterThan(upsertIdx);
+    expect(deleteIdx).toBeGreaterThan(pointerIdx);
+    expect(logSpy).toHaveBeenCalledWith(
+      "docs_embedded",
+      expect.objectContaining({ sha: "new-sha", docCount: 1, chunkCount: 1 }),
+    );
+  });
+
+  it("upsert failure → pointer untouched, docs_embed_failed logged, rebuild still succeeds", async () => {
+    kvData.set("index:sha", "old-sha");
+    kvData.set("index:vector_docs_ns", "acme/backend:docs:old-sha");
+    getHeadShaSpy.mockResolvedValue("new-sha");
+    getRepoTreeSpy.mockResolvedValue([treeBlob("docs/setup.md")]);
+    readFileSpy.mockImplementation(async (path: string) => {
+      if (path === "docs/setup.md") {
+        return { path, content: "# Setup\n\nInstall the app." };
+      }
+      throw new Error(`unexpected read: ${path}`);
+    });
+    vectorUpsertSpy.mockImplementation(async () => {
+      callOrder.push("vectorUpsert");
+      return false;
+    });
+
+    const summary = await getOrRebuildIndex();
+
+    expect(kvData.get("index:vector_docs_ns")).toBe("acme/backend:docs:old-sha");
+    expect(vectorDeleteNamespaceSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      "docs_embed_failed",
+      expect.objectContaining({ sha: "new-sha" }),
+    );
+    expect(logSpy).toHaveBeenCalledWith("index_rebuilt", expect.anything());
+    expect(typeof summary).toBe("string");
+  });
+
+  it("caps content fetches at MAX_DOCS_TO_EMBED and logs docs_embed_capped (the #108 fan-out lesson)", async () => {
+    kvData.set("index:sha", "old-sha");
+    getHeadShaSpy.mockResolvedValue("new-sha");
+    const docs = Array.from({ length: MAX_DOCS_TO_EMBED + 10 }, (_, i) =>
+      treeBlob(`docs/d${i}.md`),
+    );
+    getRepoTreeSpy.mockResolvedValue(docs);
+    readFileSpy.mockImplementation(async (path: string) => {
+      if (path.startsWith("docs/")) return { path, content: "# T\n\nbody" };
+      throw new Error(`unexpected read: ${path}`);
+    });
+
+    await getOrRebuildIndex();
+
+    const docReads = readFileSpy.mock.calls.filter(([p]) =>
+      String(p).startsWith("docs/"),
+    );
+    expect(docReads).toHaveLength(MAX_DOCS_TO_EMBED);
+    expect(logSpy).toHaveBeenCalledWith(
+      "docs_embed_capped",
+      expect.anything(),
+    );
+  });
+});
+
+describe("getDocsVectorNamespace (#127)", () => {
+  it("returns the stored pointer, or null when the index has never embedded docs", async () => {
+    expect(await getDocsVectorNamespace()).toBeNull();
+    kvData.set("index:vector_docs_ns", "acme/backend:docs:abc");
+    expect(await getDocsVectorNamespace()).toBe("acme/backend:docs:abc");
   });
 });

--- a/src/lib/repo-index.ts
+++ b/src/lib/repo-index.ts
@@ -295,8 +295,17 @@ export function chunkMarkdownByHeadings(path: string, content: string): DocChunk
       sections.push({ heading: currentHeading, body });
     }
   };
+  // Fence tracking (#127 review): `# comment` lines inside ``` / ~~~
+  // fenced blocks are code, not headings — never split on them.
+  let inFence = false;
   for (const line of content.split("\n")) {
-    const m = /^#{1,3} (.+)$/.exec(line);
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
+      inFence = !inFence;
+      buf.push(line);
+      continue;
+    }
+    const m = inFence ? null : /^#{1,3} (.+)$/.exec(line);
     if (m) {
       flushSection();
       currentHeading = m[1].trim();
@@ -420,10 +429,23 @@ export async function getOrRebuildIndex(): Promise<string> {
     });
 
     // #127: embed doc chunks for hybrid retrieval. Runs ONLY on the
-    // SHA-changed path, after every KV write above, and is internally
-    // non-throwing — an embed failure degrades semantic doc search but
-    // never fails the index rebuild.
-    await embedDocChunks(currentSha, filterDocPaths(paths, config));
+    // SHA-changed path, after every KV write above. Fire-and-forget:
+    // embedding (up to MAX_DOCS_TO_EMBED content fetches + an upsert)
+    // must NOT sit on the agent's critical path — the rebuild returns
+    // the summary immediately and the embed completes in the background
+    // within the invocation window. Tradeoff: if the container is
+    // killed mid-embed, the docs pointer stays on the previous SHA's
+    // namespace until the next SHA change — acceptable, the doc arm
+    // just serves slightly stale chunks (or degrades if none exist).
+    // embedDocChunks is internally non-throwing; the catch is
+    // belt-and-braces so a contract violation can never surface as an
+    // unhandled rejection.
+    void embedDocChunks(currentSha, filterDocPaths(paths, config)).catch((err) => {
+      log("docs_embed_failed", {
+        sha: currentSha,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    });
 
     return summary;
   } catch (err) {
@@ -488,8 +510,17 @@ async function embedDocChunks(sha: string, docPaths: string[]): Promise<void> {
       }
     }
 
-    const namespace = docsNamespace(sha);
+    // Guard (#127 review): an empty chunk set (every readFile failed, or
+    // every doc was empty) must NOT swap the pointer — vectorUpsert([])
+    // short-circuits true, which would repoint queries at an EMPTY
+    // namespace and delete the previous working generation.
     const items = chunks.map((c) => ({ id: c.id, text: c.text, metadata: c.metadata }));
+    if (items.length === 0) {
+      log("docs_embed_empty", { sha, docCount });
+      return;
+    }
+
+    const namespace = docsNamespace(sha);
     const ok = await vectorUpsert(namespace, items);
     if (!ok) {
       log("docs_embed_failed", { sha, docCount, chunkCount: chunks.length });

--- a/src/lib/repo-index.ts
+++ b/src/lib/repo-index.ts
@@ -1,6 +1,12 @@
 import { kv } from "./kv";
 import { log } from "@/lib/logger";
 import {
+  isVectorConfigured,
+  docsNamespace,
+  vectorUpsert,
+  vectorDeleteNamespace,
+} from "./vector";
+import {
   type BattleMageConfig,
   parseBattleMageConfig,
   getAnnotation,
@@ -189,12 +195,149 @@ export function buildDocCatalogSection(entries: DocEntry[]): string {
   );
 }
 
+// ── Doc chunking for semantic retrieval (#127) ───────────────────────
+// Docs are split into heading-scoped chunks and embedded into a
+// SHA-scoped vector namespace during index rebuild. Chunking is pure and
+// exported for testing; the embedding side effect lives in
+// embedDocChunks below.
+
+/**
+ * Hard character cap per embedded chunk. Sections larger than this are
+ * re-split on paragraph boundaries so no single embedding input is a
+ * whole-file blob.
+ */
+export const MAX_CHUNK_CHARS = 1500;
+
+/**
+ * Hard cap on per-rebuild doc content fetches. Same lesson as #108: the
+ * embed pipeline reads doc CONTENT (one GitHub call per doc), and on a
+ * 260-doc repo an uncapped loop is a fan-out incident. When the cap
+ * trips, `docs_embed_capped` is logged so the gap is observable.
+ */
+export const MAX_DOCS_TO_EMBED = 50;
+
+export interface DocChunk {
+  /** Deterministic id: `${path}#${ordinal}`. */
+  id: string;
+  /** Text sent for embedding: heading + section body. */
+  text: string;
+  metadata: { path: string; heading: string; excerpt: string };
+}
+
+const EXCERPT_MAX_CHARS = 160;
+
+function makeExcerpt(text: string): string {
+  return text.replace(/\s+/g, " ").trim().slice(0, EXCERPT_MAX_CHARS);
+}
+
+// Greedily pack paragraphs into pieces of at most `budget` chars. A
+// single paragraph over budget is hard-sliced — pathological, but the
+// cap must hold unconditionally.
+function splitOnParagraphs(body: string, budget: number): string[] {
+  const paragraphs = body.split(/\n{2,}/);
+  const pieces: string[] = [];
+  let current = "";
+  const flush = () => {
+    if (current.length > 0) pieces.push(current);
+    current = "";
+  };
+  for (const para of paragraphs) {
+    if (para.length > budget) {
+      flush();
+      for (let i = 0; i < para.length; i += budget) {
+        pieces.push(para.slice(i, i + budget));
+      }
+      continue;
+    }
+    const candidate = current.length === 0 ? para : `${current}\n\n${para}`;
+    if (candidate.length > budget) {
+      flush();
+      current = para;
+    } else {
+      current = candidate;
+    }
+  }
+  flush();
+  return pieces;
+}
+
+/**
+ * Split a Markdown doc into heading-scoped chunks for embedding.
+ *
+ * - Splits on `#`, `##`, and `###` headings; `####`+ stays inside its
+ *   parent section (deep subheads are too granular to stand alone).
+ * - Content before the first heading becomes a preamble chunk titled
+ *   via extractDocTitle(path).
+ * - Sections over MAX_CHUNK_CHARS are re-split on paragraph boundaries;
+ *   every sub-chunk shares the section heading.
+ * - Ids are deterministic `${path}#${ordinal}` so re-embedding the same
+ *   content is an idempotent upsert.
+ *
+ * Pure function — exported for testing.
+ */
+export function chunkMarkdownByHeadings(path: string, content: string): DocChunk[] {
+  if (!content || content.trim().length === 0) return [];
+
+  interface Section {
+    heading: string;
+    body: string;
+  }
+  const sections: Section[] = [];
+  let currentHeading: string | null = null; // null = preamble
+  let buf: string[] = [];
+  const flushSection = () => {
+    const body = buf.join("\n").trim();
+    buf = [];
+    if (currentHeading === null) {
+      // Preamble only becomes a chunk when it has content.
+      if (body.length > 0) sections.push({ heading: extractDocTitle(path), body });
+    } else {
+      sections.push({ heading: currentHeading, body });
+    }
+  };
+  for (const line of content.split("\n")) {
+    const m = /^#{1,3} (.+)$/.exec(line);
+    if (m) {
+      flushSection();
+      currentHeading = m[1].trim();
+    } else {
+      buf.push(line);
+    }
+  }
+  flushSection();
+
+  const chunks: DocChunk[] = [];
+  for (const section of sections) {
+    // Budget the body so heading + separator + body stays under the cap.
+    const budget = Math.max(1, MAX_CHUNK_CHARS - section.heading.length - 2);
+    const pieces =
+      section.body.length === 0 ? [""] : splitOnParagraphs(section.body, budget);
+    for (const piece of pieces) {
+      const text = piece.length > 0 ? `${section.heading}\n\n${piece}` : section.heading;
+      chunks.push({
+        id: `${path}#${chunks.length}`,
+        text,
+        metadata: {
+          path,
+          heading: section.heading,
+          excerpt: makeExcerpt(piece.length > 0 ? piece : section.heading),
+        },
+      });
+    }
+  }
+  return chunks;
+}
+
 // ── KV keys ──────────────────────────────────────────────────────────
 const INDEX_SHA_KEY = "index:sha";
 const INDEX_TOPICS_KEY = "index:topics";
 const INDEX_SUMMARY_KEY = "index:summary";
 const INDEX_DOC_CATALOG_KEY = "index:doc_catalog";
 const INDEX_BUILT_AT_KEY = "index:built_at";
+// Points at the docs vector namespace currently serving queries (#127).
+// Written ONLY after a successful upsert of the new generation, so
+// readers never see a half-populated namespace.
+const INDEX_VECTOR_DOCS_NS_KEY = "index:vector_docs_ns";
 
 // ── GitHub helpers (import from github.ts at runtime) ────────────────
 // These are dynamically imported to keep the pure functions above testable
@@ -275,10 +418,102 @@ export async function getOrRebuildIndex(): Promise<string> {
       docCount: docCatalog.length,
       duration_ms: Date.now() - startTime,
     });
+
+    // #127: embed doc chunks for hybrid retrieval. Runs ONLY on the
+    // SHA-changed path, after every KV write above, and is internally
+    // non-throwing — an embed failure degrades semantic doc search but
+    // never fails the index rebuild.
+    await embedDocChunks(currentSha, filterDocPaths(paths, config));
+
     return summary;
   } catch (err) {
     log("index_build_error", { message: err instanceof Error ? err.message : String(err) });
     return "";
+  }
+}
+
+/**
+ * The docs vector namespace currently serving semantic doc queries, or
+ * null when no generation has ever been embedded (or KV is unavailable).
+ * Non-throwing — a missing pointer degrades search_repo to lexical-only.
+ */
+export async function getDocsVectorNamespace(): Promise<string | null> {
+  try {
+    const ns = await kv.get<string>(INDEX_VECTOR_DOCS_NS_KEY);
+    return ns ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Chunk + embed docs into a fresh SHA-scoped namespace (#127).
+ *
+ * Generation swap ordering (invariant N1):
+ *   1. upsert all chunks into docsNamespace(sha)
+ *   2. only on success, repoint INDEX_VECTOR_DOCS_NS_KEY at it
+ *   3. best-effort delete the previous generation's namespace
+ * An upsert failure leaves the pointer untouched — queries keep serving
+ * the previous generation and `docs_embed_failed` records the gap.
+ *
+ * Non-throwing by construction: any unexpected error is caught and
+ * logged so a vector outage can never fail the index rebuild.
+ */
+async function embedDocChunks(sha: string, docPaths: string[]): Promise<void> {
+  // Skip the whole pipeline (including the GitHub content fan-out) when
+  // the vector index isn't provisioned — this is the expected state for
+  // installs without UPSTASH_VECTOR_REST_*, not an error.
+  if (!isVectorConfigured()) return;
+  try {
+    const startTime = Date.now();
+    if (docPaths.length > MAX_DOCS_TO_EMBED) {
+      log("docs_embed_capped", {
+        totalDocs: docPaths.length,
+        cap: MAX_DOCS_TO_EMBED,
+      });
+    }
+    const capped = docPaths.slice(0, MAX_DOCS_TO_EMBED);
+    const { readFile } = await import("@/lib/github");
+    const chunks: DocChunk[] = [];
+    let docCount = 0;
+    for (const path of capped) {
+      try {
+        const result = await readFile(path);
+        if ("content" in result && typeof result.content === "string") {
+          docCount++;
+          chunks.push(...chunkMarkdownByHeadings(path, result.content));
+        }
+      } catch {
+        // Unreadable doc — skip it, embed the rest.
+      }
+    }
+
+    const namespace = docsNamespace(sha);
+    const items = chunks.map((c) => ({ id: c.id, text: c.text, metadata: c.metadata }));
+    const ok = await vectorUpsert(namespace, items);
+    if (!ok) {
+      log("docs_embed_failed", { sha, docCount, chunkCount: chunks.length });
+      return;
+    }
+
+    const previous = await getDocsVectorNamespace();
+    await kv.set(INDEX_VECTOR_DOCS_NS_KEY, namespace);
+    if (previous && previous !== namespace) {
+      // Best-effort cleanup — vectorDeleteNamespace is non-throwing, and
+      // a leaked stale namespace is unreachable once the pointer moved.
+      await vectorDeleteNamespace(previous);
+    }
+    log("docs_embedded", {
+      sha,
+      docCount,
+      chunkCount: chunks.length,
+      duration_ms: Date.now() - startTime,
+    });
+  } catch (err) {
+    log("docs_embed_failed", {
+      sha,
+      message: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 

--- a/src/lib/retrieval.test.ts
+++ b/src/lib/retrieval.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+import {
+  RRF_K,
+  RECALL_TOP_K,
+  MAX_ARM_RESULTS,
+  AGE_TIER_BOOSTS,
+  ageBoost,
+  fuseRankedLists,
+  lexicalRank,
+  type RecallCandidate,
+} from "./retrieval";
+
+// Pinned clock — no test below may depend on the real current time.
+const NOW = new Date("2026-07-08T00:00:00Z");
+
+describe("retrieval constants", () => {
+  it("pins the RRF constant and recall sizes", () => {
+    expect(RRF_K).toBe(60);
+    expect(RECALL_TOP_K).toBe(5);
+    expect(MAX_ARM_RESULTS).toBe(10);
+  });
+
+  it("age tiers are 7/30/90 days with strictly decreasing boosts", () => {
+    expect(AGE_TIER_BOOSTS.map((t) => t.maxAgeDays)).toEqual([7, 30, 90]);
+    const boosts = AGE_TIER_BOOSTS.map((t) => t.boost);
+    for (let i = 1; i < boosts.length; i++) {
+      expect(boosts[i]).toBeLessThan(boosts[i - 1]);
+      expect(boosts[i]).toBeGreaterThan(0);
+    }
+  });
+
+  it("largest boost is near-tie sized: smaller than the smallest single-arm adjacent-rank gap", () => {
+    // Deepest rank an arm can contribute is MAX_ARM_RESULTS; the gap
+    // between ranks (MAX_ARM_RESULTS - 1) and MAX_ARM_RESULTS is the
+    // smallest gap a boost must NOT be able to flip.
+    const maxBoost = Math.max(...AGE_TIER_BOOSTS.map((t) => t.boost));
+    const smallestGap =
+      1 / (RRF_K + MAX_ARM_RESULTS - 1) - 1 / (RRF_K + MAX_ARM_RESULTS);
+    expect(maxBoost).toBeLessThan(smallestGap);
+  });
+});
+
+describe("ageBoost (inclusive tier boundaries, pinned clock)", () => {
+  it("0 days old → freshest tier", () => {
+    expect(ageBoost("2026-07-08", NOW)).toBe(0.00015);
+  });
+  it("exactly 7 days old → freshest tier (boundary inclusive)", () => {
+    expect(ageBoost("2026-07-01", NOW)).toBe(0.00015);
+  });
+  it("8 days old → 30d tier", () => {
+    expect(ageBoost("2026-06-30", NOW)).toBe(0.0001);
+  });
+  it("exactly 30 days old → 30d tier (boundary inclusive)", () => {
+    expect(ageBoost("2026-06-08", NOW)).toBe(0.0001);
+  });
+  it("31 days old → 90d tier", () => {
+    expect(ageBoost("2026-06-07", NOW)).toBe(0.00005);
+  });
+  it("exactly 90 days old → 90d tier (boundary inclusive)", () => {
+    expect(ageBoost("2026-04-09", NOW)).toBe(0.00005);
+  });
+  it("91 days old → no boost", () => {
+    expect(ageBoost("2026-04-08", NOW)).toBe(0);
+  });
+  it("missing or unparseable timestamp → no boost", () => {
+    expect(ageBoost(undefined, NOW)).toBe(0);
+    expect(ageBoost("not-a-date", NOW)).toBe(0);
+    expect(ageBoost("unknown", NOW)).toBe(0); // legacy history sentinel
+  });
+});
+
+describe("fuseRankedLists — reciprocal rank fusion (hand-computed)", () => {
+  it("sums 1/(RRF_K + rank) across arms; item ranked high in both arms wins", () => {
+    // lexical: a=1, b=2, c=3   semantic: b=1, c=2, a=3
+    const fused = fuseRankedLists(["a", "b", "c"], ["b", "c", "a"]);
+    // b: 1/62 + 1/61 = 0.032522474881015337
+    // a: 1/61 + 1/63 = 0.032266458495966693
+    // c: 1/63 + 1/62 = 0.032002048131080388
+    expect(fused.map((f) => f.id)).toEqual(["b", "a", "c"]);
+    expect(fused[0].score).toBeCloseTo(1 / 62 + 1 / 61, 12);
+    expect(fused[1].score).toBeCloseTo(1 / 61 + 1 / 63, 12);
+    expect(fused[2].score).toBeCloseTo(1 / 63 + 1 / 62, 12);
+  });
+
+  it("single-arm item scores exactly 1/(RRF_K + rank)", () => {
+    const fused = fuseRankedLists(["x"], []);
+    expect(fused).toHaveLength(1);
+    expect(fused[0].score).toBeCloseTo(1 / 61, 12);
+  });
+
+  it("exact cross-arm tie without timestamps keeps lexical-arm candidate first (deterministic)", () => {
+    // a is lexical rank 1, b is semantic rank 1 — identical 1/61 scores.
+    const fused = fuseRankedLists(["a"], ["b"]);
+    expect(fused.map((f) => f.id)).toEqual(["a", "b"]);
+    expect(fused[0].score).toBeCloseTo(fused[1].score, 12);
+  });
+
+  it("age boost breaks an exact cross-arm tie in favor of the fresher item", () => {
+    const fused = fuseRankedLists(["a"], ["b"], {
+      timestamps: { a: "2026-04-08", b: "2026-07-06" }, // a: 91d → +0; b: 2d → +0.00015
+      now: NOW,
+    });
+    expect(fused.map((f) => f.id)).toEqual(["b", "a"]);
+    expect(fused[0].score).toBeCloseTo(1 / 61 + 0.00015, 12);
+    expect(fused[1].score).toBeCloseTo(1 / 61, 12);
+  });
+
+  it("age boost between tiers breaks a same-score tie (7d tier beats 90d tier)", () => {
+    const fused = fuseRankedLists(["a"], ["b"], {
+      timestamps: { a: "2026-05-20", b: "2026-07-07" }, // a: 49d → +0.00005; b: 1d → +0.00015
+      now: NOW,
+    });
+    expect(fused.map((f) => f.id)).toEqual(["b", "a"]);
+    expect(fused[0].score).toBeCloseTo(1 / 61 + 0.00015, 12);
+    expect(fused[1].score).toBeCloseTo(1 / 61 + 0.00005, 12);
+  });
+
+  it("age boost NEVER flips a single-arm adjacent-rank pair (F2 invariant)", () => {
+    // a is rank 1 but stale (>90d, +0); b is rank 2 and fresh (+0.00015).
+    // Gap 1/61 - 1/62 ≈ 0.000264 > 0.00015, so a must stay first.
+    const fused = fuseRankedLists(["a", "b"], [], {
+      timestamps: { a: "2026-01-01", b: "2026-07-07" },
+      now: NOW,
+    });
+    expect(fused.map((f) => f.id)).toEqual(["a", "b"]);
+    expect(fused[0].score).toBeCloseTo(1 / 61, 12);
+    expect(fused[1].score).toBeCloseTo(1 / 62 + 0.00015, 12);
+  });
+
+  it("duplicate ids within one arm keep only the best rank", () => {
+    const fused = fuseRankedLists(["a", "a", "b"], []);
+    expect(fused.map((f) => f.id)).toEqual(["a", "b"]);
+    expect(fused[0].score).toBeCloseTo(1 / 61, 12);
+    // b takes rank 2 after dedupe, not rank 3.
+    expect(fused[1].score).toBeCloseTo(1 / 62, 12);
+  });
+
+  it("empty lexical arm degrades to pure semantic ranking", () => {
+    const fused = fuseRankedLists([], ["x", "y"]);
+    expect(fused.map((f) => f.id)).toEqual(["x", "y"]);
+    expect(fused[0].score).toBeCloseTo(1 / 61, 12);
+    expect(fused[1].score).toBeCloseTo(1 / 62, 12);
+  });
+
+  it("empty semantic arm degrades to pure lexical ranking", () => {
+    const fused = fuseRankedLists(["x", "y"], []);
+    expect(fused.map((f) => f.id)).toEqual(["x", "y"]);
+  });
+
+  it("both arms empty → empty result", () => {
+    expect(fuseRankedLists([], [])).toEqual([]);
+  });
+
+  it("caps output at RECALL_TOP_K by default", () => {
+    const ids = ["a", "b", "c", "d", "e", "f", "g", "h"];
+    const fused = fuseRankedLists(ids, []);
+    expect(fused).toHaveLength(RECALL_TOP_K);
+    expect(fused.map((f) => f.id)).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  it("honors an explicit topK, including 0", () => {
+    expect(fuseRankedLists(["a", "b", "c"], [], { topK: 2 })).toHaveLength(2);
+    expect(fuseRankedLists(["a", "b", "c"], [], { topK: 0 })).toEqual([]);
+  });
+
+  it("ids without a timestamps entry get no boost (no NaN leakage)", () => {
+    const fused = fuseRankedLists(["a"], [], {
+      timestamps: { somebodyElse: "2026-07-07" },
+      now: NOW,
+    });
+    expect(fused[0].score).toBeCloseTo(1 / 61, 12);
+    expect(Number.isFinite(fused[0].score)).toBe(true);
+  });
+});
+
+describe("lexicalRank", () => {
+  const candidates: RecallCandidate[] = [
+    { id: "k1", text: "The Redis KV wrapper lives in src/lib/kv.ts", timestamp: "2026-06-01" },
+    { id: "k2", text: "Deploys go through Vercel, never Cloud Run", timestamp: "2026-05-01" },
+    { id: "k3", text: "The redis client is @upstash/redis behind the kv.ts wrapper", timestamp: "2026-07-01" },
+  ];
+
+  it("ranks by distinct matched tokens; ties broken by newer timestamp", () => {
+    // "redis" and "wrapper" match k1 and k3 equally → newer k3 first.
+    const ranked = lexicalRank("where is the redis wrapper", candidates);
+    expect(ranked).toEqual(["k3", "k1"]);
+  });
+
+  it("excludes zero-score candidates entirely", () => {
+    const ranked = lexicalRank("redis wrapper", candidates);
+    expect(ranked).not.toContain("k2");
+  });
+
+  it("matching is case-insensitive", () => {
+    const ranked = lexicalRank("REDIS Wrapper", candidates);
+    expect(ranked).toEqual(["k3", "k1"]);
+  });
+
+  it("more distinct matched tokens outranks fewer, regardless of recency", () => {
+    const ranked = lexicalRank("vercel cloud run deploys", candidates);
+    // k2 matches vercel+cloud+run+deploys; nothing else matches ≥1 token better.
+    expect(ranked[0]).toBe("k2");
+  });
+
+  it("stopwords like 'the' do not count as matches", () => {
+    // Both k1 and k3 contain "The"/"the"; a stopword-only question matches nothing.
+    expect(lexicalRank("the", candidates)).toEqual([]);
+  });
+
+  it("empty question → empty result", () => {
+    expect(lexicalRank("", candidates)).toEqual([]);
+    expect(lexicalRank("   ", candidates)).toEqual([]);
+  });
+
+  it("caps at MAX_ARM_RESULTS", () => {
+    const many: RecallCandidate[] = Array.from({ length: 15 }, (_, i) => ({
+      id: `id${i}`,
+      text: `vercel deployment note ${i}`,
+      timestamp: "2026-06-01",
+    }));
+    expect(lexicalRank("vercel deployment", many)).toHaveLength(MAX_ARM_RESULTS);
+  });
+});

--- a/src/lib/retrieval.test.ts
+++ b/src/lib/retrieval.test.ts
@@ -220,4 +220,14 @@ describe("lexicalRank", () => {
     }));
     expect(lexicalRank("vercel deployment", many)).toHaveLength(MAX_ARM_RESULTS);
   });
+
+  it('legacy "unknown" timestamps lose ties to real ISO dates (#127 review)', () => {
+    // "unknown" > "2026-..." as a raw string — the tie-break must coerce
+    // non-ISO timestamps to the OLDEST bucket, not let them win.
+    const cands: RecallCandidate[] = [
+      { id: "legacy", text: "vercel deploy fact", timestamp: "unknown" },
+      { id: "dated", text: "vercel deploy note", timestamp: "2026-01-01" },
+    ];
+    expect(lexicalRank("vercel deploy", cands)).toEqual(["dated", "legacy"]);
+  });
 });

--- a/src/lib/retrieval.ts
+++ b/src/lib/retrieval.ts
@@ -136,6 +136,8 @@ const STOPWORDS = new Set([
   "whom", "why", "how",
 ]);
 
+const ISO_DATE_PREFIX_RE = /^\d{4}-\d{2}-\d{2}/;
+
 /**
  * Lexical arm: rank candidates by how many DISTINCT question tokens
  * substring-match their text (case-insensitive). Tokens are lowercase
@@ -158,13 +160,18 @@ export function lexicalRank(question: string, candidates: RecallCandidate[]): st
     .map((c) => {
       const text = c.text.toLowerCase();
       const score = tokens.filter((t) => text.includes(t)).length;
-      return { id: c.id, score, timestamp: c.timestamp ?? "" };
+      // Non-ISO timestamps (missing, or the legacy "unknown" sentinel)
+      // coerce to "" so they sort as the OLDEST bucket — a raw string
+      // compare would rank "unknown" above every real date (#127 review).
+      const timestamp =
+        c.timestamp && ISO_DATE_PREFIX_RE.test(c.timestamp) ? c.timestamp : "";
+      return { id: c.id, score, timestamp };
     })
     .filter((c) => c.score > 0)
     .sort(
       (a, b) =>
         b.score - a.score ||
-        // ISO dates compare correctly as strings; missing sorts oldest.
+        // ISO dates compare correctly as strings; "" sorts oldest.
         b.timestamp.localeCompare(a.timestamp),
     )
     .slice(0, MAX_ARM_RESULTS)

--- a/src/lib/retrieval.ts
+++ b/src/lib/retrieval.ts
@@ -1,0 +1,172 @@
+/**
+ * Retrieval primitives — pure functions for hybrid lexical + semantic
+ * recall (#127).
+ *
+ * Two ranked "arms" (a lexical keyword match and a semantic vector
+ * match) are fused with Reciprocal Rank Fusion (RRF): each arm
+ * contributes 1/(RRF_K + rank) per candidate, so items ranked well in
+ * BOTH arms bubble to the top without either arm's raw scores needing
+ * to be comparable. A tiny age boost breaks near-ties in favor of
+ * fresher entries — sized so it can NEVER flip two adjacently-ranked
+ * candidates from the same arm (see AGE_TIER_BOOSTS).
+ *
+ * Everything in this file is pure and side-effect free — the vector
+ * store lives behind src/lib/vector.ts, callers wire the arms together.
+ */
+
+/** Standard RRF dampening constant (Cormack et al. use 60). */
+export const RRF_K = 60;
+
+/** How many fused entries the KB recall surfaces into the prompt. */
+export const RECALL_TOP_K = 5;
+
+/** Cap per retrieval arm before fusion. */
+export const MAX_ARM_RESULTS = 10;
+
+export interface AgeTierBoost {
+  /** Inclusive upper bound of the tier, in days. */
+  maxAgeDays: number;
+  boost: number;
+}
+
+/**
+ * Freshness tiers. The largest boost (0.00015) is deliberately smaller
+ * than the smallest adjacent-rank RRF gap a single arm can produce
+ * (1/(RRF_K + MAX_ARM_RESULTS - 1) - 1/(RRF_K + MAX_ARM_RESULTS) ≈
+ * 0.000239), so age only ever breaks ties between items whose fused
+ * scores are already effectively equal — it never overrides relevance.
+ */
+export const AGE_TIER_BOOSTS: AgeTierBoost[] = [
+  { maxAgeDays: 7, boost: 0.00015 },
+  { maxAgeDays: 30, boost: 0.0001 },
+  { maxAgeDays: 90, boost: 0.00005 },
+];
+
+/** A candidate the lexical arm ranks — id + text + optional ISO date. */
+export interface RecallCandidate {
+  id: string;
+  text: string;
+  timestamp?: string;
+}
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * Tiered freshness boost for a timestamp. Age is measured in fractional
+ * days from the timestamp's UTC-midnight parse (ISO `YYYY-MM-DD` strings
+ * parse as UTC midnight per the ECMAScript date-only rule). Tier
+ * boundaries are inclusive; missing or unparseable timestamps (including
+ * the legacy "unknown" sentinel) get no boost.
+ */
+export function ageBoost(timestamp: string | undefined, now: Date = new Date()): number {
+  if (!timestamp) return 0;
+  const parsed = Date.parse(timestamp);
+  if (Number.isNaN(parsed)) return 0;
+  const ageDays = (now.getTime() - parsed) / MS_PER_DAY;
+  for (const tier of AGE_TIER_BOOSTS) {
+    if (ageDays <= tier.maxAgeDays) return tier.boost;
+  }
+  return 0;
+}
+
+export interface FusedResult {
+  id: string;
+  score: number;
+}
+
+export interface FuseOptions {
+  /** id → ISO date; ids without an entry get no age boost. */
+  timestamps?: Record<string, string | undefined>;
+  /** Injectable clock for deterministic tests. */
+  now?: Date;
+  /** Result cap; defaults to RECALL_TOP_K. Explicit 0 is honored. */
+  topK?: number;
+}
+
+/**
+ * Reciprocal Rank Fusion over two ranked id lists.
+ *
+ * score(id) = Σ over arms of 1/(RRF_K + rank) — ranks are 1-based, and
+ * duplicate ids WITHIN one arm keep only their best (first) rank —
+ * plus the age boost for the id's timestamp (if provided).
+ *
+ * Sorting is a stable descending sort, so exact ties keep enumeration
+ * order: lexical-arm candidates first, then semantic-only candidates in
+ * semantic order.
+ */
+export function fuseRankedLists(
+  lexicalIds: string[],
+  semanticIds: string[],
+  options?: FuseOptions,
+): FusedResult[] {
+  const topK = options?.topK ?? RECALL_TOP_K;
+  const now = options?.now ?? new Date();
+
+  // Enumeration order (lexical first) determines tie order after the
+  // stable sort below.
+  const rrfScores = new Map<string, number>();
+  for (const arm of [lexicalIds, semanticIds]) {
+    const seen = new Set<string>();
+    let rank = 0;
+    for (const id of arm) {
+      if (seen.has(id)) continue; // within-arm dedupe keeps best rank
+      seen.add(id);
+      rank++;
+      rrfScores.set(id, (rrfScores.get(id) ?? 0) + 1 / (RRF_K + rank));
+    }
+  }
+
+  const fused: FusedResult[] = [...rrfScores.entries()].map(([id, rrf]) => ({
+    id,
+    score: rrf + ageBoost(options?.timestamps?.[id], now),
+  }));
+  // Array.prototype.sort is stable per ES2019 — ties keep insertion order.
+  fused.sort((a, b) => b.score - a.score);
+  return fused.slice(0, topK);
+}
+
+// Small stopword set — question words and glue that would otherwise
+// substring-match almost every entry. Tokens under 3 chars are already
+// dropped before this filter applies.
+const STOPWORDS = new Set([
+  "the", "and", "for", "are", "was", "were", "not", "but", "you", "your",
+  "our", "their", "his", "her", "its", "has", "have", "had", "can", "could",
+  "should", "would", "will", "does", "did", "with", "this", "that", "these",
+  "those", "from", "into", "about", "what", "when", "where", "which", "who",
+  "whom", "why", "how",
+]);
+
+/**
+ * Lexical arm: rank candidates by how many DISTINCT question tokens
+ * substring-match their text (case-insensitive). Tokens are lowercase
+ * alphanumeric runs of 3+ chars, minus STOPWORDS. Ties break toward the
+ * newer timestamp; zero-score candidates are excluded entirely; output
+ * is capped at MAX_ARM_RESULTS ids.
+ */
+export function lexicalRank(question: string, candidates: RecallCandidate[]): string[] {
+  const tokens = [
+    ...new Set(
+      question
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter((t) => t.length >= 3 && !STOPWORDS.has(t)),
+    ),
+  ];
+  if (tokens.length === 0) return [];
+
+  return candidates
+    .map((c) => {
+      const text = c.text.toLowerCase();
+      const score = tokens.filter((t) => text.includes(t)).length;
+      return { id: c.id, score, timestamp: c.timestamp ?? "" };
+    })
+    .filter((c) => c.score > 0)
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        // ISO dates compare correctly as strings; missing sorts oldest.
+        b.timestamp.localeCompare(a.timestamp),
+    )
+    .slice(0, MAX_ARM_RESULTS)
+    .map((c) => c.id);
+}

--- a/src/lib/turn-runner.ts
+++ b/src/lib/turn-runner.ts
@@ -339,7 +339,13 @@ export async function runMentionTurn(params: MentionTurnParams): Promise<void> {
       (toolName, input) => {
         progressThrottle.update(buildThinkingMessage(toolName, input));
       },
-      { maxRounds: EFFORT_BUDGETS[mentionEffort].maxRounds, effort: mentionEffort },
+      {
+        maxRounds: EFFORT_BUDGETS[mentionEffort].maxRounds,
+        effort: mentionEffort,
+        // KB recall keys off the CLEAN question, not the hint-augmented
+        // message the model receives (#127 review).
+        recallQuestion: cleanMessage,
+      },
     );
     // Drain any pending progress update before the final write so a
     // stale progress message can't land on top of the final answer.
@@ -664,7 +670,12 @@ export async function runFollowupTurn(params: FollowupTurnParams): Promise<void>
       (toolName, input) => {
         followupProgress.update(buildThinkingMessage(toolName, input));
       },
-      { maxRounds: EFFORT_BUDGETS[followupEval.effort].maxRounds, effort: followupEval.effort },
+      {
+        maxRounds: EFFORT_BUDGETS[followupEval.effort].maxRounds,
+        effort: followupEval.effort,
+        // Same as the mention flow: recall on the clean question.
+        recallQuestion: cleanMessage,
+      },
     );
     await followupProgress.flush();
 

--- a/src/lib/vector.test.ts
+++ b/src/lib/vector.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as Sentry from "@sentry/nextjs";
+
+const { logSpy } = vi.hoisted(() => ({ logSpy: vi.fn() }));
+vi.mock("./logger", () => ({
+  log: (...args: unknown[]) => logSpy(...args),
+}));
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+// NOTE: no vi.mock of "@upstash/vector". The SDK is isolated behind the
+// VectorStore interface; tests inject a fake store via the factory seam,
+// so this suite pins OUR chokepoint contract, not the SDK surface.
+import {
+  vectorQuery,
+  vectorUpsert,
+  vectorDelete,
+  vectorDeleteNamespace,
+  isVectorConfigured,
+  kbNamespace,
+  docsNamespace,
+  VECTOR_OP_TIMEOUT_MS,
+  __setVectorStoreFactoryForTests,
+  type VectorStore,
+} from "./vector";
+
+function makeFakeStore(overrides: Partial<VectorStore> = {}): VectorStore {
+  return {
+    upsert: vi.fn(async () => {}),
+    query: vi.fn(async () => [
+      { id: "doc-1", score: 0.91, metadata: { path: "docs/setup.md" } },
+      { id: "doc-2", score: 0.84, metadata: { path: "docs/usage.md" } },
+    ]),
+    delete: vi.fn(async () => {}),
+    deleteNamespace: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+function stubVectorEnv(): void {
+  vi.stubEnv("UPSTASH_VECTOR_REST_URL", "https://example-vector.upstash.io");
+  vi.stubEnv("UPSTASH_VECTOR_REST_TOKEN", "test-token");
+}
+
+beforeEach(() => {
+  logSpy.mockClear();
+  vi.mocked(Sentry.captureException).mockClear();
+  // Reset the memoized store between tests.
+  __setVectorStoreFactoryForTests(null);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+  __setVectorStoreFactoryForTests(null);
+});
+
+describe("namespace helpers (pure given env)", () => {
+  it("kbNamespace is {owner}/{repo}:kb", () => {
+    vi.stubEnv("GITHUB_OWNER", "acme");
+    vi.stubEnv("GITHUB_REPO", "backend");
+    expect(kbNamespace()).toBe("acme/backend:kb");
+  });
+
+  it("docsNamespace is {owner}/{repo}:docs:{sha}", () => {
+    vi.stubEnv("GITHUB_OWNER", "acme");
+    vi.stubEnv("GITHUB_REPO", "backend");
+    expect(docsNamespace("abc1234")).toBe("acme/backend:docs:abc1234");
+  });
+});
+
+describe("isVectorConfigured", () => {
+  it("false when both env vars are absent", () => {
+    vi.stubEnv("UPSTASH_VECTOR_REST_URL", "");
+    vi.stubEnv("UPSTASH_VECTOR_REST_TOKEN", "");
+    expect(isVectorConfigured()).toBe(false);
+  });
+
+  it("false when only the URL is set", () => {
+    vi.stubEnv("UPSTASH_VECTOR_REST_URL", "https://example-vector.upstash.io");
+    vi.stubEnv("UPSTASH_VECTOR_REST_TOKEN", "");
+    expect(isVectorConfigured()).toBe(false);
+  });
+
+  it("true when both are set", () => {
+    stubVectorEnv();
+    expect(isVectorConfigured()).toBe(true);
+  });
+});
+
+describe("degradation: not configured", () => {
+  beforeEach(() => {
+    vi.stubEnv("UPSTASH_VECTOR_REST_URL", "");
+    vi.stubEnv("UPSTASH_VECTOR_REST_TOKEN", "");
+  });
+
+  it("vectorQuery returns null and logs vector_unavailable; the store factory is never invoked", async () => {
+    const factory = vi.fn(() => makeFakeStore());
+    __setVectorStoreFactoryForTests(factory);
+
+    const result = await vectorQuery("acme/backend:kb", "how does auth work", 10);
+    expect(result).toBeNull();
+    expect(factory).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      "vector_unavailable",
+      expect.objectContaining({ op: "query", reason: "not_configured" }),
+    );
+  });
+
+  it("vectorUpsert returns false and logs vector_unavailable", async () => {
+    const factory = vi.fn(() => makeFakeStore());
+    __setVectorStoreFactoryForTests(factory);
+
+    const ok = await vectorUpsert("acme/backend:kb", [{ id: "e1", text: "fact" }]);
+    expect(ok).toBe(false);
+    expect(factory).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      "vector_unavailable",
+      expect.objectContaining({ op: "upsert", reason: "not_configured" }),
+    );
+  });
+
+  it("unconfigured is NOT an error: no vector_error, no Sentry capture", async () => {
+    await vectorQuery("ns", "q", 5);
+    expect(logSpy.mock.calls.map((c) => c[0])).not.toContain("vector_error");
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+});
+
+describe("happy path observability", () => {
+  beforeEach(() => stubVectorEnv());
+
+  it("vectorQuery returns matches and logs vector_op with op/namespace/durationMs/count", async () => {
+    __setVectorStoreFactoryForTests(() => makeFakeStore());
+    const matches = await vectorQuery("acme/backend:docs:abc", "deployment flow", 10);
+    expect(matches).toHaveLength(2);
+    expect(matches![0]).toEqual(
+      expect.objectContaining({ id: "doc-1", score: 0.91 }),
+    );
+    const call = logSpy.mock.calls.find((c) => c[0] === "vector_op");
+    expect(call).toBeDefined();
+    const payload = call![1] as Record<string, unknown>;
+    expect(payload.op).toBe("query");
+    expect(payload.namespace).toBe("acme/backend:docs:abc");
+    expect(payload.count).toBe(2);
+    expect(typeof payload.durationMs).toBe("number");
+  });
+
+  it("an available store with no matches returns [] (distinct from null)", async () => {
+    __setVectorStoreFactoryForTests(() =>
+      makeFakeStore({ query: vi.fn(async () => []) }),
+    );
+    const matches = await vectorQuery("ns", "q", 10);
+    expect(matches).toEqual([]);
+    expect(matches).not.toBeNull();
+  });
+
+  it("memoizes the store: two calls construct it once", async () => {
+    const factory = vi.fn(() => makeFakeStore());
+    __setVectorStoreFactoryForTests(factory);
+    await vectorQuery("ns", "q1", 5);
+    await vectorQuery("ns", "q2", 5);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("vectorUpsert forwards items, returns true, and logs count", async () => {
+    const store = makeFakeStore();
+    __setVectorStoreFactoryForTests(() => store);
+    const items = [
+      { id: "e1", text: "fact one", metadata: { timestamp: "2026-07-01" } },
+      { id: "e2", text: "fact two", metadata: { timestamp: "2026-07-02" } },
+    ];
+    const ok = await vectorUpsert("acme/backend:kb", items);
+    expect(ok).toBe(true);
+    expect(store.upsert).toHaveBeenCalledWith("acme/backend:kb", items);
+    expect(logSpy).toHaveBeenCalledWith(
+      "vector_op",
+      expect.objectContaining({ op: "upsert", count: 2 }),
+    );
+  });
+
+  it("vectorUpsert with an empty item list short-circuits true without touching the store", async () => {
+    const store = makeFakeStore();
+    __setVectorStoreFactoryForTests(() => store);
+    const ok = await vectorUpsert("acme/backend:kb", []);
+    expect(ok).toBe(true);
+    expect(store.upsert).not.toHaveBeenCalled();
+  });
+
+  it("vectorDelete and vectorDeleteNamespace return true and log their ops", async () => {
+    const store = makeFakeStore();
+    __setVectorStoreFactoryForTests(() => store);
+    expect(await vectorDelete("acme/backend:kb", ["e1"])).toBe(true);
+    expect(await vectorDeleteNamespace("acme/backend:docs:old")).toBe(true);
+    expect(store.delete).toHaveBeenCalledWith("acme/backend:kb", ["e1"]);
+    expect(store.deleteNamespace).toHaveBeenCalledWith("acme/backend:docs:old");
+  });
+});
+
+describe("degradation: store errors never throw", () => {
+  beforeEach(() => stubVectorEnv());
+
+  it("query error → null + vector_error + Sentry tagged vector.op", async () => {
+    const err = new Error("upstash vector unreachable");
+    __setVectorStoreFactoryForTests(() =>
+      makeFakeStore({ query: vi.fn(async () => { throw err; }) }),
+    );
+    const result = await vectorQuery("acme/backend:kb", "q", 10);
+    expect(result).toBeNull();
+    expect(logSpy).toHaveBeenCalledWith(
+      "vector_error",
+      expect.objectContaining({
+        op: "query",
+        errorClass: "Error",
+        errorMessage: expect.stringContaining("unreachable"),
+      }),
+    );
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      err,
+      expect.objectContaining({
+        tags: expect.objectContaining({ "vector.op": "query" }),
+      }),
+    );
+  });
+
+  it("upsert error → false, no throw", async () => {
+    __setVectorStoreFactoryForTests(() =>
+      makeFakeStore({ upsert: vi.fn(async () => { throw new Error("boom"); }) }),
+    );
+    await expect(
+      vectorUpsert("ns", [{ id: "e1", text: "t" }]),
+    ).resolves.toBe(false);
+    expect(logSpy).toHaveBeenCalledWith(
+      "vector_error",
+      expect.objectContaining({ op: "upsert" }),
+    );
+  });
+
+  it("delete and deleteNamespace errors → false, no throw", async () => {
+    __setVectorStoreFactoryForTests(() =>
+      makeFakeStore({
+        delete: vi.fn(async () => { throw new Error("boom"); }),
+        deleteNamespace: vi.fn(async () => { throw new Error("boom"); }),
+      }),
+    );
+    await expect(vectorDelete("ns", ["x"])).resolves.toBe(false);
+    await expect(vectorDeleteNamespace("ns")).resolves.toBe(false);
+  });
+});
+
+describe("degradation: timeout", () => {
+  beforeEach(() => stubVectorEnv());
+
+  it("query exceeding VECTOR_OP_TIMEOUT_MS resolves null and logs vector_error with VectorTimeoutError", async () => {
+    vi.useFakeTimers();
+    __setVectorStoreFactoryForTests(() =>
+      makeFakeStore({ query: () => new Promise(() => {}) }), // never resolves
+    );
+    const pending = vectorQuery("acme/backend:kb", "slow question", 10);
+    await vi.advanceTimersByTimeAsync(VECTOR_OP_TIMEOUT_MS + 1);
+    await expect(pending).resolves.toBeNull();
+    expect(logSpy).toHaveBeenCalledWith(
+      "vector_error",
+      expect.objectContaining({ op: "query", errorClass: "VectorTimeoutError" }),
+    );
+  });
+});
+
+describe("privacy: content never reaches logs", () => {
+  beforeEach(() => stubVectorEnv());
+
+  it("neither query text nor upserted text appears in any log payload", async () => {
+    __setVectorStoreFactoryForTests(() => makeFakeStore());
+    await vectorQuery("acme/backend:kb", "SECRET_QUESTION_TEXT", 10);
+    await vectorUpsert("acme/backend:kb", [
+      { id: "e1", text: "SECRET_KB_ENTRY_BODY" },
+    ]);
+    for (const call of logSpy.mock.calls) {
+      const payload = JSON.stringify(call);
+      expect(payload).not.toContain("SECRET_QUESTION_TEXT");
+      expect(payload).not.toContain("SECRET_KB_ENTRY_BODY");
+    }
+  });
+});

--- a/src/lib/vector.ts
+++ b/src/lib/vector.ts
@@ -1,0 +1,288 @@
+// ── Vector store wrapper with Sentry observability ───────────────────
+// Single chokepoint for every Upstash Vector operation, mirroring the
+// kv.ts pattern (#117): every call emits a structured `vector_op` log
+// line with latency + outcome metadata, and every error emits
+// `vector_error` + Sentry.captureException tagged `vector.op`.
+//
+// Two deliberate differences from kv.ts:
+// 1. NON-THROWING public API — the vector index is an optional recall
+//    accelerator, never a source of truth. Callers get a boolean/null
+//    degradation signal instead of an exception, so a missing or flaky
+//    index can never break a save, a rebuild, or an agent turn.
+// 2. Graceful "not configured" path — when the UPSTASH_VECTOR_REST_*
+//    env vars are absent the wrapper logs `vector_unavailable` (an
+//    expected state, NOT an error — no Sentry) and degrades. The SDK
+//    client is constructed lazily and only when configured.
+//
+// The @upstash/vector SDK is confined to createUpstashVectorStore() —
+// everything else talks to the VectorStore interface, which is also the
+// test seam (__setVectorStoreFactoryForTests injects a fake store).
+//
+// PRIVACY: query text and entry text are NEVER logged — only namespaces,
+// counts, and durations. See #127.
+
+import { Index } from "@upstash/vector";
+import * as Sentry from "@sentry/nextjs";
+import { log } from "./logger";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface VectorUpsertItem {
+  id: string;
+  /** Raw text — the index embeds it server-side (built-in model). */
+  text: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface VectorMatch {
+  id: string;
+  score: number;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * The narrow store contract the rest of the codebase depends on. The
+ * only production implementation wraps @upstash/vector; tests inject
+ * fakes through __setVectorStoreFactoryForTests.
+ */
+export interface VectorStore {
+  upsert(namespace: string, items: VectorUpsertItem[]): Promise<void>;
+  query(namespace: string, text: string, topK: number): Promise<VectorMatch[]>;
+  delete(namespace: string, ids: string[]): Promise<void>;
+  deleteNamespace(namespace: string): Promise<void>;
+}
+
+// ── Configuration & namespaces ───────────────────────────────────────
+
+/**
+ * True when both Upstash Vector env vars are present. Checked per call
+ * (not at module load) so tests and late-injected env both work.
+ */
+export function isVectorConfigured(): boolean {
+  return Boolean(
+    process.env.UPSTASH_VECTOR_REST_URL && process.env.UPSTASH_VECTOR_REST_TOKEN,
+  );
+}
+
+/** Namespace holding one embedding per visible KB entry. */
+export function kbNamespace(): string {
+  return `${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}:kb`;
+}
+
+/**
+ * Namespace holding doc chunks for one repo SHA. SHA-scoped so a rebuild
+ * writes a fresh namespace and atomically repoints (see repo-index.ts).
+ */
+export function docsNamespace(sha: string): string {
+  return `${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}:docs:${sha}`;
+}
+
+// ── Store construction (lazy + memoized; SDK confined here) ──────────
+
+type VectorStoreFactory = () => VectorStore;
+
+/**
+ * The ONLY code that touches @upstash/vector. Verified against SDK
+ * v1.2.3: `new Index({url, token})`, `index.namespace(ns)` for scoped
+ * upsert/query/delete, raw-text ingestion via the `data` field (the
+ * index embeds server-side), `index.deleteNamespace(ns)`.
+ */
+function createUpstashVectorStore(): VectorStore {
+  const index = new Index({
+    url: process.env.UPSTASH_VECTOR_REST_URL,
+    token: process.env.UPSTASH_VECTOR_REST_TOKEN,
+  });
+  return {
+    async upsert(namespace, items) {
+      await index.namespace(namespace).upsert(
+        items.map((i) => ({ id: i.id, data: i.text, metadata: i.metadata })),
+      );
+    },
+    async query(namespace, text, topK) {
+      const results = await index
+        .namespace(namespace)
+        .query({ data: text, topK, includeMetadata: true });
+      return results.map((r) => ({
+        id: String(r.id),
+        score: r.score,
+        metadata: r.metadata as Record<string, unknown> | undefined,
+      }));
+    },
+    async delete(namespace, ids) {
+      await index.namespace(namespace).delete(ids);
+    },
+    async deleteNamespace(namespace) {
+      await index.deleteNamespace(namespace);
+    },
+  };
+}
+
+let storeFactory: VectorStoreFactory = createUpstashVectorStore;
+let memoizedStore: VectorStore | null = null;
+
+/**
+ * Test seam: inject a fake store factory (null restores the real one).
+ * Also resets the memoized store so each test constructs afresh.
+ */
+export function __setVectorStoreFactoryForTests(factory: VectorStoreFactory | null): void {
+  storeFactory = factory ?? createUpstashVectorStore;
+  memoizedStore = null;
+}
+
+// Lazily construct + memoize. NEVER called on the unconfigured path —
+// the public API short-circuits first, so the factory (and therefore
+// the SDK client) is only ever invoked when env credentials exist.
+function getStore(): VectorStore {
+  if (!memoizedStore) memoizedStore = storeFactory();
+  return memoizedStore;
+}
+
+// ── Timeout guard ────────────────────────────────────────────────────
+
+/** Hard latency cap per vector op — recall must never stall a turn. */
+export const VECTOR_OP_TIMEOUT_MS = 2000;
+
+export class VectorTimeoutError extends Error {
+  constructor(op: string) {
+    super(`vector ${op} exceeded ${VECTOR_OP_TIMEOUT_MS}ms`);
+    this.name = "VectorTimeoutError";
+  }
+}
+
+function withTimeout<T>(op: string, promise: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new VectorTimeoutError(op)), VECTOR_OP_TIMEOUT_MS);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer)) as Promise<T>;
+}
+
+// ── Shared logging helpers (mirror kv.ts) ────────────────────────────
+
+type VectorOp = "upsert" | "query" | "delete" | "deleteNamespace";
+
+function logUnavailable(op: VectorOp): void {
+  // Expected degradation state, not an error — no Sentry capture.
+  log("vector_unavailable", { op, reason: "not_configured" });
+}
+
+function logError(op: VectorOp, namespace: string, startedAt: number, err: unknown): void {
+  const errorMessage = err instanceof Error ? err.message : String(err);
+  const errorClass = err instanceof Error ? err.constructor.name : "Unknown";
+  log("vector_error", {
+    op,
+    namespace,
+    durationMs: Date.now() - startedAt,
+    errorClass,
+    errorMessage: errorMessage.slice(0, 200),
+  });
+  Sentry.captureException(err, {
+    tags: { "vector.op": op, "vector.namespace": namespace },
+  });
+}
+
+// ── Public wrapper (non-throwing) ────────────────────────────────────
+
+/**
+ * Embed + store items. Returns true on success, false on degradation
+ * (not configured, timeout, or store error). An empty item list
+ * short-circuits true without touching the store.
+ */
+export async function vectorUpsert(
+  namespace: string,
+  items: VectorUpsertItem[],
+): Promise<boolean> {
+  if (items.length === 0) return true;
+  if (!isVectorConfigured()) {
+    logUnavailable("upsert");
+    return false;
+  }
+  const startedAt = Date.now();
+  try {
+    await withTimeout("upsert", getStore().upsert(namespace, items));
+    log("vector_op", {
+      op: "upsert",
+      namespace,
+      durationMs: Date.now() - startedAt,
+      count: items.length,
+    });
+    return true;
+  } catch (err) {
+    logError("upsert", namespace, startedAt, err);
+    return false;
+  }
+}
+
+/**
+ * Semantic similarity query. Returns matches on success, [] when the
+ * index is available but has no matches, and null when the vector layer
+ * is degraded (not configured, timeout, or store error) — callers use
+ * null to fall back to lexical-only retrieval.
+ */
+export async function vectorQuery(
+  namespace: string,
+  text: string,
+  topK: number,
+): Promise<VectorMatch[] | null> {
+  if (!isVectorConfigured()) {
+    logUnavailable("query");
+    return null;
+  }
+  const startedAt = Date.now();
+  try {
+    const matches = await withTimeout("query", getStore().query(namespace, text, topK));
+    log("vector_op", {
+      op: "query",
+      namespace,
+      durationMs: Date.now() - startedAt,
+      count: matches.length,
+    });
+    return matches;
+  } catch (err) {
+    logError("query", namespace, startedAt, err);
+    return null;
+  }
+}
+
+/** Delete ids from a namespace. Returns false on any degradation. */
+export async function vectorDelete(namespace: string, ids: string[]): Promise<boolean> {
+  if (!isVectorConfigured()) {
+    logUnavailable("delete");
+    return false;
+  }
+  const startedAt = Date.now();
+  try {
+    await withTimeout("delete", getStore().delete(namespace, ids));
+    log("vector_op", {
+      op: "delete",
+      namespace,
+      durationMs: Date.now() - startedAt,
+      count: ids.length,
+    });
+    return true;
+  } catch (err) {
+    logError("delete", namespace, startedAt, err);
+    return false;
+  }
+}
+
+/** Drop an entire namespace (stale docs generation). Non-throwing. */
+export async function vectorDeleteNamespace(namespace: string): Promise<boolean> {
+  if (!isVectorConfigured()) {
+    logUnavailable("deleteNamespace");
+    return false;
+  }
+  const startedAt = Date.now();
+  try {
+    await withTimeout("deleteNamespace", getStore().deleteNamespace(namespace));
+    log("vector_op", {
+      op: "deleteNamespace",
+      namespace,
+      durationMs: Date.now() - startedAt,
+    });
+    return true;
+  } catch (err) {
+    logError("deleteNamespace", namespace, startedAt, err);
+    return false;
+  }
+}

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -1,12 +1,34 @@
-import { describe, it, expect } from "vitest";
-import { tools } from "./index";
+import { describe, it, expect, vi } from "vitest";
+
+// #127: the search_repo routing test exercises the real executor with
+// its network-touching arms stubbed. importOriginal keeps every other
+// export intact for the sibling tool modules.
+const { searchCodeSpy } = vi.hoisted(() => ({
+  searchCodeSpy: vi.fn(async (..._a: unknown[]) => [
+    { path: "src/auth.ts", url: "https://github.com/acme/backend/blob/main/src/auth.ts", score: 3 },
+  ]),
+}));
+vi.mock("@/lib/github", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  searchCode: (...a: unknown[]) => searchCodeSpy(...a),
+}));
+vi.mock("@/lib/repo-index", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getDocsVectorNamespace: vi.fn(async () => null),
+}));
+
+import { tools, executeTool } from "./index";
 
 describe("tools registry — prompt caching", () => {
-  it("has all 7 tools", () => {
-    expect(tools).toHaveLength(7);
+  it("has all 8 tools", () => {
+    expect(tools).toHaveLength(8);
   });
 
-  it("caches the tool definitions — only the LAST tool carries cache_control", () => {
+  it("registers search_repo (#127)", () => {
+    expect(tools.map((t) => t.name)).toContain("search_repo");
+  });
+
+  it("invariant T1: exactly ONE tool carries cache_control, and it is the LAST array element", () => {
     // Anthropic caches every block up to and including the one marked with
     // cache_control. Marking only the last tool caches the entire tools array.
     const last = tools[tools.length - 1];
@@ -19,5 +41,17 @@ describe("tools registry — prompt caching", () => {
         `tool[${i}] (${tools[i].name}) must not carry cache_control`,
       ).toBeUndefined();
     }
+  });
+});
+
+describe("executeTool — search_repo routing (#127)", () => {
+  it("routes search_repo to its executor and returns a text result", async () => {
+    const result = await executeTool("search_repo", { query: "auth" });
+    expect(result.type).toBe("text");
+    if (result.type === "text") {
+      expect(result.text).toContain("src/auth.ts");
+      expect(result.references).toEqual([]);
+    }
+    expect(searchCodeSpy).toHaveBeenCalledWith("auth");
   });
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,10 +7,13 @@ import type { IssueProposal } from "./create-issue";
 import { saveKnowledgeTool, executeSaveKnowledge } from "./save-knowledge";
 import { listCommitsTool, executeListCommits } from "./list-commits";
 import { listPRsTool, executeListPRs } from "./list-prs";
+import { searchRepoTool, executeSearchRepo } from "./search-repo";
 
 // ── Tool registry ─────────────────────────────────────────────────────
 // Anthropic caches every block up through the one marked with cache_control.
 // Marking only the LAST tool caches the entire tools array as one chunk.
+// Invariant T1: exactly one cache_control marker, on the LAST element —
+// new tools register BEFORE saveKnowledgeTool.
 export const tools: Tool[] = [
   searchCodeTool,
   readFileTool,
@@ -18,6 +21,7 @@ export const tools: Tool[] = [
   listCommitsTool,
   listPRsTool,
   createIssueTool,
+  searchRepoTool,
   { ...saveKnowledgeTool, cache_control: { type: "ephemeral" } },
 ];
 
@@ -47,6 +51,11 @@ export async function executeTool(
     case "search_code": {
       // Returns { text, references } with real GitHub html_urls (include line anchors)
       const result = await executeSearchCode(input);
+      return { type: "text", text: result.text, references: result.references };
+    }
+    case "search_repo": {
+      // Hybrid code + docs search (#127). Discovery aid — no references.
+      const result = await executeSearchRepo(input);
       return { type: "text", text: result.text, references: result.references };
     }
     case "read_file": {

--- a/src/tools/search-repo.test.ts
+++ b/src/tools/search-repo.test.ts
@@ -128,6 +128,26 @@ describe("executeSearchRepo — degradation", () => {
     expect(result.references).toEqual([]);
   });
 
+  it("guards a missing query without calling any arm (#127 review)", async () => {
+    const result = await executeSearchRepo({});
+    expect(result.text).toBe("No search query provided.");
+    expect(result.references).toEqual([]);
+    expect(searchCodeSpy).not.toHaveBeenCalled();
+    expect(getDocsVectorNamespaceSpy).not.toHaveBeenCalled();
+  });
+
+  it("guards a blank query without calling any arm (#127 review)", async () => {
+    const result = await executeSearchRepo({ query: "   " });
+    expect(result.text).toBe("No search query provided.");
+    expect(searchCodeSpy).not.toHaveBeenCalled();
+  });
+
+  it("guards a non-string query", async () => {
+    const result = await executeSearchRepo({ query: 42 });
+    expect(result.text).toBe("No search query provided.");
+    expect(searchCodeSpy).not.toHaveBeenCalled();
+  });
+
   it("filters tooling paths from the lexical arm", async () => {
     searchCodeSpy.mockResolvedValue([
       codeResult(".claude/skills/wizard/SKILL.md"),

--- a/src/tools/search-repo.test.ts
+++ b/src/tools/search-repo.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { searchCodeSpy, vectorQuerySpy, getDocsVectorNamespaceSpy } = vi.hoisted(
+  () => ({
+    searchCodeSpy: vi.fn(),
+    vectorQuerySpy: vi.fn(),
+    getDocsVectorNamespaceSpy: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/github", () => ({
+  searchCode: (...a: unknown[]) => searchCodeSpy(...a),
+}));
+vi.mock("@/lib/vector", () => ({
+  vectorQuery: (...a: unknown[]) => vectorQuerySpy(...a),
+}));
+vi.mock("@/lib/repo-index", () => ({
+  getDocsVectorNamespace: (...a: unknown[]) => getDocsVectorNamespaceSpy(...a),
+}));
+
+import { searchRepoTool, executeSearchRepo } from "./search-repo";
+import { MAX_ARM_RESULTS } from "@/lib/retrieval";
+
+function codeResult(path: string, score = 1) {
+  return { path, url: `https://github.com/acme/backend/blob/main/${path}`, score };
+}
+
+function docMatch(chunkId: string, score: number, heading: string, excerpt: string) {
+  const path = chunkId.split("#")[0];
+  return { id: chunkId, score, metadata: { path, heading, excerpt } };
+}
+
+beforeEach(() => {
+  searchCodeSpy.mockReset().mockResolvedValue([]);
+  vectorQuerySpy.mockReset().mockResolvedValue(null);
+  getDocsVectorNamespaceSpy.mockReset().mockResolvedValue(null);
+});
+
+describe("searchRepoTool definition", () => {
+  it("is named search_repo and requires a query", () => {
+    expect(searchRepoTool.name).toBe("search_repo");
+    expect(searchRepoTool.input_schema.required).toEqual(["query"]);
+  });
+});
+
+describe("executeSearchRepo — hybrid fusion", () => {
+  it("fuses both arms with RRF: results interleave code rank 1, doc rank 1, code rank 2, doc rank 2", async () => {
+    // Typed ids (code:/doc:) never collide across arms, so fusion here is
+    // a pure rank interleave: equal ranks tie and the lexical (code) arm
+    // wins ties by enumeration order — hand-computed:
+    //   code:a 1/61, doc:x 1/61, code:b 1/62, doc:y 1/62.
+    searchCodeSpy.mockResolvedValue([codeResult("src/a.ts"), codeResult("src/b.ts")]);
+    getDocsVectorNamespaceSpy.mockResolvedValue("acme/backend:docs:sha1");
+    vectorQuerySpy.mockResolvedValue([
+      docMatch("docs/x.md#0", 0.9, "X Heading", "x excerpt"),
+      docMatch("docs/y.md#2", 0.8, "Y Heading", "y excerpt"),
+    ]);
+
+    const result = await executeSearchRepo({ query: "auth flow" });
+    const lines = result.text.split("\n");
+    expect(lines[0]).toContain("src/a.ts");
+    expect(lines[0]).toContain("[code]");
+    expect(lines[1]).toContain("docs/x.md");
+    expect(lines[1]).toContain("[doc]");
+    expect(lines[2]).toContain("src/b.ts");
+    expect(lines[3]).toContain("docs/y.md");
+  });
+
+  it("queries the docs namespace from the pointer with MAX_ARM_RESULTS", async () => {
+    getDocsVectorNamespaceSpy.mockResolvedValue("acme/backend:docs:sha1");
+    vectorQuerySpy.mockResolvedValue([]);
+    await executeSearchRepo({ query: "deployment" });
+    expect(vectorQuerySpy).toHaveBeenCalledWith(
+      "acme/backend:docs:sha1",
+      "deployment",
+      MAX_ARM_RESULTS,
+    );
+  });
+
+  it("doc lines carry heading and excerpt from chunk metadata", async () => {
+    getDocsVectorNamespaceSpy.mockResolvedValue("ns");
+    vectorQuerySpy.mockResolvedValue([
+      docMatch("docs/setup.md#3", 0.9, "Vercel Setup", "Deploys go through Vercel."),
+    ]);
+    const result = await executeSearchRepo({ query: "how do we deploy" });
+    expect(result.text).toContain("[doc]");
+    expect(result.text).toContain("docs/setup.md");
+    expect(result.text).toContain("Vercel Setup");
+    expect(result.text).toContain("Deploys go through Vercel.");
+  });
+
+  it("code lines carry path, score and url", async () => {
+    searchCodeSpy.mockResolvedValue([codeResult("src/lib/slack.ts", 7)]);
+    const result = await executeSearchRepo({ query: "postReply" });
+    expect(result.text).toContain("[code]");
+    expect(result.text).toContain("`src/lib/slack.ts`");
+    expect(result.text).toContain("score: 7");
+    expect(result.text).toContain("https://github.com/acme/backend/blob/main/src/lib/slack.ts");
+  });
+});
+
+describe("executeSearchRepo — degradation", () => {
+  it("vectorQuery null (vector degraded) → lexical-only output, no throw", async () => {
+    searchCodeSpy.mockResolvedValue([codeResult("src/a.ts")]);
+    getDocsVectorNamespaceSpy.mockResolvedValue("ns");
+    vectorQuerySpy.mockResolvedValue(null);
+    const result = await executeSearchRepo({ query: "auth" });
+    expect(result.text).toContain("src/a.ts");
+    expect(result.text).not.toContain("[doc]");
+  });
+
+  it("missing namespace pointer → lexical-only, vector store never queried", async () => {
+    searchCodeSpy.mockResolvedValue([codeResult("src/a.ts")]);
+    getDocsVectorNamespaceSpy.mockResolvedValue(null);
+    const result = await executeSearchRepo({ query: "auth" });
+    expect(result.text).toContain("src/a.ts");
+    expect(vectorQuerySpy).not.toHaveBeenCalled();
+  });
+
+  it("both arms empty → No results found message", async () => {
+    const result = await executeSearchRepo({ query: "nonexistent thing" });
+    expect(result.text).toBe('No results found for "nonexistent thing".');
+  });
+
+  it("returns no references — search results are discovery aids", async () => {
+    searchCodeSpy.mockResolvedValue([codeResult("src/a.ts")]);
+    const result = await executeSearchRepo({ query: "auth" });
+    expect(result.references).toEqual([]);
+  });
+
+  it("filters tooling paths from the lexical arm", async () => {
+    searchCodeSpy.mockResolvedValue([
+      codeResult(".claude/skills/wizard/SKILL.md"),
+      codeResult("src/a.ts"),
+    ]);
+    const result = await executeSearchRepo({ query: "wizard" });
+    expect(result.text).not.toContain(".claude/");
+    expect(result.text).toContain("src/a.ts");
+  });
+});

--- a/src/tools/search-repo.ts
+++ b/src/tools/search-repo.ts
@@ -60,7 +60,12 @@ async function runDocArm(query: string): Promise<VectorMatch[]> {
 export async function executeSearchRepo(
   input: Record<string, unknown>,
 ): Promise<SearchRepoResult> {
-  const query = input.query as string;
+  // Guard (#127 review): the model can emit a malformed tool call —
+  // a missing/non-string/blank query must not reach searchCode.
+  const query = typeof input.query === "string" ? input.query.trim() : "";
+  if (query.length === 0) {
+    return { text: "No search query provided.", references: [] };
+  }
 
   const [codeItems, docMatches] = await Promise.all([
     runCodeArm(query),

--- a/src/tools/search-repo.ts
+++ b/src/tools/search-repo.ts
@@ -1,0 +1,104 @@
+import type { Tool } from "@anthropic-ai/sdk/resources/messages";
+import { searchCode } from "@/lib/github";
+import { vectorQuery, type VectorMatch } from "@/lib/vector";
+import { getDocsVectorNamespace } from "@/lib/repo-index";
+import { fuseRankedLists, MAX_ARM_RESULTS } from "@/lib/retrieval";
+import { isToolingPath } from "@/lib/path-filter";
+import type { Reference } from "@/tools";
+
+/**
+ * Hybrid repo search (#127): fuses a lexical GitHub code-search arm with
+ * a semantic doc-chunk arm (Upstash Vector) via Reciprocal Rank Fusion.
+ * Arms carry typed ids (`code:${path}` / `doc:${chunkId}`) so results
+ * render as typed lines the model can tell apart.
+ *
+ * Degradation: a missing docs-namespace pointer (index never embedded)
+ * or a degraded vector layer (vectorQuery → null) silently collapses to
+ * lexical-only — the tool never throws because of the semantic arm.
+ */
+export const searchRepoTool: Tool = {
+  name: "search_repo",
+  description:
+    "Hybrid search across BOTH code and documentation — combines lexical code search with semantic (meaning-based) doc search. Best for conceptual questions like \"how does X work\" or \"where is Y handled\" where you don't know the exact identifier. For an exact function/class/keyword, use search_code instead.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      query: {
+        type: "string",
+        description:
+          "Natural-language or keyword query — a concept, feature, or question phrase",
+      },
+    },
+    required: ["query"],
+  },
+};
+
+export interface SearchRepoResult {
+  text: string;
+  references: Reference[];
+}
+
+interface CodeItem {
+  path: string;
+  url: string;
+  score: number;
+}
+
+async function runCodeArm(query: string): Promise<CodeItem[]> {
+  const results = await searchCode(query);
+  // Filter out tooling paths (.claude/ etc.) — not project code.
+  return results.filter((r) => !isToolingPath(r.path)).slice(0, MAX_ARM_RESULTS);
+}
+
+async function runDocArm(query: string): Promise<VectorMatch[]> {
+  const namespace = await getDocsVectorNamespace();
+  if (!namespace) return []; // index never embedded docs — lexical-only
+  const matches = await vectorQuery(namespace, query, MAX_ARM_RESULTS);
+  return matches ?? []; // null = vector degraded — lexical-only
+}
+
+export async function executeSearchRepo(
+  input: Record<string, unknown>,
+): Promise<SearchRepoResult> {
+  const query = input.query as string;
+
+  const [codeItems, docMatches] = await Promise.all([
+    runCodeArm(query),
+    runDocArm(query),
+  ]);
+
+  // Typed ids keep the arms disjoint; fusion is a rank interleave with
+  // lexical winning exact ties. No timestamps — repo content freshness
+  // is a per-SHA property, not a per-result one.
+  const lexicalIds = codeItems.map((i) => `code:${i.path}`);
+  const semanticIds = docMatches.map((m) => `doc:${m.id}`);
+  const fused = fuseRankedLists(lexicalIds, semanticIds, { topK: MAX_ARM_RESULTS });
+
+  if (fused.length === 0) {
+    return { text: `No results found for "${query}".`, references: [] };
+  }
+
+  const codeById = new Map(codeItems.map((i) => [`code:${i.path}`, i]));
+  const docById = new Map(docMatches.map((m) => [`doc:${m.id}`, m]));
+
+  const lines = fused.map((f) => {
+    const code = codeById.get(f.id);
+    if (code) {
+      return `- [code] \`${code.path}\` (score: ${code.score}) — ${code.url}`;
+    }
+    const doc = docById.get(f.id)!;
+    const meta = (doc.metadata ?? {}) as {
+      path?: string;
+      heading?: string;
+      excerpt?: string;
+    };
+    const path = meta.path ?? String(doc.id).split("#")[0];
+    const heading = meta.heading ? ` › ${meta.heading}` : "";
+    const excerpt = meta.excerpt ? ` — ${meta.excerpt}` : "";
+    return `- [doc] \`${path}\`${heading}${excerpt}`;
+  });
+
+  // Search results are discovery aids — don't add them as references.
+  // Only files the agent actually reads (via read_file) get referenced.
+  return { text: lines.join("\n"), references: [] };
+}


### PR DESCRIPTION
## Summary

Implements #127 — adds the semantic arm to retrieval while keeping GitHub lexical search as the always-available baseline.

- **`vector.ts`**: observability-wrapped chokepoint mirroring `kv.ts` — non-throwing public API (`null`/`false` on degradation, never a throw into the agent loop), lazy env-gated client, 2s timeout with abort, `vector_op`/`vector_unavailable`/`vector_error` events. The SDK is confined to one private factory, coded against the installed `@upstash/vector` v1.2.3 (raw-text `data` upserts — the index embeds server-side).
- **`retrieval.ts`**: pure RRF fusion (k=60) with age boosts sized to break near-ties only — the largest boost is provably smaller than any single-arm adjacent-rank gap, asserted programmatically in the tests.
- **KB recall**: top-5 fused recall per question replaces the full-KB prompt dump; prompt size is bounded regardless of KB size. KV stays the source of truth — vector ids are re-validated against the visible entry set at apply time, so a stale index can never surface a retired entry. KBs with ≤5 entries skip both arms (zero vector calls).
- **Doc chunks**: heading-aware splitting, embedded only on HEAD SHA change, capped at 50 content fetches (the #108 fan-out lesson), namespace-per-SHA with pointer-swap ordering (failed embed → pointer untouched, rebuild still succeeds).
- **`search_repo`** (8th tool): lexical + doc-chunk arms in parallel, RRF-fused, typed `[code]`/`[doc]` results; the `cache_control` marker invariant (exactly one, on the last registry element) is now pinned by a test.
- **Degradation**: no env vars → lexical-only + one log event; never user-facing. The PR merges and runs correctly before the Upstash Vector index exists.

## Rebase note

Rebased onto post-#126 main: `runAgent` carries both the effort options and the question threading into `buildSystemBlocks`; docs merged additively (tool count 8 + effort budgets everywhere).

## Testing

TDD throughout (5 RED→GREEN slices, squashed): +92 new tests — hand-computed RRF fixtures, age-boost boundary matrix (7/30/90d inclusive edges), full degradation matrix (unconfigured/error/timeout), K1 stale-index filtering, chunking edges, cache-marker invariant. Full suite **672 passing**, typecheck clean.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hybrid repository search that combines code search with documentation results.
  * Added optional vector-based retrieval for knowledge and docs, with automatic fallback to lexical-only search when unavailable.
  * Updated progress/status messaging to include the new repository search tool.

* **Bug Fixes**
  * Retired knowledge entries are now prevented from resurfacing in search results.
  * Improved degraded-mode handling so missing vector configuration no longer causes failures.

* **Documentation**
  * Expanded setup, troubleshooting, architecture, and feature docs to cover hybrid retrieval and optional vector configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->