### PR TITLE
feat: Incremental semantic code index (closes #135)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ A Slack agent with Claude AI intelligence and full GitHub repo access — reads 
 - **Slack**: Webhook mode via Next.js API route (`/api/slack`), ack-then-process via `after()`
 - **AI**: Anthropic Claude API with tool use (8 tools, adaptive per-turn round budget: quick 4 / standard 10 / deep 15)
 - **GitHub**: Octokit REST API (fine-grained PAT, read-only for code/PRs, read-write for issues)
-- **Knowledge**: Vercel KV (corrections, feedback, repo index cache) + Upstash Vector (semantic recall for KB + docs, graceful lexical-only degradation)
+- **Knowledge**: Vercel KV (corrections, feedback, repo index cache) + Upstash Vector (semantic recall for KB + docs + source code, graceful lexical-only degradation)
 - **Context**: CLAUDE.md + KB + feedback + repo index + source hierarchy + search strategy + recency/brevity rules
 - **Progress**: Live thinking messages with contextual emoji, deleted on answer
 - **Formatting**: Markdown-to-Slack mrkdwn conversion, typed references with emoji (📄📖🎫🔀📜), ranked by source-of-truth hierarchy, capped at 7
@@ -43,6 +43,7 @@ src/
   app/
     api/slack/route.ts    — Slack webhook handler (mention, reaction, thread follow-up)
     api/cron/sweep/route.ts — Recovery sweep (retries turns killed mid-processing)
+    api/cron/code-index/route.ts — Incremental code-index tick (embeds changed source files)
     page.tsx              — Landing page
   lib/
     slack.ts              — Slack client, signature verification, message helpers
@@ -65,11 +66,13 @@ src/
     split-reply.ts        — Pure splitter for long Slack replies (paragraph/line/word/fence-aware)
     kv.ts                 — @upstash/redis wrapper with Sentry observability (kv_op + kv_error events)
     vector.ts             — @upstash/vector wrapper (non-throwing, vector_op/vector_error events, 2s timeout)
-    retrieval.ts          — Pure hybrid-retrieval primitives (RRF fusion, age boost, lexical ranking)
+    retrieval.ts          — Pure hybrid-retrieval primitives (RRF fusion, semantic merge, age boost, lexical ranking)
+    code-chunker.ts       — Pure source-file chunking + embed-eligibility predicate (#135)
+    code-index.ts         — Incremental code-index tick: manifest diff, budgets, degradation (#135)
   tools/
     index.ts              — Tool registry and executor
     search-code.ts        — GitHub code search tool
-    search-repo.ts        — Hybrid code + docs search (lexical + semantic, RRF-fused)
+    search-repo.ts        — Hybrid code + docs + src search (lexical + semantic, RRF-fused)
     read-file.ts          — GitHub file/directory read tool
     list-issues.ts        — GitHub issue list/lookup tool
     list-commits.ts       — Recent commits on main (with dates)
@@ -92,8 +95,9 @@ docs/
     issue-creation.md     — Batch issue proposals + bulk-confirm flow
     effort-routing.md     — Fast-model follow-up gate + per-turn effort budgets
     hybrid-retrieval.md   — Lexical + semantic retrieval (Upstash Vector, RRF fusion, degradation)
+    code-index.md         — Incremental semantic code index (manifest cursor, cron tick, src arm)
 TELEMETRY.md              — Incident-response event vocabulary + Sentry query recipes
-vercel.json               — Vercel Cron schedule for the recovery sweep
+vercel.json               — Vercel Cron schedules (recovery sweep + code-index tick)
 ```
 
 ## Testing (TDD Required)

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -100,13 +100,13 @@ count(event:idempotency_replayed) + count(event:idempotency_in_flight)
 
 Is the source index keeping up with the repo?
 
-```
+```text
 event:src_index_noop           — steady state (head SHA fully indexed)
 event:src_index_tick           — catching up (status: complete | partial | degraded)
 event:src_index_tick_failed    — the tick itself broke
 ```
 
-Healthy: mostly `src_index_noop` every ~5 minutes, with short bursts of `src_index_tick status:partial → complete` after pushes. Persistent `partial` with a non-shrinking `remaining` means the per-tick budgets can't keep up (or one file keeps failing — check `src_index_file_skipped` for a repeated `path`). Any `src_index_degraded` correlates with `vector_error`; `src_index_tree_truncated` on a huge repo means the recursive tree API is truncating and the index cannot safely advance. A **missing** heartbeat means the cron isn't firing — check the Vercel Cron dashboard and look for `src_index_unauthorized`.
+Every ~5 minutes exactly one per-tick terminal event should appear: `src_index_noop` (the healthy steady state) or `src_index_tick` with `status: complete | partial | degraded` (catching up after a push). `src_index_claim_lost` and `src_index_unavailable` are **benign, not page-worthy** — the former is cadence overlap on the NX claim, the latter simply means `UPSTASH_VECTOR_REST_*` isn't provisioned. Persistent `partial` with a non-shrinking `remaining` means the per-tick budgets can't keep up (or one file keeps failing — check `src_index_file_skipped` for a repeated `path`). Any `status: degraded` correlates with `vector_error`; `src_index_tree_truncated` on a huge repo means the recursive tree API is truncating and the index cannot safely advance. **No terminal event at all** for several cadences means the cron isn't firing — check the Vercel Cron dashboard and look for `src_index_unauthorized`.
 
 ### Cross-run correlation
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -48,6 +48,19 @@ These names are treated as a public contract — renaming one is a breaking chan
 | `recovery_sweep_failed` / `recovery_sweep_member_failed` | The sweep itself broke (whole run / one thread — state stays recoverable; the next sweep retries after the claim TTL) |
 | `recovery_sweep_unauthorized` | Cron auth rejected — check `CRON_SECRET` |
 
+### Code index (incremental source embedding, #135)
+
+| Event | Meaning |
+|---|---|
+| `src_index_tick` | Indexing-tick heartbeat (`status`, `upserted`, `deleted`, `skipped`, `remaining`) |
+| `src_index_noop` | Head SHA already indexed — the healthy steady state |
+| `src_index_tree_truncated` | GitHub truncated the tree listing — tick aborted before any delete (mass-delete guard) |
+| `src_index_file_skipped` | One unreadable file skipped — retried next tick |
+| `src_index_degraded` | Vector layer failed mid-tick — progress persisted, SHA not advanced |
+| `src_index_tick_failed` | The tick itself threw (KV/infrastructure) — Sentry issue tagged `flow: cron_code_index` |
+| `src_index_claim_lost` | Another tick owns the NX claim (`srcindex:claim`, 270 s TTL) — benign skip |
+| `src_index_unauthorized` | Cron auth rejected — check `CRON_SECRET` |
+
 ## Query recipes (Sentry Logs UI)
 
 ### Turn failure rate
@@ -82,6 +95,18 @@ count(event:idempotency_replayed) + count(event:idempotency_in_flight)
 ```
 
 …as a share of `event:issue_batch_confirmed`. Healthy: near zero in steady state (the del-claim + tombstone layer catches most races first). A sustained rise means duplicate confirmations are reaching the innermost layer — look for Slack event redeliveries (`x-slack-retry-num` handling) or tombstone-TTL gaps. Any nonzero `idempotency_degraded` means Upstash was unreachable during issue creation — correlate with `kv_error`.
+
+### Code-index health
+
+Is the source index keeping up with the repo?
+
+```
+event:src_index_noop           — steady state (head SHA fully indexed)
+event:src_index_tick           — catching up (status: complete | partial | degraded)
+event:src_index_tick_failed    — the tick itself broke
+```
+
+Healthy: mostly `src_index_noop` every ~5 minutes, with short bursts of `src_index_tick status:partial → complete` after pushes. Persistent `partial` with a non-shrinking `remaining` means the per-tick budgets can't keep up (or one file keeps failing — check `src_index_file_skipped` for a repeated `path`). Any `src_index_degraded` correlates with `vector_error`; `src_index_tree_truncated` on a huge repo means the recursive tree API is truncating and the index cannot safely advance. A **missing** heartbeat means the cron isn't firing — check the Vercel Cron dashboard and look for `src_index_unauthorized`.
 
 ### Cross-run correlation
 

--- a/docs/features/code-index.md
+++ b/docs/features/code-index.md
@@ -1,0 +1,67 @@
+# Incremental Semantic Code Index
+
+The code index (#135, sub-issue of epic #128) extends hybrid retrieval beyond docs: **source files** are chunked and embedded into Upstash Vector, so `search_repo` can answer "where is X handled?" from the code's *meaning*, not just keyword hits. Unlike the docs pipeline (small, rebuilt per SHA — see [hybrid-retrieval.md](hybrid-retrieval.md)), a source tree is far too large to re-embed per commit, so the index advances **incrementally** on a dedicated cron tick.
+
+## Architecture
+
+```
+/api/cron/code-index (every 5 min, maxDuration 240s)
+  └─ runCodeIndexTick()                      src/lib/code-index.ts
+       ├─ NX claim  srcindex:claim (TTL 270s)          — single writer
+       ├─ fast path srcindex:sha === head SHA          — noop
+       ├─ getRepoTreeSnapshot(headSha)                 — ONE snapshot per tick
+       ├─ diff blobs vs srcindex:manifest              — what changed
+       ├─ vectorDelete (removed files, batched)        ┐ into the STABLE
+       ├─ readFile@snapshot → chunkCodeFile → upsert   ┘ namespace {owner}/{repo}:src
+       └─ write manifest once; advance sha only when CLEAN
+```
+
+### The manifest is the cursor
+
+`srcindex:manifest` (KV) maps `path → {sha: blobSha, chunks: count}` — it is simultaneously the record of what's embedded and the progress cursor. Each tick diffs the current tree snapshot against it:
+
+- eligible blob new or blob-sha changed → **upsert** (re-chunk + re-embed)
+- manifest path gone from the tree, or no longer eligible → **delete** its chunk ids
+
+A partial tick persists completed files in the manifest, so the next tick's diff is exactly the remainder. `srcindex:sha` advances **only on a clean complete tick** (no remainder, no skips, no degradation) — the noop fast path can never mask unfinished work.
+
+### Stable namespace, path-stable ids
+
+The namespace `{owner}/{repo}:src` is deliberately **not** SHA-scoped (contrast `docsNamespace`): ids are `${path}#${ordinal}`, so re-embedding a changed file is an idempotent per-id upsert. When a file shrinks from N to M chunks, the stale ordinals `#M..#N-1` are trimmed **after** the upsert (`staleChunkIds`) — the worst mid-window state is a few stale-but-harmless extra chunks, never missing ones.
+
+## Chunking (`src/lib/code-chunker.ts`, pure)
+
+- **Eligibility** is a single predicate, `isEmbeddableSourcePath`, consumed by BOTH diff sides: extension allowlist (no md/json/yaml/lock — the docs arm owns prose), no tooling paths (`.claude/`), no `.min.` artifacts, no `excluded`/`vendor`/`historic` config annotations, and blobs over `MAX_EMBED_FILE_BYTES` (200 KB) are skipped.
+- **TS/JS** files split at **column-0 declaration boundaries** (`export`/`function`/`class`/`const`/…) — a cheap proxy for top-level structure; indented declarations are nested and never split.
+- **Everything else** uses a greedy line-window pack; a single oversized line is hard-sliced.
+- Every chunk's text is `${path}\n\n${lines}`, hard-capped at `MAX_CODE_CHUNK_CHARS` (1500) including the header. Metadata carries `{path, startLine, endLine, excerpt}` (excerpt ≤160 chars, whitespace-collapsed).
+
+## Tick budgets & safety invariants
+
+| Guard | Value | Why |
+|-------|-------|-----|
+| `MAX_FILES_PER_TICK` | 40 | Bounds the GitHub content fan-out per tick |
+| `TICK_TIME_BUDGET_MS` | 180 000 | Wall-clock yield well inside the route's 240 s `maxDuration` |
+| `MAX_DELETE_IDS_PER_TICK` | 1000 | Mass-rename safety |
+| `SRC_INDEX_CLAIM_TTL_SEC` | 270 | > route `maxDuration` (a live tick never loses its claim) and < the 300 s cadence |
+
+- **One SHA snapshot per tick** — every `readFile` is pinned to the snapshot's SHA; a push mid-tick can't produce torn reads.
+- **Truncated-tree abort** — if GitHub truncates the recursive listing, the tick aborts *before any delete*: a partial tree must not be read as mass deletion.
+- **Non-throwing degradation** — a failed vector op stops the tick with status `degraded`; progress so far persists in the manifest, `srcindex:sha` stays put, nothing throws. An unreadable file is skipped and logged; siblings continue.
+- **Privacy** — file content never reaches logs (paths + counts only), matching the vector wrapper's rule.
+
+## Retrieval (`search_repo` src arm)
+
+`search_repo` now runs three arms: lexical GitHub code search, semantic doc chunks, and semantic src chunks. The two semantic sub-arms share one embedding model, so their raw scores are comparable — `mergeSemanticMatches` (in `src/lib/retrieval.ts`) merges them by descending score (docs win exact ties) before the merged list enters the existing two-arm RRF fusion against the lexical arm. Typed ids (`code:`/`doc:`/`src:`) keep everything disjoint; the same path can legitimately appear as both a `[code]` and a `[src]` line:
+
+```
+- [src] `src/lib/auth.ts:L40-71` — verifies the session token
+```
+
+Degradation is per-sub-arm: a degraded src query collapses to docs-only, both degraded collapses to lexical-only, and the tool never throws because of the semantic arm.
+
+## Operations
+
+- Auth: Vercel Cron sends `Authorization: Bearer $CRON_SECRET`; the route reuses `isAuthorizedCronRequest` (fail closed — unset secret denies everything).
+- Unprovisioned vector env (`UPSTASH_VECTOR_REST_*` unset) is an expected no-op (`src_index_unavailable`), not an error.
+- Event vocabulary and health queries: [docs/observability.md](../observability.md) (`src_index_*` section) and [TELEMETRY.md](../../TELEMETRY.md).

--- a/docs/features/code-index.md
+++ b/docs/features/code-index.md
@@ -4,7 +4,7 @@ The code index (#135, sub-issue of epic #128) extends hybrid retrieval beyond do
 
 ## Architecture
 
-```
+```text
 /api/cron/code-index (every 5 min, maxDuration 240s)
   └─ runCodeIndexTick()                      src/lib/code-index.ts
        ├─ NX claim  srcindex:claim (TTL 270s)          — single writer
@@ -54,7 +54,7 @@ The namespace `{owner}/{repo}:src` is deliberately **not** SHA-scoped (contrast 
 
 `search_repo` now runs three arms: lexical GitHub code search, semantic doc chunks, and semantic src chunks. The two semantic sub-arms share one embedding model, so their raw scores are comparable — `mergeSemanticMatches` (in `src/lib/retrieval.ts`) merges them by descending score (docs win exact ties) before the merged list enters the existing two-arm RRF fusion against the lexical arm. Typed ids (`code:`/`doc:`/`src:`) keep everything disjoint; the same path can legitimately appear as both a `[code]` and a `[src]` line:
 
-```
+```text
 - [src] `src/lib/auth.ts:L40-71` — verifies the session token
 ```
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -196,6 +196,23 @@ Mention and follow-up turns write a processing marker as the first step of the `
 | `recovery_sweep_failed` | The whole sweep aborted | errorMessage |
 | `recovery_sweep_unauthorized` | Request without a valid `Bearer $CRON_SECRET` header | — |
 
+### Code-Index Events (lib/code-index.ts + /api/cron/code-index) — #135
+
+A dedicated cron tick (every 5 minutes, `maxDuration` 240 s) keeps the stable `{owner}/{repo}:src` vector namespace in sync with the repo's source tree by diffing a tree snapshot against the `srcindex:manifest` KV cursor. Single writer via a `SET NX` claim (`srcindex:claim`, 270 s TTL). File **content never reaches logs** — paths and counts only.
+
+| Event | When | Key data |
+|-------|------|----------|
+| `src_index_noop` | Head SHA already fully indexed — fast path, no tree fetch | sha |
+| `src_index_unavailable` | Tick attempted while `UPSTASH_VECTOR_REST_*` is unset — expected degradation, NOT an error | reason (`not_configured`) |
+| `src_index_claim_lost` | Another tick holds the NX claim — benign skip | — |
+| `src_index_tree_truncated` | GitHub truncated the recursive tree listing — tick aborted BEFORE any delete (mass-delete guard) | sha |
+| `src_index_file_skipped` | One file failed to read (or wasn't a file) — skipped, siblings continue; retried next tick because the SHA doesn't advance | path, errorMessage (or reason) |
+| `src_index_degraded` | A vector upsert/delete returned degradation — tick stopped, partial progress persisted in the manifest, SHA untouched | phase (`upsert`/`delete`/`trim`), path or ids |
+| `src_index_tick` | End of every non-noop indexing tick | sha, status (`complete`/`partial`/`degraded`), upserted, deleted, skipped, remaining |
+| `src_index_tick_end` | Route-level summary of the tick's counters | status, upserted, deleted, skipped, remaining |
+| `src_index_tick_failed` | The tick threw (infrastructure/KV error or contract violation; also `Sentry.captureException` tagged `flow: cron_code_index`) | errorMessage |
+| `src_index_unauthorized` | Request without a valid `Bearer $CRON_SECRET` header | — |
+
 ### Error Events (all flows)
 
 Renamed in #125 (previously a single generic `error` event) so severity routing and dashboards can distinguish agent-turn failures from webhook plumbing failures. Any event name containing `error` or `failed` is routed to `console.error` by the logger.

--- a/src/app/api/cron/code-index/route.test.ts
+++ b/src/app/api/cron/code-index/route.test.ts
@@ -1,0 +1,110 @@
+// ── Code-index cron route tests (#135) ───────────────────────────────
+// Mirrors the sweep route harness: auth is exact-match Bearer and
+// fail-closed; the tick's counters pass straight through as JSON; a
+// throwing tick (contract violation — runCodeIndexTick is non-throwing
+// by design) still gets Sentry + the #98 flushLogs tail-drop rule.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+
+const h = vi.hoisted(() => ({
+  runCodeIndexTickSpy: vi.fn(),
+  rlogSpy: vi.fn(),
+  flushLogsSpy: vi.fn(async (..._args: unknown[]) => {}),
+}));
+
+vi.mock("@/lib/code-index", () => ({
+  runCodeIndexTick: (...args: unknown[]) => h.runCodeIndexTickSpy(...args),
+  CODE_INDEX_ROUTE_MAX_DURATION_SEC: 240,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: vi.fn(),
+  createRequestLogger: () =>
+    Object.assign(
+      (event: string, data?: Record<string, unknown>) => h.rlogSpy(event, data),
+      { requestId: "req-codeindex-1" },
+    ),
+  flushLogs: (...args: unknown[]) => h.flushLogsSpy(...args),
+}));
+
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+
+// The route pulls isAuthorizedCronRequest from recovery.ts, which
+// imports the real kv module — stub it so no Redis client is built.
+vi.mock("@/lib/kv", () => ({ kv: {} }));
+
+import { GET, maxDuration } from "./route";
+import { CODE_INDEX_ROUTE_MAX_DURATION_SEC } from "@/lib/code-index";
+
+function cronRequest(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest("http://localhost/api/cron/code-index", { headers });
+}
+
+beforeEach(() => {
+  h.runCodeIndexTickSpy.mockReset();
+  h.rlogSpy.mockClear();
+  h.flushLogsSpy.mockClear();
+  vi.mocked(Sentry.captureException).mockClear();
+  process.env.CRON_SECRET = "s3cret";
+});
+
+describe("auth (fail-closed, mirrors isAuthorizedCronRequest contract)", () => {
+  it("rejects a missing/mismatched Authorization header with 401 and never runs the tick", async () => {
+    process.env.CRON_SECRET = "s3cret";
+    const missing = await GET(cronRequest());
+    expect(missing.status).toBe(401);
+
+    const wrong = await GET(cronRequest({ authorization: "Bearer wrong" }));
+    expect(wrong.status).toBe(401);
+
+    // Unset secret + correct-looking header → still 401 (fail-closed).
+    delete process.env.CRON_SECRET;
+    const unset = await GET(cronRequest({ authorization: "Bearer s3cret" }));
+    expect(unset.status).toBe(401);
+
+    expect(h.runCodeIndexTickSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("authorized tick", () => {
+  it("authorized: runs the tick and returns its counters as JSON with 200", async () => {
+    h.runCodeIndexTickSpy.mockResolvedValue({
+      status: "complete",
+      upserted: 3,
+      deleted: 1,
+      skipped: 0,
+      remaining: 0,
+    });
+    const res = await GET(cronRequest({ authorization: "Bearer s3cret" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      status: "complete",
+      upserted: 3,
+      deleted: 1,
+      skipped: 0,
+      remaining: 0,
+    });
+  });
+
+  it("a tick that throws (contract violation) → 500, Sentry captured, flushLogs still runs", async () => {
+    const err = new Error("contract violation");
+    h.runCodeIndexTickSpy.mockRejectedValue(err);
+    const res = await GET(cronRequest({ authorization: "Bearer s3cret" }));
+    expect(res.status).toBe(500);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      err,
+      expect.objectContaining({ tags: { flow: "cron_code_index" } }),
+    );
+    expect(h.flushLogsSpy).toHaveBeenCalled();
+  });
+});
+
+describe("route config", () => {
+  it("exports maxDuration = CODE_INDEX_ROUTE_MAX_DURATION_SEC", () => {
+    expect(maxDuration).toBe(240);
+    expect(maxDuration).toBe(CODE_INDEX_ROUTE_MAX_DURATION_SEC);
+  });
+});

--- a/src/app/api/cron/code-index/route.ts
+++ b/src/app/api/cron/code-index/route.ts
@@ -1,0 +1,55 @@
+// ── Incremental code-index tick (#135) ───────────────────────────────
+// Vercel Cron entry point (see vercel.json — every 5 minutes). Each
+// invocation runs ONE bounded runCodeIndexTick: diff the repo tree
+// against the srcindex:manifest cursor, embed/delete the difference,
+// persist progress. All indexing invariants (single writer, budgets,
+// truncated-tree guard, degradation) live in src/lib/code-index.ts —
+// this route only does auth, dispatch, and observability.
+//
+// Auth: Vercel Cron sends `Authorization: Bearer $CRON_SECRET`. Exact
+// match via isAuthorizedCronRequest — fail closed (unset secret denies
+// everything), same contract as the recovery sweep.
+
+import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { createRequestLogger, flushLogs } from "@/lib/logger";
+import { isAuthorizedCronRequest } from "@/lib/recovery";
+import { runCodeIndexTick } from "@/lib/code-index";
+
+// Literal (Next.js segment config must be statically analyzable);
+// pinned equal to CODE_INDEX_ROUTE_MAX_DURATION_SEC by the route test.
+// SRC_INDEX_CLAIM_TTL_SEC (270) strictly exceeds this, so a live tick
+// can never lose its claim mid-run.
+export const maxDuration = 240;
+
+export async function GET(request: NextRequest) {
+  const rlog = createRequestLogger();
+
+  if (
+    !isAuthorizedCronRequest(
+      request.headers.get("authorization"),
+      process.env.CRON_SECRET,
+    )
+  ) {
+    rlog("src_index_unauthorized");
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  try {
+    const result = await runCodeIndexTick();
+    rlog("src_index_tick_end", { ...result });
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    // runCodeIndexTick is non-throwing for expected failures — reaching
+    // here means infrastructure (KV) or a contract violation.
+    rlog("src_index_tick_failed", {
+      errorMessage: err instanceof Error ? err.message.slice(0, 200) : String(err),
+    });
+    Sentry.captureException(err, { tags: { flow: "cron_code_index" } });
+    return NextResponse.json({ ok: false }, { status: 500 });
+  } finally {
+    // Same tail-drop rule as every after() body (#98): explicitly drain
+    // the Sentry buffer before the container freezes.
+    await flushLogs(rlog, "cron_code_index");
+  }
+}

--- a/src/lib/code-chunker.test.ts
+++ b/src/lib/code-chunker.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  isEmbeddableSourcePath,
+  chunkCodeFile,
+  MAX_CODE_CHUNK_CHARS,
+  MAX_EMBED_FILE_BYTES,
+} from "./code-chunker";
+import type { BattleMageConfig } from "./config";
+
+const noConfig: BattleMageConfig = { paths: {} };
+
+describe("isEmbeddableSourcePath", () => {
+  it("accepts allowlisted source extensions", () => {
+    expect(isEmbeddableSourcePath("src/lib/foo.ts", 100, noConfig)).toBe(true);
+    expect(isEmbeddableSourcePath("app/Http/Kernel.php", 100, noConfig)).toBe(true);
+  });
+
+  it("rejects markdown (docs arm owns prose), json/yaml/lock noise, and tooling paths", () => {
+    expect(isEmbeddableSourcePath("docs/setup.md", 100, noConfig)).toBe(false);
+    expect(isEmbeddableSourcePath("package-lock.json", 100, noConfig)).toBe(false);
+    expect(isEmbeddableSourcePath("config/app.yaml", 100, noConfig)).toBe(false);
+    expect(isEmbeddableSourcePath(".claude/skills/wizard/SKILL.md", 100, noConfig)).toBe(false);
+    expect(isEmbeddableSourcePath("public/vendor.min.js", 100, noConfig)).toBe(false);
+  });
+
+  it("rejects excluded/vendor/historic config annotations (S6 predicate)", () => {
+    const config: BattleMageConfig = {
+      paths: { "vendor/": "vendor", "archive/": "historic", "secrets/": "excluded" },
+    };
+    expect(isEmbeddableSourcePath("vendor/lib/a.php", 100, config)).toBe(false);
+    expect(isEmbeddableSourcePath("archive/old.ts", 100, config)).toBe(false);
+    expect(isEmbeddableSourcePath("secrets/keys.ts", 100, config)).toBe(false);
+    expect(isEmbeddableSourcePath("src/a.ts", 100, config)).toBe(true);
+  });
+
+  it("size boundary: at cap eligible, one over rejected, undefined size eligible", () => {
+    expect(isEmbeddableSourcePath("src/a.ts", MAX_EMBED_FILE_BYTES, noConfig)).toBe(true);
+    expect(isEmbeddableSourcePath("src/a.ts", MAX_EMBED_FILE_BYTES + 1, noConfig)).toBe(false);
+    expect(isEmbeddableSourcePath("src/a.ts", undefined, noConfig)).toBe(true);
+  });
+});
+
+describe("chunkCodeFile — TS/JS section-aware", () => {
+  it("returns [] for empty and whitespace-only content", () => {
+    expect(chunkCodeFile("src/a.ts", "")).toEqual([]);
+    expect(chunkCodeFile("src/a.ts", "   \n\n  ")).toEqual([]);
+  });
+
+  it("packs a small file into one chunk with full line range and path-prefixed text", () => {
+    const content = `import { x } from "./x";\n\nexport function alpha() {\n  return 1;\n}\n`;
+    const chunks = chunkCodeFile("src/a.ts", content);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].id).toBe("src/a.ts#0");
+    expect(chunks[0].text.startsWith("src/a.ts\n\n")).toBe(true);
+    expect(chunks[0].metadata).toMatchObject({ path: "src/a.ts", startLine: 1, endLine: 5 });
+  });
+
+  it("splits at a column-0 declaration boundary when packing would exceed the cap", () => {
+    // Two ~1000-char top-level functions: together they bust the 1500 cap,
+    // so the split must land EXACTLY on the second boundary line.
+    const filler = "  // padding padding padding padding padding\n".repeat(21); // ~966 chars
+    const alpha = `export function alpha() {\n${filler}}\n`;
+    const beta = `export function beta() {\n${filler}}\n`;
+    const chunks = chunkCodeFile("src/a.ts", alpha + beta);
+    expect(chunks).toHaveLength(2);
+    const alphaLines = alpha.split("\n").length - 1; // 23
+    expect(chunks[0].metadata.endLine).toBe(alphaLines);
+    expect(chunks[1].metadata.startLine).toBe(alphaLines + 1);
+    expect(chunks[1].text).toContain("export function beta()");
+    expect(chunks[1].id).toBe("src/a.ts#1");
+  });
+
+  it("indented declarations are NOT boundaries (column-0 heuristic)", () => {
+    const content = `export function outer() {\n  const inner = () => 1;\n  function nested() {}\n}\n`;
+    expect(chunkCodeFile("src/a.ts", content)).toHaveLength(1);
+  });
+
+  it("caps every chunk's text at MAX_CODE_CHUNK_CHARS unconditionally", () => {
+    const oneLongLine = "x".repeat(4000); // single oversized segment → hard slice
+    const chunks = chunkCodeFile("src/a.ts", oneLongLine);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) expect(c.text.length).toBeLessThanOrEqual(MAX_CODE_CHUNK_CHARS);
+  });
+});
+
+describe("chunkCodeFile — line-window fallback (non-TS/JS)", () => {
+  it("packs whole lines greedily; chunk line ranges are contiguous and ordinals sequential", () => {
+    const line = "$sum = $sum + 1; // ".padEnd(99, "p"); // 99 chars + \n
+    const content = Array.from({ length: 45 }, () => line).join("\n"); // ~4500 chars
+    const chunks = chunkCodeFile("app/calc.php", content);
+    expect(chunks).toHaveLength(4); // budget = 1500 - len("app/calc.php") - 2 = 1486 → 14 lines/chunk
+    chunks.forEach((c, i) => expect(c.id).toBe(`app/calc.php#${i}`));
+    for (let i = 1; i < chunks.length; i++) {
+      expect(chunks[i].metadata.startLine).toBe(chunks[i - 1].metadata.endLine + 1);
+    }
+    expect(chunks[0].metadata.startLine).toBe(1);
+    expect(chunks[chunks.length - 1].metadata.endLine).toBe(45);
+  });
+
+  it("excerpt is whitespace-collapsed and capped at 160 chars", () => {
+    const content = "line  one\n\n\nline    two " + "z".repeat(300);
+    const [chunk] = chunkCodeFile("app/calc.php", content.slice(0, 400));
+    expect(chunk.metadata.excerpt.length).toBeLessThanOrEqual(160);
+    expect(chunk.metadata.excerpt).not.toMatch(/\s{2,}/);
+    expect(chunk.metadata.excerpt.startsWith("line one")).toBe(true);
+  });
+});

--- a/src/lib/code-chunker.ts
+++ b/src/lib/code-chunker.ts
@@ -1,0 +1,239 @@
+/**
+ * Code chunking for the incremental semantic code index (#135).
+ *
+ * Two pure exports:
+ * - isEmbeddableSourcePath — the SINGLE eligibility predicate (invariant
+ *   S6). Both sides of the tree/manifest diff in code-index.ts consume
+ *   this exact function, so a file can never be simultaneously "should
+ *   upsert" and "should delete".
+ * - chunkCodeFile — splits one file into embeddable chunks. TS/JS files
+ *   split at column-0 declaration boundaries (a cheap, dependency-free
+ *   proxy for top-level structure); everything else uses a greedy
+ *   line-window pack. Every chunk's text is prefixed with the file path
+ *   so the embedding carries location context, and is HARD-capped at
+ *   MAX_CODE_CHUNK_CHARS unconditionally.
+ *
+ * Everything here is pure — the GitHub/vector side effects live in
+ * code-index.ts.
+ */
+
+import { isToolingPath } from "./path-filter";
+import { getAnnotation, type BattleMageConfig } from "./config";
+
+/** Hard character cap per embedded chunk (path header included). */
+export const MAX_CODE_CHUNK_CHARS = 1500;
+
+/** Files larger than this are never fetched or embedded — generated
+ * bundles and fixtures dominate above this size, not source. */
+export const MAX_EMBED_FILE_BYTES = 200_000;
+
+// Extension allowlist: source code only. Deliberately excludes prose
+// (md — the docs arm owns it), data/config noise (json/yaml/lock), and
+// anything else that would pollute semantic code recall.
+const SOURCE_EXTENSIONS = new Set([
+  "ts", "tsx", "js", "jsx", "mjs", "cjs",
+  "py", "rb", "php", "go", "rs",
+  "java", "kt", "kts", "swift", "scala",
+  "c", "h", "cc", "cpp", "hpp", "cs",
+  "sh", "bash", "sql", "vue", "svelte",
+]);
+
+// Extensions that get the column-0 declaration-boundary treatment.
+const SECTION_AWARE_EXTENSIONS = new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs"]);
+
+// Column-0 heuristic: a line STARTING with a top-level declaration
+// keyword begins a new logical section. Indented declarations are
+// nested and therefore never boundaries.
+const DECLARATION_BOUNDARY_RE =
+  /^(?:export\b|import\b|function\b|async\b|class\b|const\b|let\b|var\b|interface\b|type\b|enum\b|abstract\b|declare\b|namespace\b)/;
+
+function extensionOf(path: string): string {
+  const base = path.split("/").pop() ?? path;
+  const dot = base.lastIndexOf(".");
+  return dot <= 0 ? "" : base.slice(dot + 1).toLowerCase();
+}
+
+/**
+ * The single eligibility predicate (invariant S6): is this blob a
+ * source file the code index should embed?
+ *
+ * - extension must be on the source allowlist (no md/json/yaml/lock)
+ * - tooling paths (.claude/ etc.) are never source
+ * - minified artifacts (`.min.`) are generated, not source
+ * - config annotations excluded/vendor/historic opt the path out
+ * - blobs over MAX_EMBED_FILE_BYTES are skipped; an UNKNOWN size stays
+ *   eligible (the tree API omits size for some entries)
+ */
+export function isEmbeddableSourcePath(
+  path: string,
+  size: number | undefined,
+  config: BattleMageConfig,
+): boolean {
+  if (size !== undefined && size > MAX_EMBED_FILE_BYTES) return false;
+  if (isToolingPath(path)) return false;
+  if (path.includes(".min.")) return false;
+  if (!SOURCE_EXTENSIONS.has(extensionOf(path))) return false;
+  const annotation = getAnnotation(path, config);
+  return annotation !== "excluded" && annotation !== "vendor" && annotation !== "historic";
+}
+
+export interface CodeChunk {
+  /** Deterministic, path-stable id: `${path}#${ordinal}`. */
+  id: string;
+  /** Text sent for embedding: `${path}\n\n${lines}` — capped at
+   * MAX_CODE_CHUNK_CHARS including the path header. */
+  text: string;
+  metadata: {
+    path: string;
+    /** 1-based inclusive line range of the chunk's content. */
+    startLine: number;
+    endLine: number;
+    /** Whitespace-collapsed preview, ≤160 chars — safe to render. */
+    excerpt: string;
+  };
+}
+
+const EXCERPT_MAX_CHARS = 160;
+
+function makeExcerpt(text: string): string {
+  return text.replace(/\s+/g, " ").trim().slice(0, EXCERPT_MAX_CHARS);
+}
+
+interface NumberedLine {
+  text: string;
+  /** 1-based line number in the original file. */
+  num: number;
+}
+
+interface Window {
+  text: string;
+  startLine: number;
+  endLine: number;
+}
+
+/**
+ * Greedily pack whole lines into windows of at most `budget` chars
+ * (lines joined by "\n"). A single line over budget is hard-sliced —
+ * pathological (minified/generated content), but the cap must hold
+ * unconditionally. Slices of one line share that line's number.
+ */
+function packLines(lines: NumberedLine[], budget: number): Window[] {
+  const windows: Window[] = [];
+  let cur: NumberedLine[] = [];
+  let curLen = 0;
+  const flush = () => {
+    if (cur.length > 0) {
+      windows.push({
+        text: cur.map((l) => l.text).join("\n"),
+        startLine: cur[0].num,
+        endLine: cur[cur.length - 1].num,
+      });
+      cur = [];
+      curLen = 0;
+    }
+  };
+  for (const line of lines) {
+    if (line.text.length > budget) {
+      flush();
+      for (let i = 0; i < line.text.length; i += budget) {
+        windows.push({
+          text: line.text.slice(i, i + budget),
+          startLine: line.num,
+          endLine: line.num,
+        });
+      }
+      continue;
+    }
+    const candidate = cur.length === 0 ? line.text.length : curLen + 1 + line.text.length;
+    if (candidate > budget) flush();
+    curLen = cur.length === 0 ? line.text.length : curLen + 1 + line.text.length;
+    cur.push(line);
+  }
+  flush();
+  return windows;
+}
+
+/**
+ * Pack declaration-delimited segments greedily; a segment that alone
+ * exceeds the budget degrades to the line-window pack for its lines.
+ */
+function packSegments(segments: NumberedLine[][], budget: number): Window[] {
+  const windows: Window[] = [];
+  let cur: NumberedLine[] = [];
+  let curLen = 0;
+  const flush = () => {
+    if (cur.length > 0) {
+      windows.push({
+        text: cur.map((l) => l.text).join("\n"),
+        startLine: cur[0].num,
+        endLine: cur[cur.length - 1].num,
+      });
+      cur = [];
+      curLen = 0;
+    }
+  };
+  for (const segment of segments) {
+    const segLen =
+      segment.reduce((sum, l) => sum + l.text.length, 0) + (segment.length - 1);
+    if (segLen > budget) {
+      flush();
+      windows.push(...packLines(segment, budget));
+      continue;
+    }
+    const candidate = cur.length === 0 ? segLen : curLen + 1 + segLen;
+    if (candidate > budget) flush();
+    curLen = cur.length === 0 ? segLen : curLen + 1 + segLen;
+    cur.push(...segment);
+  }
+  flush();
+  return windows;
+}
+
+/**
+ * Split one source file into embeddable chunks. Pure function.
+ *
+ * TS/JS: lines are grouped into segments starting at each column-0
+ * declaration boundary, then segments pack greedily up to the budget —
+ * so a split always lands ON a boundary line unless a single section is
+ * itself over budget. Other languages: greedy line-window pack.
+ *
+ * The per-chunk content budget is MAX_CODE_CHUNK_CHARS minus the
+ * `${path}\n\n` header, so the FULL text never exceeds the cap.
+ */
+export function chunkCodeFile(path: string, content: string): CodeChunk[] {
+  if (!content || content.trim().length === 0) return [];
+
+  const rawLines = content.split("\n");
+  // A trailing newline produces one empty trailing element — drop it so
+  // line ranges reflect real lines.
+  if (rawLines.length > 1 && rawLines[rawLines.length - 1] === "") rawLines.pop();
+  const lines: NumberedLine[] = rawLines.map((text, i) => ({ text, num: i + 1 }));
+
+  const budget = Math.max(1, MAX_CODE_CHUNK_CHARS - path.length - 2);
+
+  let windows: Window[];
+  if (SECTION_AWARE_EXTENSIONS.has(extensionOf(path))) {
+    const segments: NumberedLine[][] = [];
+    for (const line of lines) {
+      if (segments.length === 0 || DECLARATION_BOUNDARY_RE.test(line.text)) {
+        segments.push([line]);
+      } else {
+        segments[segments.length - 1].push(line);
+      }
+    }
+    windows = packSegments(segments, budget);
+  } else {
+    windows = packLines(lines, budget);
+  }
+
+  return windows.map((w, ordinal) => ({
+    id: `${path}#${ordinal}`,
+    text: `${path}\n\n${w.text}`,
+    metadata: {
+      path,
+      startLine: w.startLine,
+      endLine: w.endLine,
+      excerpt: makeExcerpt(w.text),
+    },
+  }));
+}

--- a/src/lib/code-index.test.ts
+++ b/src/lib/code-index.test.ts
@@ -360,11 +360,29 @@ describe("runCodeIndexTick", () => {
       return { path, content: "export const b = 2;\n" };
     });
     const result = await runCodeIndexTick();
-    expect(result).toMatchObject({ upserted: 1, skipped: 1 });
+    // A skipped file is NOT done — it stays out of the manifest and is
+    // re-diffed next tick, so it counts toward `remaining` (PR #138).
+    expect(result).toMatchObject({ upserted: 1, skipped: 1, remaining: 1 });
     expect(result.status).not.toBe("complete");
     expect(logSpy).toHaveBeenCalledWith("src_index_file_skipped", expect.objectContaining({ path: "src/a.ts" }));
     const manifest = kvData.get("srcindex:manifest") as SrcManifest;
     expect(manifest["src/a.ts"]).toBeUndefined();
+    expect(kvData.get("srcindex:sha")).toBeUndefined();
+  });
+
+  it("all files unreadable: remaining reports the full backlog, not zero (PR #138 review)", async () => {
+    getHeadShaSpy.mockResolvedValue("sha-9");
+    getRepoTreeSnapshotSpy.mockResolvedValue({
+      sha: "sha-9",
+      truncated: false,
+      blobs: [
+        { path: "src/a.ts", sha: "blob-a", size: 50 },
+        { path: "src/b.ts", sha: "blob-b", size: 50 },
+      ],
+    });
+    readFileSpy.mockRejectedValue(new Error("github_unreachable"));
+    const result = await runCodeIndexTick();
+    expect(result).toMatchObject({ status: "partial", upserted: 0, skipped: 2, remaining: 2 });
     expect(kvData.get("srcindex:sha")).toBeUndefined();
   });
 

--- a/src/lib/code-index.test.ts
+++ b/src/lib/code-index.test.ts
@@ -1,0 +1,385 @@
+// ── Incremental semantic code index (#135) ───────────────────────────
+// Part A pins the pure diff/id helpers; Part B drives runCodeIndexTick
+// through the hoisted harness: an in-memory kv fake with Upstash
+// SET NX → null semantics, a mocked vector layer with a cross-mock
+// call-order journal, and mocked GitHub reads pinned to the tick's
+// tree snapshot SHA.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { BattleMageConfig } from "./config";
+
+const h = vi.hoisted(() => {
+  const callOrder: string[] = [];
+  return {
+    callOrder,
+    kvData: new Map<string, unknown>(),
+    logSpy: vi.fn((..._args: unknown[]) => {}),
+    getHeadShaSpy: vi.fn(),
+    getRepoTreeSnapshotSpy: vi.fn(),
+    readFileSpy: vi.fn(),
+    isVectorConfiguredMock: vi.fn((..._args: unknown[]) => true),
+    vectorUpsertSpy: vi.fn(async (..._args: unknown[]) => {
+      callOrder.push("vectorUpsert");
+      return true;
+    }),
+    vectorDeleteSpy: vi.fn(async (..._args: unknown[]) => {
+      callOrder.push("vectorDelete");
+      return true;
+    }),
+  };
+});
+
+vi.mock("./kv", () => ({
+  kv: {
+    get: vi.fn(async (key: string) =>
+      h.kvData.has(key) ? h.kvData.get(key) : null,
+    ),
+    set: vi.fn(
+      async (key: string, value: unknown, opts?: { ex?: number; nx?: boolean }) => {
+        // Mirror Upstash SET NX semantics: null when the key exists.
+        if (opts?.nx && h.kvData.has(key)) return null;
+        h.kvData.set(key, value);
+        return "OK";
+      },
+    ),
+    del: vi.fn(async (key: string) => (h.kvData.delete(key) ? 1 : 0)),
+  },
+}));
+
+vi.mock("./logger", () => ({
+  log: (...args: unknown[]) => h.logSpy(...args),
+}));
+
+vi.mock("./vector", () => ({
+  isVectorConfigured: (...args: unknown[]) => h.isVectorConfiguredMock(...args),
+  srcNamespace: () => "acme/backend:src",
+  docsNamespace: (sha: string) => `acme/backend:docs:${sha}`,
+  kbNamespace: () => "acme/backend:kb",
+  vectorUpsert: (...args: unknown[]) => h.vectorUpsertSpy(...args),
+  vectorDelete: (...args: unknown[]) => h.vectorDeleteSpy(...args),
+  vectorDeleteNamespace: vi.fn(async () => true),
+}));
+
+vi.mock("@/lib/github", () => ({
+  getHeadSha: (...args: unknown[]) => h.getHeadShaSpy(...args),
+  getRepoTreeSnapshot: (...args: unknown[]) => h.getRepoTreeSnapshotSpy(...args),
+  readFile: (...args: unknown[]) => h.readFileSpy(...args),
+}));
+
+import {
+  diffTreeAgainstManifest,
+  chunkIdsFor,
+  staleChunkIds,
+  runCodeIndexTick,
+  MAX_FILES_PER_TICK,
+  SRC_INDEX_CLAIM_TTL_SEC,
+  CODE_INDEX_ROUTE_MAX_DURATION_SEC,
+  type SrcManifest,
+} from "./code-index";
+import { MAX_EMBED_FILE_BYTES } from "./code-chunker";
+
+const {
+  kvData,
+  logSpy,
+  getHeadShaSpy,
+  getRepoTreeSnapshotSpy,
+  readFileSpy,
+  isVectorConfiguredMock,
+  vectorUpsertSpy,
+  vectorDeleteSpy,
+  callOrder,
+} = h;
+
+// ── Part A — pure functions, no mocks ────────────────────────────────
+
+describe("diffTreeAgainstManifest", () => {
+  const config: BattleMageConfig = { paths: { "vendor/": "vendor" } };
+
+  it("first run (empty manifest): every eligible blob is an upsert, nothing deleted", () => {
+    const blobs = [
+      { path: "src/a.ts", sha: "sha-a", size: 10 },
+      { path: "docs/x.md", sha: "sha-x", size: 10 }, // ineligible ext
+      { path: "vendor/l.php", sha: "sha-v", size: 10 }, // vendor
+    ];
+    const diff = diffTreeAgainstManifest(blobs, {}, config);
+    expect(diff.toUpsert).toEqual([{ path: "src/a.ts", sha: "sha-a", size: 10 }]);
+    expect(diff.toDelete).toEqual([]);
+  });
+
+  it("unchanged blob sha → no work; changed sha → upsert; missing path → delete with old chunk count", () => {
+    const manifest = {
+      "src/a.ts": { sha: "sha-a", chunks: 2 },
+      "src/b.ts": { sha: "sha-b-old", chunks: 3 },
+      "src/gone.ts": { sha: "sha-g", chunks: 4 },
+    };
+    const blobs = [
+      { path: "src/a.ts", sha: "sha-a", size: 10 },
+      { path: "src/b.ts", sha: "sha-b-new", size: 10 },
+    ];
+    const diff = diffTreeAgainstManifest(blobs, manifest, { paths: {} });
+    expect(diff.toUpsert).toEqual([{ path: "src/b.ts", sha: "sha-b-new", size: 10 }]);
+    expect(diff.toDelete).toEqual([{ path: "src/gone.ts", chunks: 4 }]);
+  });
+
+  it("S6: a manifest path that BECAME ineligible (config now marks it vendor) moves to the delete side", () => {
+    const manifest = { "vendor/l.php": { sha: "sha-v", chunks: 2 } };
+    const blobs = [{ path: "vendor/l.php", sha: "sha-v", size: 10 }];
+    const diff = diffTreeAgainstManifest(blobs, manifest, config);
+    expect(diff.toUpsert).toEqual([]);
+    expect(diff.toDelete).toEqual([{ path: "vendor/l.php", chunks: 2 }]);
+  });
+
+  it("oversize blob never enters the upsert side; if previously indexed it is deleted", () => {
+    const manifest = { "src/big.ts": { sha: "old", chunks: 9 } };
+    const blobs = [{ path: "src/big.ts", sha: "new", size: MAX_EMBED_FILE_BYTES + 1 }];
+    const diff = diffTreeAgainstManifest(blobs, manifest, { paths: {} });
+    expect(diff.toUpsert).toEqual([]);
+    expect(diff.toDelete).toEqual([{ path: "src/big.ts", chunks: 9 }]);
+  });
+});
+
+describe("chunkIdsFor / staleChunkIds", () => {
+  it("chunkIdsFor(path, 3) → ordinals 0..2; count 0 → []", () => {
+    expect(chunkIdsFor("src/a.ts", 3)).toEqual(["src/a.ts#0", "src/a.ts#1", "src/a.ts#2"]);
+    expect(chunkIdsFor("src/a.ts", 0)).toEqual([]);
+  });
+
+  it("staleChunkIds trims only the shrink tail; growth and equality trim nothing", () => {
+    expect(staleChunkIds("src/a.ts", 5, 3)).toEqual(["src/a.ts#3", "src/a.ts#4"]);
+    expect(staleChunkIds("src/a.ts", 3, 3)).toEqual([]);
+    expect(staleChunkIds("src/a.ts", 3, 5)).toEqual([]);
+  });
+});
+
+describe("timing invariants (mirror of recovery I4 pinning)", () => {
+  it("claim TTL exceeds route maxDuration and stays under the 300s cron cadence", () => {
+    expect(SRC_INDEX_CLAIM_TTL_SEC).toBeGreaterThan(CODE_INDEX_ROUTE_MAX_DURATION_SEC);
+    expect(SRC_INDEX_CLAIM_TTL_SEC).toBeLessThan(300);
+  });
+});
+
+// ── Part B — runCodeIndexTick ────────────────────────────────────────
+
+beforeEach(() => {
+  kvData.clear();
+  callOrder.length = 0;
+  logSpy.mockClear();
+  getHeadShaSpy.mockReset();
+  getRepoTreeSnapshotSpy.mockReset();
+  readFileSpy.mockReset();
+  isVectorConfiguredMock.mockReset().mockReturnValue(true);
+  vectorUpsertSpy.mockReset().mockImplementation(async () => {
+    callOrder.push("vectorUpsert");
+    return true;
+  });
+  vectorDeleteSpy.mockReset().mockImplementation(async () => {
+    callOrder.push("vectorDelete");
+    return true;
+  });
+});
+
+describe("runCodeIndexTick", () => {
+  it("noop fast path: headSha === srcindex:sha → no tree fetch, no claim held afterward, src_index_noop", async () => {
+    kvData.set("srcindex:sha", "sha-1");
+    getHeadShaSpy.mockResolvedValue("sha-1");
+    const result = await runCodeIndexTick();
+    expect(result.status).toBe("noop");
+    expect(getRepoTreeSnapshotSpy).not.toHaveBeenCalled();
+    expect(kvData.has("srcindex:claim")).toBe(false);
+    expect(logSpy).toHaveBeenCalledWith("src_index_noop", expect.objectContaining({ sha: "sha-1" }));
+  });
+
+  it("claim lost: existing srcindex:claim → skips ALL work including getHeadSha", async () => {
+    kvData.set("srcindex:claim", { claimedAt: 1 });
+    const result = await runCodeIndexTick();
+    expect(result.status).toBe("claim_lost");
+    expect(getHeadShaSpy).not.toHaveBeenCalled();
+    // The losing racer must not release the winner's claim.
+    expect(kvData.has("srcindex:claim")).toBe(true);
+  });
+
+  it("vector not configured → unavailable no-op, zero github calls", async () => {
+    isVectorConfiguredMock.mockReturnValue(false);
+    const result = await runCodeIndexTick();
+    expect(result.status).toBe("not_configured");
+    expect(getHeadShaSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith("src_index_unavailable", expect.anything());
+  });
+
+  it("first run: upserts each eligible file's chunks, writes manifest with blob shas + counts, advances sha, releases claim", async () => {
+    getHeadShaSpy.mockResolvedValue("sha-2");
+    getRepoTreeSnapshotSpy.mockResolvedValue({
+      sha: "sha-2",
+      truncated: false,
+      blobs: [{ path: "src/a.ts", sha: "blob-a", size: 50 }],
+    });
+    readFileSpy.mockResolvedValue({ path: "src/a.ts", content: "export const a = 1;\n" });
+    const result = await runCodeIndexTick();
+    expect(result).toMatchObject({ status: "complete", upserted: 1, deleted: 0, skipped: 0, remaining: 0 });
+    // S5: content read pinned to the snapshot sha
+    expect(readFileSpy).toHaveBeenCalledWith("src/a.ts", "sha-2");
+    expect(vectorUpsertSpy).toHaveBeenCalledWith(
+      "acme/backend:src",
+      [expect.objectContaining({ id: "src/a.ts#0", metadata: expect.objectContaining({ path: "src/a.ts", startLine: 1 }) })],
+    );
+    expect(kvData.get("srcindex:manifest")).toEqual({ "src/a.ts": { sha: "blob-a", chunks: 1 } });
+    expect(kvData.get("srcindex:sha")).toBe("sha-2");
+    expect(kvData.has("srcindex:claim")).toBe(false); // released in finally
+  });
+
+  it("incremental: only the changed blob is read + upserted; the unchanged one is untouched", async () => {
+    kvData.set("srcindex:sha", "sha-2");
+    kvData.set("srcindex:manifest", {
+      "src/a.ts": { sha: "blob-a", chunks: 1 },
+      "src/b.ts": { sha: "blob-b-old", chunks: 2 },
+    });
+    getHeadShaSpy.mockResolvedValue("sha-3");
+    getRepoTreeSnapshotSpy.mockResolvedValue({
+      sha: "sha-3",
+      truncated: false,
+      blobs: [
+        { path: "src/a.ts", sha: "blob-a", size: 50 },
+        { path: "src/b.ts", sha: "blob-b-new", size: 50 },
+      ],
+    });
+    readFileSpy.mockResolvedValue({ path: "src/b.ts", content: "export const b = 2;\n" });
+    const result = await runCodeIndexTick();
+    expect(result).toMatchObject({ status: "complete", upserted: 1 });
+    expect(readFileSpy).toHaveBeenCalledTimes(1);
+    expect(readFileSpy).toHaveBeenCalledWith("src/b.ts", "sha-3");
+    expect((kvData.get("srcindex:manifest") as SrcManifest)["src/b.ts"]).toEqual({ sha: "blob-b-new", chunks: 1 });
+    expect(kvData.get("srcindex:sha")).toBe("sha-3");
+  });
+
+  it("shrink: trims stale ordinals AFTER the upsert, manifest records the new smaller count", async () => {
+    // src/b.ts previously 3 chunks, new content chunks to 1 →
+    // vectorDelete(["src/b.ts#1","src/b.ts#2"]) and callOrder shows upsert before delete.
+    kvData.set("srcindex:manifest", { "src/b.ts": { sha: "old", chunks: 3 } });
+    getHeadShaSpy.mockResolvedValue("sha-shrink");
+    getRepoTreeSnapshotSpy.mockResolvedValue({
+      sha: "sha-shrink",
+      truncated: false,
+      blobs: [{ path: "src/b.ts", sha: "blob-b-new", size: 50 }],
+    });
+    readFileSpy.mockResolvedValue({ path: "src/b.ts", content: "export const b = 2;\n" });
+    await runCodeIndexTick();
+    expect(vectorDeleteSpy).toHaveBeenCalledWith("acme/backend:src", ["src/b.ts#1", "src/b.ts#2"]);
+    expect(callOrder.indexOf("vectorUpsert")).toBeLessThan(callOrder.indexOf("vectorDelete"));
+    expect(kvData.get("srcindex:manifest")).toEqual({ "src/b.ts": { sha: "blob-b-new", chunks: 1 } });
+  });
+
+  it("deleted file: batched vectorDelete of all its ordinals, manifest entry removed, no readFile", async () => {
+    kvData.set("srcindex:manifest", { "src/gone.ts": { sha: "g", chunks: 2 } });
+    getHeadShaSpy.mockResolvedValue("sha-4");
+    getRepoTreeSnapshotSpy.mockResolvedValue({ sha: "sha-4", truncated: false, blobs: [] });
+    const result = await runCodeIndexTick();
+    expect(result).toMatchObject({ status: "complete", deleted: 1 });
+    expect(vectorDeleteSpy).toHaveBeenCalledWith("acme/backend:src", ["src/gone.ts#0", "src/gone.ts#1"]);
+    expect(readFileSpy).not.toHaveBeenCalled();
+    expect(kvData.get("srcindex:manifest")).toEqual({});
+  });
+
+  it("budget: MAX_FILES_PER_TICK + 1 changed files → exactly MAX processed, remaining 1, sha NOT advanced (S4)", async () => {
+    const blobs = Array.from({ length: MAX_FILES_PER_TICK + 1 }, (_, i) =>
+      ({ path: `src/f${i}.ts`, sha: `blob-${i}`, size: 10 }));
+    getHeadShaSpy.mockResolvedValue("sha-5");
+    getRepoTreeSnapshotSpy.mockResolvedValue({ sha: "sha-5", truncated: false, blobs });
+    readFileSpy.mockImplementation(async (path: string) => ({
+      path,
+      content: "export const x = 1;\n",
+    }));
+    const result = await runCodeIndexTick();
+    expect(result).toMatchObject({ status: "partial", upserted: MAX_FILES_PER_TICK, remaining: 1 });
+    expect(readFileSpy).toHaveBeenCalledTimes(MAX_FILES_PER_TICK);
+    expect(kvData.get("srcindex:sha")).not.toBe("sha-5");
+    // …and the completed files ARE in the manifest, so the next tick's diff is exactly the remainder.
+    expect(Object.keys(kvData.get("srcindex:manifest") as SrcManifest)).toHaveLength(MAX_FILES_PER_TICK);
+  });
+
+  it("wall-clock budget: injected clock advancing 100s per file stops after 2 files despite budget of 40", async () => {
+    let t = 0;
+    const now = () => { const v = t; t += 100_000; return v; };
+    const blobs = Array.from({ length: 5 }, (_, i) =>
+      ({ path: `src/f${i}.ts`, sha: `blob-${i}`, size: 10 }));
+    getHeadShaSpy.mockResolvedValue("sha-clock");
+    getRepoTreeSnapshotSpy.mockResolvedValue({ sha: "sha-clock", truncated: false, blobs });
+    readFileSpy.mockImplementation(async (path: string) => ({
+      path,
+      content: "export const x = 1;\n",
+    }));
+    const result = await runCodeIndexTick({ now });
+    expect(result.upserted).toBe(2); // 0ms, 100s < 180s budget; 200s > budget → stop
+    expect(result.status).toBe("partial");
+  });
+
+  it("vector degradation mid-tick: upsert false on file 2 → stop, manifest keeps ONLY file 1, sha untouched, no throw", async () => {
+    vectorUpsertSpy.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    getHeadShaSpy.mockResolvedValue("sha-deg");
+    getRepoTreeSnapshotSpy.mockResolvedValue({
+      sha: "sha-deg",
+      truncated: false,
+      blobs: [
+        { path: "src/a.ts", sha: "blob-a", size: 50 },
+        { path: "src/b.ts", sha: "blob-b", size: 50 },
+      ],
+    });
+    readFileSpy.mockImplementation(async (path: string) => ({
+      path,
+      content: "export const x = 1;\n",
+    }));
+    const result = await runCodeIndexTick();
+    expect(result.status).toBe("degraded");
+    expect(kvData.get("srcindex:manifest")).toEqual({ "src/a.ts": { sha: "blob-a", chunks: 1 } });
+    expect(kvData.get("srcindex:sha")).toBeUndefined();
+    expect(logSpy).toHaveBeenCalledWith("src_index_degraded", expect.anything());
+  });
+
+  it("truncated tree: aborts BEFORE any delete or upsert (the mass-delete guard)", async () => {
+    kvData.set("srcindex:manifest", { "src/a.ts": { sha: "a", chunks: 1 } });
+    getHeadShaSpy.mockResolvedValue("sha-6");
+    getRepoTreeSnapshotSpy.mockResolvedValue({ sha: "sha-6", truncated: true, blobs: [] });
+    const result = await runCodeIndexTick();
+    expect(result.status).toBe("tree_truncated");
+    expect(vectorDeleteSpy).not.toHaveBeenCalled();
+    expect(vectorUpsertSpy).not.toHaveBeenCalled();
+    expect(kvData.get("srcindex:manifest")).toEqual({ "src/a.ts": { sha: "a", chunks: 1 } });
+  });
+
+  it("one unreadable file: skipped + logged, siblings processed, sha NOT advanced so only the failure retries", async () => {
+    getHeadShaSpy.mockResolvedValue("sha-7");
+    getRepoTreeSnapshotSpy.mockResolvedValue({
+      sha: "sha-7",
+      truncated: false,
+      blobs: [
+        { path: "src/a.ts", sha: "blob-a", size: 50 },
+        { path: "src/b.ts", sha: "blob-b", size: 50 },
+      ],
+    });
+    readFileSpy.mockImplementation(async (path: string) => {
+      if (path === "src/a.ts") throw new Error("github_unreachable");
+      return { path, content: "export const b = 2;\n" };
+    });
+    const result = await runCodeIndexTick();
+    expect(result).toMatchObject({ upserted: 1, skipped: 1 });
+    expect(result.status).not.toBe("complete");
+    expect(logSpy).toHaveBeenCalledWith("src_index_file_skipped", expect.objectContaining({ path: "src/a.ts" }));
+    const manifest = kvData.get("srcindex:manifest") as SrcManifest;
+    expect(manifest["src/a.ts"]).toBeUndefined();
+    expect(kvData.get("srcindex:sha")).toBeUndefined();
+  });
+
+  it("S8 privacy: no log call ever contains file content", async () => {
+    const MARKER = "SECRET_CONTENT_MARKER_XYZ";
+    getHeadShaSpy.mockResolvedValue("sha-8");
+    getRepoTreeSnapshotSpy.mockResolvedValue({
+      sha: "sha-8",
+      truncated: false,
+      blobs: [{ path: "src/a.ts", sha: "blob-a", size: 50 }],
+    });
+    readFileSpy.mockResolvedValue({ path: "src/a.ts", content: `export const k = "${MARKER}";\n` });
+    await runCodeIndexTick();
+    for (const call of logSpy.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain(MARKER);
+    }
+  });
+});

--- a/src/lib/code-index.ts
+++ b/src/lib/code-index.ts
@@ -1,0 +1,357 @@
+// ── Incremental semantic code index (#135) ───────────────────────────
+// Keeps a STABLE vector namespace (`{owner}/{repo}:src`, see
+// srcNamespace) in sync with the repo's source tree, one cron tick at a
+// time. Unlike the docs pipeline (SHA-scoped generations, full rebuild
+// per SHA — repo-index.ts), source trees are too large to re-embed per
+// commit, so the index advances incrementally:
+//
+//   manifest (srcindex:manifest) — Record<path, {sha: blobSha, chunks}>
+//   is BOTH the index of what's embedded AND the progress cursor: each
+//   tick diffs the current tree snapshot against it and processes only
+//   the difference, bounded by MAX_FILES_PER_TICK and a wall-clock
+//   budget. A partial tick persists its progress in the manifest, so
+//   the next tick's diff is exactly the remainder.
+//
+// Invariants (see the #135 design):
+//   S1 single writer — NX claim `srcindex:claim` (TTL 270s > route
+//      maxDuration 240s, < the 300s cron cadence, mirroring recovery
+//      I4), deleted in finally.
+//   S2 vector-leads-manifest — a file enters the manifest only AFTER
+//      its chunks were upserted (and stale ordinals trimmed), so the
+//      manifest never claims vectors that don't exist.
+//   S3 one SHA snapshot per tick — every readFile is pinned to the
+//      tree snapshot's sha; no torn reads across a mid-tick push.
+//   S4 `srcindex:sha` advances ONLY on a clean complete tick (no
+//      remainder, no skips, no degradation) — the noop fast path can
+//      never mask unfinished work.
+//   S5 truncated-tree abort BEFORE any delete — a partial tree listing
+//      must not be interpreted as mass deletion.
+//   S6 single eligibility predicate — both diff sides consume
+//      isEmbeddableSourcePath.
+//   S7 non-throwing degradation — vector failures stop the tick with
+//      status "degraded"; they never throw or corrupt the manifest.
+//   S8 privacy — file content NEVER reaches logs; paths and counts only.
+
+import { kv } from "./kv";
+import { log } from "./logger";
+import {
+  isVectorConfigured,
+  srcNamespace,
+  vectorUpsert,
+  vectorDelete,
+} from "./vector";
+import { getCachedConfig } from "./repo-index";
+import {
+  isEmbeddableSourcePath,
+  chunkCodeFile,
+} from "./code-chunker";
+import type { BattleMageConfig } from "./config";
+
+// ── KV keys ──────────────────────────────────────────────────────────
+export const SRC_INDEX_MANIFEST_KEY = "srcindex:manifest";
+export const SRC_INDEX_SHA_KEY = "srcindex:sha";
+export const SRC_INDEX_CLAIM_KEY = "srcindex:claim";
+
+// ── Budgets & timing ─────────────────────────────────────────────────
+
+/** Max files (re)embedded per tick — bounds the GitHub content fan-out. */
+export const MAX_FILES_PER_TICK = 40;
+
+/** Wall-clock budget per tick; checked after each file against the
+ * injectable clock so the tick yields before the route's maxDuration. */
+export const TICK_TIME_BUDGET_MS = 180_000;
+
+/** Cap on stale-vector ids deleted per tick (mass-rename safety). */
+export const MAX_DELETE_IDS_PER_TICK = 1000;
+
+/** The cron route's `export const maxDuration` (mirrored here so the
+ * timing-invariant test can pin claim TTL > route budget). */
+export const CODE_INDEX_ROUTE_MAX_DURATION_SEC = 240;
+
+/** NX-claim TTL: strictly greater than the route's maxDuration (a live
+ * tick can never lose its claim mid-run) and strictly under the 300s
+ * cron cadence (an abandoned claim delays work by at most one tick). */
+export const SRC_INDEX_CLAIM_TTL_SEC = 270;
+
+// ── Types ────────────────────────────────────────────────────────────
+
+/** What's embedded, per path: the blob sha it was chunked from and how
+ * many ordinal chunks exist in the vector namespace. */
+export type SrcManifest = Record<string, { sha: string; chunks: number }>;
+
+export interface TreeBlob {
+  path: string;
+  sha: string;
+  size?: number;
+}
+
+export interface SrcIndexDiff {
+  /** Eligible blobs that are new or whose blob sha changed. */
+  toUpsert: TreeBlob[];
+  /** Manifest entries whose path vanished from the tree OR became
+   * ineligible — their chunks must be deleted. */
+  toDelete: { path: string; chunks: number }[];
+}
+
+export type CodeIndexTickStatus =
+  | "not_configured"
+  | "claim_lost"
+  | "noop"
+  | "tree_truncated"
+  | "complete"
+  | "partial"
+  | "degraded";
+
+export interface CodeIndexTickResult {
+  status: CodeIndexTickStatus;
+  /** Files whose chunks were (re)embedded this tick. */
+  upserted: number;
+  /** Files whose chunks were removed this tick. */
+  deleted: number;
+  /** Files that failed to read and were skipped (retried next tick). */
+  skipped: number;
+  /** Diff entries left for the next tick. */
+  remaining: number;
+}
+
+// ── Pure helpers ─────────────────────────────────────────────────────
+
+/** All ordinal chunk ids for a path: `${path}#0` .. `${path}#count-1`. */
+export function chunkIdsFor(path: string, count: number): string[] {
+  return Array.from({ length: count }, (_, i) => `${path}#${i}`);
+}
+
+/**
+ * Ids left dangling when a file shrinks from oldCount to newCount
+ * chunks. Growth and equality trim nothing. Trimmed AFTER the upsert
+ * (D2): between upsert and trim the worst case is a few stale-but-
+ * harmless extra chunks, never missing ones.
+ */
+export function staleChunkIds(path: string, oldCount: number, newCount: number): string[] {
+  if (newCount >= oldCount) return [];
+  return Array.from({ length: oldCount - newCount }, (_, i) => `${path}#${newCount + i}`);
+}
+
+/**
+ * Diff a full tree snapshot against the manifest (S6: BOTH sides use
+ * isEmbeddableSourcePath). Pure function.
+ *
+ * - eligible blob absent from manifest, or present with a different
+ *   blob sha → toUpsert
+ * - manifest path missing from the tree, or present but no longer
+ *   eligible (deleted file, new config annotation, size growth) →
+ *   toDelete with its recorded chunk count
+ */
+export function diffTreeAgainstManifest(
+  blobs: TreeBlob[],
+  manifest: SrcManifest,
+  config: BattleMageConfig,
+): SrcIndexDiff {
+  const eligible = new Map<string, TreeBlob>();
+  for (const blob of blobs) {
+    if (isEmbeddableSourcePath(blob.path, blob.size, config)) {
+      eligible.set(blob.path, blob);
+    }
+  }
+
+  const toUpsert: TreeBlob[] = [];
+  for (const blob of eligible.values()) {
+    const entry = manifest[blob.path];
+    if (!entry || entry.sha !== blob.sha) toUpsert.push(blob);
+  }
+
+  const toDelete: { path: string; chunks: number }[] = [];
+  for (const [path, entry] of Object.entries(manifest)) {
+    if (!eligible.has(path)) toDelete.push({ path, chunks: entry.chunks });
+  }
+
+  return { toUpsert, toDelete };
+}
+
+// ── The tick ─────────────────────────────────────────────────────────
+
+export interface CodeIndexTickOptions {
+  /** Injectable clock for the wall-clock budget (tests). */
+  now?: () => number;
+}
+
+function emptyResult(status: CodeIndexTickStatus): CodeIndexTickResult {
+  return { status, upserted: 0, deleted: 0, skipped: 0, remaining: 0 };
+}
+
+/**
+ * One incremental indexing tick. Non-throwing for every EXPECTED
+ * failure mode (vector degradation, unreadable files, truncated tree);
+ * infrastructure errors (KV down) propagate to the route's catch.
+ */
+export async function runCodeIndexTick(
+  options?: CodeIndexTickOptions,
+): Promise<CodeIndexTickResult> {
+  const now = options?.now ?? Date.now;
+
+  if (!isVectorConfigured()) {
+    // Expected state for installs without UPSTASH_VECTOR_* — not an error.
+    log("src_index_unavailable", { reason: "not_configured" });
+    return emptyResult("not_configured");
+  }
+
+  // S1: single writer. SET NX → null means another tick holds the claim
+  // (Upstash semantics, same protocol as acquireSweepClaim). The loser
+  // does NO work at all — not even the head-SHA read.
+  const claimed = await kv.set(
+    SRC_INDEX_CLAIM_KEY,
+    { claimedAt: Date.now() },
+    { nx: true, ex: SRC_INDEX_CLAIM_TTL_SEC },
+  );
+  if (claimed === null) {
+    log("src_index_claim_lost", {});
+    return emptyResult("claim_lost");
+  }
+
+  try {
+    const { getHeadSha, getRepoTreeSnapshot, readFile } = await import("@/lib/github");
+
+    // Fast path: nothing moved since the last CLEAN tick (S4).
+    const headSha = await getHeadSha();
+    const indexedSha = await kv.get<string>(SRC_INDEX_SHA_KEY);
+    if (headSha === indexedSha) {
+      log("src_index_noop", { sha: headSha });
+      return emptyResult("noop");
+    }
+
+    // S3: one snapshot per tick — every content read below is pinned to
+    // snapshot.sha, never to a moving branch head.
+    const snapshot = await getRepoTreeSnapshot(headSha);
+    if (snapshot.truncated) {
+      // S5: a truncated listing looks like mass deletion — abort before
+      // ANY delete or upsert.
+      log("src_index_tree_truncated", { sha: snapshot.sha });
+      return emptyResult("tree_truncated");
+    }
+
+    const config = await getCachedConfig();
+    const manifest = (await kv.get<SrcManifest>(SRC_INDEX_MANIFEST_KEY)) ?? {};
+    const diff = diffTreeAgainstManifest(snapshot.blobs, manifest, config);
+
+    // Working copy — mutated as files complete, written ONCE at tick end
+    // (also on degraded exit) so partial progress always persists.
+    const working: SrcManifest = { ...manifest };
+    const namespace = srcNamespace();
+    let upserted = 0;
+    let deleted = 0;
+    let skipped = 0;
+    let degraded = false;
+
+    const finish = async (): Promise<CodeIndexTickResult> => {
+      const remaining =
+        diff.toUpsert.length + diff.toDelete.length - upserted - skipped - deleted;
+      await kv.set(SRC_INDEX_MANIFEST_KEY, working);
+      const clean = !degraded && remaining === 0 && skipped === 0;
+      if (clean) await kv.set(SRC_INDEX_SHA_KEY, snapshot.sha);
+      const status: CodeIndexTickStatus = degraded
+        ? "degraded"
+        : clean
+        ? "complete"
+        : "partial";
+      const result: CodeIndexTickResult = { status, upserted, deleted, skipped, remaining };
+      log("src_index_tick", { sha: snapshot.sha, ...result });
+      return result;
+    };
+
+    // ── Deletions first: one batched vectorDelete, capped per tick ──
+    if (diff.toDelete.length > 0) {
+      const deleteIds: string[] = [];
+      const deletablePaths: string[] = [];
+      for (const entry of diff.toDelete) {
+        const ids = chunkIdsFor(entry.path, entry.chunks);
+        if (deleteIds.length + ids.length > MAX_DELETE_IDS_PER_TICK) break;
+        deleteIds.push(...ids);
+        deletablePaths.push(entry.path);
+      }
+      if (deleteIds.length > 0) {
+        const ok = await vectorDelete(namespace, deleteIds);
+        if (!ok) {
+          degraded = true;
+          log("src_index_degraded", { phase: "delete", ids: deleteIds.length });
+          return await finish();
+        }
+        // S2 for deletes: manifest entries drop only AFTER the vectors did.
+        for (const path of deletablePaths) delete working[path];
+        deleted += deletablePaths.length;
+      }
+    }
+
+    // ── Upserts: bounded by file count AND wall clock ────────────────
+    const startedAt = now();
+    for (const blob of diff.toUpsert) {
+      if (upserted + skipped >= MAX_FILES_PER_TICK) break;
+
+      let content: string | null = null;
+      try {
+        const result = await readFile(blob.path, snapshot.sha);
+        if ("content" in result && typeof result.content === "string") {
+          content = result.content;
+        }
+      } catch (err) {
+        // One unreadable file must not sink the tick — skip it (the
+        // un-advanced sha + missing manifest entry retry it next tick).
+        skipped++;
+        log("src_index_file_skipped", {
+          path: blob.path,
+          errorMessage: err instanceof Error ? err.message.slice(0, 200) : String(err),
+        });
+        if (now() - startedAt > TICK_TIME_BUDGET_MS) break;
+        continue;
+      }
+
+      if (content === null) {
+        skipped++;
+        log("src_index_file_skipped", { path: blob.path, reason: "not_a_file" });
+        if (now() - startedAt > TICK_TIME_BUDGET_MS) break;
+        continue;
+      }
+
+      const chunks = chunkCodeFile(blob.path, content);
+      const previousChunks = working[blob.path]?.chunks ?? 0;
+
+      if (chunks.length > 0) {
+        const ok = await vectorUpsert(
+          namespace,
+          chunks.map((c) => ({ id: c.id, text: c.text, metadata: c.metadata })),
+        );
+        if (!ok) {
+          degraded = true;
+          log("src_index_degraded", { phase: "upsert", path: blob.path });
+          return await finish();
+        }
+      }
+
+      // D2: shrink-trim AFTER the upsert — the window between them can
+      // only over-serve (stale ordinals), never under-serve.
+      const stale = staleChunkIds(blob.path, previousChunks, chunks.length);
+      if (stale.length > 0) {
+        const ok = await vectorDelete(namespace, stale);
+        if (!ok) {
+          // Trim failed: do NOT record the new manifest entry — the old
+          // entry (old sha + old count) makes the next tick redo both
+          // the upsert (idempotent) and the trim.
+          degraded = true;
+          log("src_index_degraded", { phase: "trim", path: blob.path });
+          return await finish();
+        }
+      }
+
+      // S2: manifest reflects the file only after its vectors settled.
+      working[blob.path] = { sha: blob.sha, chunks: chunks.length };
+      upserted++;
+
+      if (now() - startedAt > TICK_TIME_BUDGET_MS) break;
+    }
+
+    return await finish();
+  } finally {
+    // Release the claim on every exit path past acquisition. A crash
+    // that skips this leaves the TTL to expire — one missed cadence.
+    await kv.del(SRC_INDEX_CLAIM_KEY);
+  }
+}

--- a/src/lib/code-index.ts
+++ b/src/lib/code-index.ts
@@ -243,9 +243,15 @@ export async function runCodeIndexTick(
     let degraded = false;
 
     const finish = async (): Promise<CodeIndexTickResult> => {
+      // A skipped file is NOT done: it never entered the manifest, so
+      // the next tick's diff re-surfaces it — it stays in `remaining`
+      // (PR #138 review: subtracting `skipped` here undercounted the
+      // backlog and could report remaining 0 on an unfinished tick).
       const remaining =
-        diff.toUpsert.length + diff.toDelete.length - upserted - skipped - deleted;
+        diff.toUpsert.length + diff.toDelete.length - upserted - deleted;
       await kv.set(SRC_INDEX_MANIFEST_KEY, working);
+      // `remaining > 0` already covers skips; `skipped === 0` stays as a
+      // defensive second lock on the SHA advance (invariant S4).
       const clean = !degraded && remaining === 0 && skipped === 0;
       if (clean) await kv.set(SRC_INDEX_SHA_KEY, snapshot.sha);
       const status: CodeIndexTickStatus = degraded

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -193,6 +193,38 @@ export async function getRepoTree(): Promise<{ path: string; type: string }[]> {
     .map((e) => ({ path: e.path!, type: e.type! }));
 }
 
+// ── Repo tree snapshot (for the incremental code index, #135) ────────
+// Additive alongside getRepoTree: the code index needs blob SHAs (for
+// per-file change detection), sizes (for the embed-size cap), and the
+// `truncated` flag (the mass-delete guard aborts on a partial tree).
+
+export interface RepoTreeSnapshot {
+  /** The commit SHA the tree was resolved from — every content read in
+   * the same tick is pinned to this ref. */
+  sha: string;
+  /** True when GitHub truncated the recursive listing — the snapshot is
+   * incomplete and MUST NOT be diffed against the manifest. */
+  truncated: boolean;
+  blobs: { path: string; sha: string; size?: number }[];
+}
+
+export async function getRepoTreeSnapshot(ref?: string): Promise<RepoTreeSnapshot> {
+  const sha = ref ?? (await getHeadSha());
+  const { data } = await octokit.rest.git.getTree({
+    owner: owner(),
+    repo: repo(),
+    tree_sha: sha,
+    recursive: "true",
+  });
+  return {
+    sha,
+    truncated: data.truncated === true,
+    blobs: data.tree
+      .filter((e) => e.type === "blob" && e.path && e.sha)
+      .map((e) => ({ path: e.path!, sha: e.sha!, size: e.size })),
+  };
+}
+
 export async function getHeadSha(): Promise<string> {
   const { data } = await octokit.rest.repos.getBranch({
     owner: owner(),

--- a/src/lib/retrieval.test.ts
+++ b/src/lib/retrieval.test.ts
@@ -7,6 +7,7 @@ import {
   ageBoost,
   fuseRankedLists,
   lexicalRank,
+  mergeSemanticMatches,
   type RecallCandidate,
 } from "./retrieval";
 
@@ -229,5 +230,31 @@ describe("lexicalRank", () => {
       { id: "dated", text: "vercel deploy note", timestamp: "2026-01-01" },
     ];
     expect(lexicalRank("vercel deploy", cands)).toEqual(["dated", "legacy"]);
+  });
+});
+
+describe("mergeSemanticMatches", () => {
+  const m = (id: string, score: number) => ({ id, score });
+
+  it("merges by descending score across both lists", () => {
+    const merged = mergeSemanticMatches(
+      [m("doc:docs/x.md#0", 0.9), m("doc:docs/y.md#0", 0.5)],
+      [m("src:src/a.ts#0", 0.7)],
+      10,
+    );
+    expect(merged.map((x) => x.id)).toEqual(["doc:docs/x.md#0", "src:src/a.ts#0", "doc:docs/y.md#0"]);
+  });
+
+  it("exact score ties keep the first list (docs) ahead — stable", () => {
+    const merged = mergeSemanticMatches([m("doc:d#0", 0.7)], [m("src:s#0", 0.7)], 10);
+    expect(merged.map((x) => x.id)).toEqual(["doc:d#0", "src:s#0"]);
+  });
+
+  it("caps at the given topK; topK 0 → []; both lists empty → []", () => {
+    const a = [m("doc:1", 0.9), m("doc:2", 0.8)];
+    const b = [m("src:1", 0.85)];
+    expect(mergeSemanticMatches(a, b, 2).map((x) => x.id)).toEqual(["doc:1", "src:1"]);
+    expect(mergeSemanticMatches(a, b, 0)).toEqual([]);
+    expect(mergeSemanticMatches([], [], 5)).toEqual([]);
   });
 });

--- a/src/lib/retrieval.ts
+++ b/src/lib/retrieval.ts
@@ -125,6 +125,32 @@ export function fuseRankedLists(
   return fused.slice(0, topK);
 }
 
+/** The minimal shape mergeSemanticMatches needs — VectorMatch satisfies it. */
+export interface ScoredMatch {
+  id: string;
+  score: number;
+}
+
+/**
+ * Merge two SAME-SCALE semantic result lists (doc chunks and src chunks
+ * come from the same embedding model, so raw cosine scores ARE
+ * comparable — unlike the lexical arm, which is why THIS is a score
+ * merge while cross-arm combination stays RRF). Descending score;
+ * stable sort keeps the first list (docs) ahead on exact ties; capped
+ * at topK (explicit 0 honored). Pure function.
+ */
+export function mergeSemanticMatches<T extends ScoredMatch>(
+  docMatches: T[],
+  srcMatches: T[],
+  topK: number,
+): T[] {
+  const merged = [...docMatches, ...srcMatches];
+  // Array.prototype.sort is stable per ES2019 — ties keep enumeration
+  // order, i.e. docs before src.
+  merged.sort((a, b) => b.score - a.score);
+  return merged.slice(0, Math.max(0, topK));
+}
+
 // Small stopword set — question words and glue that would otherwise
 // substring-match almost every entry. Tokens under 3 chars are already
 // dropped before this filter applies.

--- a/src/lib/vector.test.ts
+++ b/src/lib/vector.test.ts
@@ -20,6 +20,7 @@ import {
   isVectorConfigured,
   kbNamespace,
   docsNamespace,
+  srcNamespace,
   VECTOR_OP_TIMEOUT_MS,
   __setVectorStoreFactoryForTests,
   type VectorStore,
@@ -67,6 +68,12 @@ describe("namespace helpers (pure given env)", () => {
     vi.stubEnv("GITHUB_OWNER", "acme");
     vi.stubEnv("GITHUB_REPO", "backend");
     expect(docsNamespace("abc1234")).toBe("acme/backend:docs:abc1234");
+  });
+
+  it("srcNamespace is the stable owner/repo:src namespace (no SHA suffix)", () => {
+    vi.stubEnv("GITHUB_OWNER", "acme");
+    vi.stubEnv("GITHUB_REPO", "backend");
+    expect(srcNamespace()).toBe("acme/backend:src");
   });
 });
 

--- a/src/lib/vector.ts
+++ b/src/lib/vector.ts
@@ -77,6 +77,16 @@ export function docsNamespace(sha: string): string {
   return `${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}:docs:${sha}`;
 }
 
+/**
+ * Namespace holding source-code chunks (#135). Deliberately STABLE
+ * (not SHA-scoped, unlike docsNamespace): the code index is maintained
+ * incrementally — per-file diffs against a KV manifest — so ids must
+ * survive across ticks instead of being rebuilt per generation.
+ */
+export function srcNamespace(): string {
+  return `${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}:src`;
+}
+
 // ── Store construction (lazy + memoized; SDK confined here) ──────────
 
 type VectorStoreFactory = () => VectorStore;

--- a/src/tools/search-repo.test.ts
+++ b/src/tools/search-repo.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/lib/github", () => ({
 }));
 vi.mock("@/lib/vector", () => ({
   vectorQuery: (...a: unknown[]) => vectorQuerySpy(...a),
+  srcNamespace: () => "acme/backend:src",
 }));
 vi.mock("@/lib/repo-index", () => ({
   getDocsVectorNamespace: (...a: unknown[]) => getDocsVectorNamespaceSpy(...a),
@@ -28,6 +29,34 @@ function codeResult(path: string, score = 1) {
 function docMatch(chunkId: string, score: number, heading: string, excerpt: string) {
   const path = chunkId.split("#")[0];
   return { id: chunkId, score, metadata: { path, heading, excerpt } };
+}
+
+interface FakeMatch {
+  id: string;
+  score: number;
+  metadata: Record<string, unknown>;
+}
+
+function srcMatch(
+  chunkId: string,
+  score: number,
+  startLine: number,
+  endLine: number,
+  excerpt: string,
+): FakeMatch {
+  const path = chunkId.split("#")[0];
+  return { id: chunkId, score, metadata: { path, startLine, endLine, excerpt } };
+}
+
+/** vectorQuerySpy dispatches on its namespace arg: the stable src
+ * namespace serves src chunks, anything else serves the docs arm. */
+function mockVectorArms(arms: {
+  docs?: FakeMatch[] | null;
+  src?: FakeMatch[] | null;
+}): void {
+  vectorQuerySpy.mockImplementation(async (namespace: string) =>
+    namespace === "acme/backend:src" ? arms.src ?? null : arms.docs ?? null,
+  );
 }
 
 beforeEach(() => {
@@ -51,10 +80,12 @@ describe("executeSearchRepo — hybrid fusion", () => {
     //   code:a 1/61, doc:x 1/61, code:b 1/62, doc:y 1/62.
     searchCodeSpy.mockResolvedValue([codeResult("src/a.ts"), codeResult("src/b.ts")]);
     getDocsVectorNamespaceSpy.mockResolvedValue("acme/backend:docs:sha1");
-    vectorQuerySpy.mockResolvedValue([
-      docMatch("docs/x.md#0", 0.9, "X Heading", "x excerpt"),
-      docMatch("docs/y.md#2", 0.8, "Y Heading", "y excerpt"),
-    ]);
+    mockVectorArms({
+      docs: [
+        docMatch("docs/x.md#0", 0.9, "X Heading", "x excerpt"),
+        docMatch("docs/y.md#2", 0.8, "Y Heading", "y excerpt"),
+      ],
+    });
 
     const result = await executeSearchRepo({ query: "auth flow" });
     const lines = result.text.split("\n");
@@ -77,11 +108,87 @@ describe("executeSearchRepo — hybrid fusion", () => {
     );
   });
 
+  it("queries the src namespace with MAX_ARM_RESULTS alongside the docs arm", async () => {
+    getDocsVectorNamespaceSpy.mockResolvedValue("acme/backend:docs:sha1");
+    vectorQuerySpy.mockResolvedValue([]);
+    await executeSearchRepo({ query: "auth flow" });
+    expect(vectorQuerySpy).toHaveBeenCalledWith(
+      "acme/backend:src",
+      "auth flow",
+      MAX_ARM_RESULTS,
+    );
+  });
+
+  it("renders embedded code chunks as [src] lines with path:Lstart-end and excerpt", async () => {
+    mockVectorArms({
+      src: [srcMatch("src/lib/auth.ts#2", 0.9, 40, 71, "verifies the session token")],
+    });
+    const result = await executeSearchRepo({ query: "session verification" });
+    const srcLine = result.text.split("\n").find((l) => l.includes("[src]"));
+    expect(srcLine).toBeDefined();
+    expect(srcLine).toContain("`src/lib/auth.ts:L40-71`");
+    expect(srcLine).toContain("verifies the session token");
+  });
+
+  it("src ids never collide with the lexical arm's code: ids — the same path appears as two typed lines", async () => {
+    searchCodeSpy.mockResolvedValue([codeResult("src/lib/auth.ts")]);
+    mockVectorArms({
+      src: [srcMatch("src/lib/auth.ts#0", 0.9, 1, 20, "auth entry point")],
+    });
+    const result = await executeSearchRepo({ query: "auth" });
+    const lines = result.text.split("\n");
+    expect(lines.some((l) => l.includes("[code]") && l.includes("src/lib/auth.ts"))).toBe(true);
+    expect(lines.some((l) => l.includes("[src]") && l.includes("src/lib/auth.ts"))).toBe(true);
+  });
+
+  it("semantic arm merges docs and src by score before fusion", async () => {
+    getDocsVectorNamespaceSpy.mockResolvedValue("acme/backend:docs:sha1");
+    mockVectorArms({
+      docs: [
+        docMatch("docs/x.md#0", 0.9, "X Heading", "x excerpt"),
+        docMatch("docs/y.md#1", 0.85, "Y Heading", "y excerpt"),
+      ],
+      src: [srcMatch("src/lib/auth.ts#0", 0.95, 1, 30, "auth core")],
+    });
+    const result = await executeSearchRepo({ query: "auth" });
+    const lines = result.text.split("\n");
+    const srcAt = lines.findIndex((l) => l.includes("[src]"));
+    const docAt = lines.findIndex((l) => l.includes("docs/x.md"));
+    expect(srcAt).toBeGreaterThanOrEqual(0);
+    expect(docAt).toBeGreaterThanOrEqual(0);
+    expect(srcAt).toBeLessThan(docAt); // 0.95 src outranks the 0.9 doc
+  });
+
+  it("src-arm degradation collapses to docs-only; both semantic arms degraded collapses to lexical-only (never throws)", async () => {
+    // src arm degraded (null), docs arm healthy → doc lines still present.
+    getDocsVectorNamespaceSpy.mockResolvedValue("acme/backend:docs:sha1");
+    mockVectorArms({
+      docs: [docMatch("docs/x.md#0", 0.9, "X Heading", "x excerpt")],
+      src: null,
+    });
+    const withDocs = await executeSearchRepo({ query: "auth" });
+    expect(withDocs.text).toContain("[doc]");
+    expect(withDocs.text).not.toContain("[src]");
+
+    // Both semantic arms degraded + lexical results → only [code] lines.
+    searchCodeSpy.mockResolvedValue([codeResult("src/a.ts")]);
+    mockVectorArms({ docs: null, src: null });
+    const lexicalOnly = await executeSearchRepo({ query: "auth" });
+    expect(lexicalOnly.text).toContain("[code]");
+    expect(lexicalOnly.text).not.toContain("[doc]");
+    expect(lexicalOnly.text).not.toContain("[src]");
+
+    // Null everywhere + no lexical → the no-results message.
+    searchCodeSpy.mockResolvedValue([]);
+    const empty = await executeSearchRepo({ query: "q" });
+    expect(empty.text).toBe('No results found for "q".');
+  });
+
   it("doc lines carry heading and excerpt from chunk metadata", async () => {
     getDocsVectorNamespaceSpy.mockResolvedValue("ns");
-    vectorQuerySpy.mockResolvedValue([
-      docMatch("docs/setup.md#3", 0.9, "Vercel Setup", "Deploys go through Vercel."),
-    ]);
+    mockVectorArms({
+      docs: [docMatch("docs/setup.md#3", 0.9, "Vercel Setup", "Deploys go through Vercel.")],
+    });
     const result = await executeSearchRepo({ query: "how do we deploy" });
     expect(result.text).toContain("[doc]");
     expect(result.text).toContain("docs/setup.md");
@@ -109,12 +216,16 @@ describe("executeSearchRepo — degradation", () => {
     expect(result.text).not.toContain("[doc]");
   });
 
-  it("missing namespace pointer → lexical-only, vector store never queried", async () => {
+  it("missing namespace pointer → docs arm skipped (docs namespace never queried); src arm still runs", async () => {
     searchCodeSpy.mockResolvedValue([codeResult("src/a.ts")]);
     getDocsVectorNamespaceSpy.mockResolvedValue(null);
     const result = await executeSearchRepo({ query: "auth" });
     expect(result.text).toContain("src/a.ts");
-    expect(vectorQuerySpy).not.toHaveBeenCalled();
+    // The src arm queries its STABLE namespace regardless of the docs
+    // pointer — only the docs namespace must stay untouched (#135).
+    for (const call of vectorQuerySpy.mock.calls) {
+      expect(call[0]).toBe("acme/backend:src");
+    }
   });
 
   it("both arms empty → No results found message", async () => {

--- a/src/tools/search-repo.ts
+++ b/src/tools/search-repo.ts
@@ -1,20 +1,31 @@
 import type { Tool } from "@anthropic-ai/sdk/resources/messages";
 import { searchCode } from "@/lib/github";
-import { vectorQuery, type VectorMatch } from "@/lib/vector";
+import { vectorQuery, srcNamespace, type VectorMatch } from "@/lib/vector";
 import { getDocsVectorNamespace } from "@/lib/repo-index";
-import { fuseRankedLists, MAX_ARM_RESULTS } from "@/lib/retrieval";
+import {
+  fuseRankedLists,
+  mergeSemanticMatches,
+  MAX_ARM_RESULTS,
+} from "@/lib/retrieval";
 import { isToolingPath } from "@/lib/path-filter";
 import type { Reference } from "@/tools";
 
 /**
- * Hybrid repo search (#127): fuses a lexical GitHub code-search arm with
- * a semantic doc-chunk arm (Upstash Vector) via Reciprocal Rank Fusion.
- * Arms carry typed ids (`code:${path}` / `doc:${chunkId}`) so results
- * render as typed lines the model can tell apart.
+ * Hybrid repo search (#127, #135): fuses a lexical GitHub code-search
+ * arm with a semantic arm (Upstash Vector) via Reciprocal Rank Fusion.
+ * The semantic arm itself is a score-merge of doc chunks (SHA-scoped
+ * namespace behind the repo-index pointer) and embedded source chunks
+ * (stable src namespace, #135) — same embedding model, so their raw
+ * scores are comparable and mergeSemanticMatches sorts them directly.
+ * Arms carry typed ids (`code:${path}` / `doc:${chunkId}` /
+ * `src:${chunkId}`) so results render as typed lines the model can
+ * tell apart — the same path can legitimately appear as both a [code]
+ * and a [src] line.
  *
  * Degradation: a missing docs-namespace pointer (index never embedded)
- * or a degraded vector layer (vectorQuery → null) silently collapses to
- * lexical-only — the tool never throws because of the semantic arm.
+ * or a degraded vector layer (vectorQuery → null) silently collapses
+ * that semantic sub-arm; both degraded collapses to lexical-only — the
+ * tool never throws because of the semantic arm.
  */
 export const searchRepoTool: Tool = {
   name: "search_repo",
@@ -52,9 +63,16 @@ async function runCodeArm(query: string): Promise<CodeItem[]> {
 
 async function runDocArm(query: string): Promise<VectorMatch[]> {
   const namespace = await getDocsVectorNamespace();
-  if (!namespace) return []; // index never embedded docs — lexical-only
+  if (!namespace) return []; // index never embedded docs — docs sub-arm off
   const matches = await vectorQuery(namespace, query, MAX_ARM_RESULTS);
-  return matches ?? []; // null = vector degraded — lexical-only
+  return matches ?? []; // null = vector degraded — docs sub-arm off
+}
+
+async function runSrcArm(query: string): Promise<VectorMatch[]> {
+  // The src namespace is STABLE (no pointer, no SHA scope — see #135):
+  // an empty or missing namespace simply returns no matches.
+  const matches = await vectorQuery(srcNamespace(), query, MAX_ARM_RESULTS);
+  return matches ?? []; // null = vector degraded — src sub-arm off
 }
 
 export async function executeSearchRepo(
@@ -67,16 +85,26 @@ export async function executeSearchRepo(
     return { text: "No search query provided.", references: [] };
   }
 
-  const [codeItems, docMatches] = await Promise.all([
+  const [codeItems, docMatches, srcMatches] = await Promise.all([
     runCodeArm(query),
     runDocArm(query),
+    runSrcArm(query),
   ]);
 
-  // Typed ids keep the arms disjoint; fusion is a rank interleave with
-  // lexical winning exact ties. No timestamps — repo content freshness
-  // is a per-SHA property, not a per-result one.
+  // Semantic sub-arms share one embedding model → raw scores merge
+  // directly (docs win exact ties — stable). Typed ids (`doc:`/`src:`)
+  // keep them apart from each other AND from the lexical `code:` ids.
+  const semantic = mergeSemanticMatches(
+    docMatches.map((m) => ({ ...m, id: `doc:${m.id}` })),
+    srcMatches.map((m) => ({ ...m, id: `src:${m.id}` })),
+    MAX_ARM_RESULTS,
+  );
+
+  // Cross-arm fusion stays a rank interleave (RRF) with lexical winning
+  // exact ties. No timestamps — repo content freshness is a per-SHA
+  // property, not a per-result one.
   const lexicalIds = codeItems.map((i) => `code:${i.path}`);
-  const semanticIds = docMatches.map((m) => `doc:${m.id}`);
+  const semanticIds = semantic.map((m) => m.id);
   const fused = fuseRankedLists(lexicalIds, semanticIds, { topK: MAX_ARM_RESULTS });
 
   if (fused.length === 0) {
@@ -84,20 +112,35 @@ export async function executeSearchRepo(
   }
 
   const codeById = new Map(codeItems.map((i) => [`code:${i.path}`, i]));
-  const docById = new Map(docMatches.map((m) => [`doc:${m.id}`, m]));
+  const semanticById = new Map(semantic.map((m) => [m.id, m]));
 
   const lines = fused.map((f) => {
     const code = codeById.get(f.id);
     if (code) {
       return `- [code] \`${code.path}\` (score: ${code.score}) — ${code.url}`;
     }
-    const doc = docById.get(f.id)!;
-    const meta = (doc.metadata ?? {}) as {
+    const match = semanticById.get(f.id)!;
+    if (f.id.startsWith("src:")) {
+      const meta = (match.metadata ?? {}) as {
+        path?: string;
+        startLine?: number;
+        endLine?: number;
+        excerpt?: string;
+      };
+      const path = meta.path ?? f.id.slice("src:".length).split("#")[0];
+      const range =
+        meta.startLine !== undefined && meta.endLine !== undefined
+          ? `:L${meta.startLine}-${meta.endLine}`
+          : "";
+      const excerpt = meta.excerpt ? ` — ${meta.excerpt}` : "";
+      return `- [src] \`${path}${range}\`${excerpt}`;
+    }
+    const meta = (match.metadata ?? {}) as {
       path?: string;
       heading?: string;
       excerpt?: string;
     };
-    const path = meta.path ?? String(doc.id).split("#")[0];
+    const path = meta.path ?? f.id.slice("doc:".length).split("#")[0];
     const heading = meta.heading ? ` › ${meta.heading}` : "";
     const excerpt = meta.excerpt ? ` — ${meta.excerpt}` : "";
     return `- [doc] \`${path}\`${heading}${excerpt}`;

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/sweep",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/cron/code-index",
+      "schedule": "*/5 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

First leg of epic #128. `search_repo`'s semantic arm now covers source code, not just docs — chunks are embedded into a **stable** Upstash Vector namespace and kept current incrementally.

- **Manifest-is-the-cursor**: `srcindex:manifest` maps path → `{blobSha, chunks}`; every cron tick re-diffs the tree snapshot against it, so each tick is a self-healing convergence step — no separate queue/cursor state that can drift, no first-run special case. A 1-file commit re-embeds only that file's chunks; deletions and shrinks trim precisely (`staleChunkIds`).
- **Off the request path** (per the epic AC and the #134 review lesson): a dedicated `/api/cron/code-index` (every 5 min, `CRON_SECRET`-gated, `maxDuration 240`) with an NX single-writer claim (270s TTL — pinned above maxDuration and below the cadence by a test). Budgets: 40 files or 180s per tick; a ~500-file first run converges in ~13 ticks.
- **Safety rails**: one pinned SHA snapshot per tick (every `readFile` at that ref — no mid-tick TOCTOU); truncated-tree responses abort *before any delete* (the mass-delete guard); a single eligibility predicate feeds both diff sides so newly-excluded paths (e.g. config marks a dir `vendor`) migrate to the delete side instead of going stale; vector/KV failures end the tick as `degraded` with only completed work recorded; `srcindex:sha` advances only on a clean, complete tick.
- **Retrieval**: code matches merge into the docs semantic arm by directly-comparable cosine score (same embedding model) via pure `mergeSemanticMatches`, then flow through the existing RRF fusion untouched. New result type: `[src] \`path:L40-71\` — excerpt`.
- **Chunking**: column-0 declaration boundaries for TS/JS, line-window fallback elsewhere, 1500-char cap, path-header context — all pure and fixture-tested.

Also additive: `getRepoTreeSnapshot` in github.ts (the existing `getRepoTree` wrapper drops blob SHAs and the `truncated` flag — both needed here; untouched for existing callers).

## Testing

TDD: all six spec sections confirmed RED before implementation; 44 new/extended tests including the shrink-trim ordering, wall-clock budget with injected clock, claim-lost, truncated-tree, degradation matrix, and log-privacy (no file content in any log line). Full suite **795 passing**, typecheck + `next build` clean.

Closes #135 (epic #128)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added incremental source-code indexing to improve repository search coverage and freshness.
  * Search results now combine lexical code matches with semantic matches from both docs and source code.
  * Added new search-result formatting for source snippets with file path and line-range context.

* **Bug Fixes**
  * Improved reliability of scheduled indexing with safer retries, partial-progress handling, and clearer failure outcomes.

* **Documentation**
  * Updated observability and feature docs to describe the new indexing behavior and health signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->