### PR TITLE
feat: Evidence-cited passive KB learning (closes #136)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ npm run dev                  # http://localhost:3000
 
 6. **Thread follow-ups** — Once the bot is participating in a thread, users can send follow-up messages without re-mentioning. The bot checks for its own prior replies, then a fast-model classifier decides whether the message is actually addressed to the bot — anything else (human-to-human chatter, classifier errors) fails closed to silence. See `docs/features/effort-routing.md`.
 
+7. **Passive KB learning is proposal-only** — After a thread goes quiet (4h), the cron sweep's second phase extracts KB candidates from the transcript with a fast model. Every candidate must cite human evidence (verified by a deterministic non-LLM gate), extraction only runs in positively-confirmed PUBLIC channels (fail closed), and NOTHING writes to the KB without an explicit ✅ / "confirm all" — the same confirmation-before-write principle as issue creation. See `docs/features/passive-kb-learning.md`.
+
 ## Project Structure
 
 ```
@@ -56,6 +58,10 @@ src/
     idempotency.ts        — Content-addressed idempotent execution (issue creation, #125)
     recovery.ts           — Processing markers + sweep decisions for died turns (#125)
     turn-runner.ts        — Mention/follow-up turn bodies (shared by webhook route + sweep)
+    kb-extract.ts         — Passive-KB transcript rendering + fast-model extractor (#136)
+    kb-gate.ts            — Deterministic provenance gate for passive KB candidates (pure)
+    kb-proposals.ts       — Pure passive-KB lifecycle helpers (KV keys, idle decision, formatters)
+    kb-runner.ts          — Passive-KB orchestration (sweep phase 2, activity index, batch save)
     config.ts             — .battle-mage.json loader (path annotations with graduated trust)
     repo-index.ts         — Repository topic index (lazy rebuild on SHA change)
     auto-correct.ts       — Stale KB entry detection and doc reference flagging
@@ -96,6 +102,7 @@ docs/
     effort-routing.md     — Fast-model follow-up gate + per-turn effort budgets
     hybrid-retrieval.md   — Lexical + semantic retrieval (Upstash Vector, RRF fusion, degradation)
     code-index.md         — Incremental semantic code index (manifest cursor, cron tick, src arm)
+    passive-kb-learning.md — Evidence-cited passive KB proposals (sweep phase 2, confirm-before-write)
 TELEMETRY.md              — Incident-response event vocabulary + Sentry query recipes
 vercel.json               — Vercel Cron schedules (recovery sweep + code-index tick)
 ```

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -61,6 +61,19 @@ These names are treated as a public contract — renaming one is a breaking chan
 | `src_index_claim_lost` | Another tick owns the NX claim (`srcindex:claim`, 270 s TTL) — benign skip |
 | `src_index_unauthorized` | Cron auth rejected — check `CRON_SECRET` |
 
+### Passive KB learning (#136)
+
+| Event | Meaning |
+|---|---|
+| `kb_extraction_complete` / `kb_extraction_error` | One fast-model extraction pass succeeded / failed (`reason: timeout \| api_error \| malformed_json \| invalid_shape`) |
+| `kb_extraction_skipped` | A quiet thread was skipped — `reason: private_channel` is the fail-closed publicness guard (check `channels:read` scope if it spikes) |
+| `kb_batch_proposed` | KB candidates posted for human confirmation (nothing saved yet) |
+| `kb_batch_confirmed` / `kb_batch_saved` | A user confirmed; the batch saved (with per-entry `kb_save_error` on partial failure) |
+| `kb_extract_sweep_complete` | KB phase heartbeat (`scanned`, `extracted`, `proposed`, `pruned`, `gaveUp`, `skipped`) — rides every recovery sweep |
+| `kb_extract_sweep_failed` | The KB phase aborted — recovery (phase 1) is unaffected by design |
+
+Healthy: `kb_extract_sweep_complete` every ~5 minutes; `proposed` small and occasional; `count(kb_batch_confirmed) / count(kb_batch_proposed)` is the adoption signal. Zero `kb_batch_saved` without a matching `kb_batch_confirmed` — anything else violates the confirmation-before-write invariant and is a bug. Full field-level catalog: docs/observability.md.
+
 ## Query recipes (Sentry Logs UI)
 
 ### Turn failure rate

--- a/docs/features/passive-kb-learning.md
+++ b/docs/features/passive-kb-learning.md
@@ -1,0 +1,179 @@
+# Passive KB Learning (Evidence-Cited)
+
+Sub-issue #136 of epic #128. The knowledge base historically only grew
+through explicit saves (`save_knowledge` tool) and 👎-corrections.
+Threads routinely surface durable facts that were never captured. This
+feature closes that gap **without ever writing to the KB
+automatically**: after a thread goes quiet, a fast-model extraction
+pass proposes candidates, a deterministic provenance gate filters them,
+and everything lands as a **proposal** the user must confirm — the same
+confirmation-before-write principle as issue creation.
+
+## The pipeline
+
+```
+answer posted ──▶ kb-extract:index bump (zset, score = Date.now())
+                        │
+        /api/cron/sweep phase 2 (every 5 min, after recovery)
+                        │
+       decideKbExtraction(state, lastActivityAt, now)
+         wait │ prune │ give_up │ extract
+                        │ extract (≤ 3 per sweep)
+       publicness check (conversations.info, FAIL CLOSED)
+                        │
+       NX claim ─▶ pre-checks (idle re-check, pending-correction,
+                        │       pending KB batch)
+       buildExtractionTranscript ─▶ extractKbCandidates (Haiku, 10s cap)
+                        │
+       gateKbCandidates (deterministic, non-LLM)
+                        │ eligible > 0
+       proposal message ─▶ pending-kb-batch record ─▶ state covered
+                        │
+       user confirms (✅ reaction or "confirm all" text)
+                        │
+       executeKbBatchSave ─▶ saveKnowledgeEntry
+                             (+ markKnowledgeSuperseded for corrections)
+```
+
+## Modules
+
+| File | Role |
+|------|------|
+| `src/lib/kb-extract.ts` | Transcript rendering + fast-model extractor (injected-call idiom, never throws) |
+| `src/lib/kb-gate.ts` | Pure provenance gate: evidence verification, dedup, channel eligibility |
+| `src/lib/kb-proposals.ts` | Pure lifecycle helpers: KV keys, `decideKbExtraction`, message formatters |
+| `src/lib/kb-runner.ts` | Orchestration: sweep phase 2, activity recording, batch save |
+
+## Evidence citations (the core contract)
+
+Every extractor candidate MUST cite transcript message indices as
+evidence. The gate verifies the citations deterministically:
+
+- `no_evidence` — empty citation list.
+- `evidence_out_of_range` — **fail closed**: ONE fabricated index kills
+  the whole candidate.
+- `no_human_evidence` — every cited message was authored by the bot.
+  The bot can never launder its own assertions into the KB; at least
+  one cited message must come from a human.
+
+The full drop-reason precedence (pinned by tests in `kb-gate.test.ts`):
+
+```
+empty_entry → entry_too_long (500 chars, inclusive pass) →
+low_confidence (< 0.75; >= passes) → no_evidence →
+evidence_out_of_range → no_human_evidence → already_saved_in_thread →
+duplicate_kb → already_proposed
+```
+
+- `already_saved_in_thread` — the thread already contains a bot
+  "`:white_check_mark: Saved to knowledge base:`" confirmation covering
+  the candidate (`KB_SAVED_CONFIRMATION_PREFIX`, shared with
+  turn-runner's correction reply; matched by normalized containment
+  because the confirmation truncates to 100 chars).
+- `duplicate_kb` — normalized equality OR containment in either
+  direction against the **visible** KB set. Superseded/archived entries
+  never block re-learning.
+- `already_proposed` — the candidate's content hash
+  (`kbCandidateHash` = sha256 of the normalized text) was proposed in a
+  prior quiet period, or duplicates an earlier candidate in the same
+  batch. Ignored (unconfirmed) proposals are never re-posted.
+
+Correction-kind candidates additionally get `flaggedKbEntries` — the
+visible KB entries they likely contradict (keyword-overlap match,
+`matchContradictedEntries`). That's an **annotation**, never a drop: on
+confirm, the save marks those entries superseded (#124 supersession).
+
+## Trigger: sweep piggyback
+
+There is no new cron. `/api/cron/sweep` runs the recovery pass (phase
+1, #125) and then passive-KB extraction (phase 2) under its own
+try/catch — a KB failure can never fail recovery.
+
+- **Discovery**: zset `kb-extract:index`, member `channel:threadTs`
+  (recovery's `indexMember` format), score = `Date.now()` at answer
+  post. `recordKbThreadActivity` bumps it best-effort after every
+  `answer_posted` (mention + follow-up, answer + proposal paths). The
+  KB proposal post itself never bumps the index — the extractor's own
+  output must not re-arm extraction.
+- **Idle gate**: a thread is "concluded" after `KB_EXTRACT_IDLE_MS`
+  (4h) of quiet. Strict `>` — and a FUTURE score (clock skew) always
+  waits.
+- **Budget**: at most `MAX_KB_EXTRACT_PER_SWEEP` (3) model calls per
+  sweep; each capped at `KB_EXTRACTOR_TIMEOUT_MS` (10s).
+- **Retries**: a failed extraction retries on later sweeps up to
+  `MAX_KB_EXTRACTION_ATTEMPTS` (2), then gives up until new thread
+  activity re-arms it (attempt counter resets).
+- **State**: `kb-extract:state:{channel}:{threadTs}` (30d TTL) —
+  `{status: covered|failed|gave_up, extractedAt, attempt,
+  proposedHashes}`. `decideKbExtraction` is a pure function over
+  (state, lastActivityAt, now).
+- **Claim**: non-destructive `SET NX` on
+  `kb-extract:claim:{channel}:{threadTs}` (120s TTL) — a structural
+  clone of recovery's `acquireSweepClaim`. Index + state survive any
+  post-claim failure.
+- **Pre-checks inside the claim**: idle re-check (score re-read), skip
+  if a `pending-correction` record owns the thread's next reply, skip
+  if an unconfirmed KB batch already sits in the thread.
+
+## Channel privacy (fail closed)
+
+Extraction only runs in channels **positively confirmed public** via
+`conversations.info` (once per channel per sweep). Private channels,
+DMs, and MPIMs are pruned from the index; channels whose publicness
+can't be confirmed (missing `channels:read` scope, API error) are
+skipped and logged as `kb_extraction_skipped` / `private_channel`. See
+the scope note in [setup.md](../setup.md).
+
+## Proposal + confirmation
+
+Proposals reuse the issue-batch machinery's shape without its anchors:
+
+- `pending-kb-batch:{channel}:{firstTs}` (24h) — the batch record.
+- `pending-kb-batch:thread:{channel}:{threadTs}` — pointer for
+  "confirm all" text confirmation.
+- `pending-kb-batch:done:{channel}:{firstTs}` (1h) — tombstone
+  absorbing a double-tap ✅.
+
+`formatKbProposalMessage` **never** contains issue-batch's
+`SINGLE_PROPOSAL_ANCHOR` or `BATCH_PROPOSAL_HEADER`, so the legacy ✅
+text parser can never mistake a KB proposal for an issue proposal —
+and there is deliberately **no text-parse fallback** for KB proposals:
+the KV record is the only path to a save. Write ordering is
+post → record → state, so a partial failure degrades to a proposal the
+user can't confirm, never a save the user didn't approve.
+
+`executeKbBatchSave` clones `executeBatchCreation`'s claim protocol
+(get → atomic `DEL` claim → tombstone → pointer cleanup →
+`Promise.allSettled` saves → summary post). Correction-kind saves run
+`saveKnowledgeEntry` then `markKnowledgeSuperseded` per flagged entry.
+
+The ✅ handler chain in `route.ts` is: issue batch →
+`executeKbBatchSave` → issue tombstone → KB tombstone (silent return)
+→ legacy issue parser.
+
+## Invariants
+
+1. Nothing writes to the KB without explicit human confirmation.
+2. Every stored candidate cites verifiable human evidence.
+3. Extraction never runs against non-public conversations (fail
+   closed).
+4. No text-parse fallback for KB proposals — KV record or nothing.
+5. A KB-side failure never breaks recovery (sweep phase isolation) or
+   the reply flow (activity bumps are best-effort).
+6. The extractor is untrusted: it can only ever produce proposal text,
+   filtered by a deterministic gate.
+7. One quiet period → at most one extraction; ignored proposals are
+   never re-posted (`proposedHashes`).
+8. The KB proposal post never re-arms its own thread for extraction.
+
+## Telemetry
+
+See the "Passive KB Events" section in
+[../observability.md](../observability.md) for the full catalog:
+`kb_extraction_complete`, `kb_extraction_error`,
+`kb_extraction_skipped`, `kb_candidates_gated`, `kb_batch_proposed`,
+`kb_batch_confirmed`, `kb_batch_saved`, `kb_save_error`,
+`kb_extract_pruned`, `kb_extraction_gave_up`, `kb_extract_claim_lost`,
+`kb_batch_claim_lost`, `kb_batch_reaction_after_claim`,
+`kb_extract_member_failed`, `kb_extract_sweep_complete`,
+`kb_extract_sweep_failed`, `kb_activity_record_failed`.

--- a/docs/features/passive-kb-learning.md
+++ b/docs/features/passive-kb-learning.md
@@ -99,7 +99,16 @@ try/catch — a KB failure can never fail recovery.
   (4h) of quiet. Strict `>` — and a FUTURE score (clock skew) always
   waits.
 - **Budget**: at most `MAX_KB_EXTRACT_PER_SWEEP` (3) model calls per
-  sweep; each capped at `KB_EXTRACTOR_TIMEOUT_MS` (10s).
+  sweep; each capped at `KB_EXTRACTOR_TIMEOUT_MS` (10s). The index scan
+  itself is bounded too: only the first `KB_EXTRACT_SCAN_LIMIT` (50)
+  zset members per sweep, ascending by score — i.e. the most-idle
+  threads first; recent members age into the window naturally.
+- **Transcript fetch**: `fetchThreadTail` (slack.ts) paginates
+  `conversations.replies` (oldest-first) following `next_cursor` up to
+  `MAX_THREAD_TAIL_PAGES` (5) pages of `THREAD_TAIL_PAGE_LIMIT` (200)
+  and keeps the most recent `MAX_EXTRACTION_MESSAGES` (60) — the
+  single-page 50-message `fetchThreadMessages` would truncate the
+  extraction window.
 - **Retries**: a failed extraction retries on later sweeps up to
   `MAX_KB_EXTRACTION_ATTEMPTS` (2), then gives up until new thread
   activity re-arms it (attempt counter resets).
@@ -145,7 +154,14 @@ user can't confirm, never a save the user didn't approve.
 `executeKbBatchSave` clones `executeBatchCreation`'s claim protocol
 (get → atomic `DEL` claim → tombstone → pointer cleanup →
 `Promise.allSettled` saves → summary post). Correction-kind saves run
-`saveKnowledgeEntry` then `markKnowledgeSuperseded` per flagged entry.
+`saveKnowledgeEntry` then `markKnowledgeSuperseded` per flagged entry;
+retirement is best-effort — a supersession failure logs
+`kb_supersede_error` but never misreports the (already durable) save.
+
+All model-produced and thread-quoted text in the proposal and summary
+messages passes through `escapeSlackMentions` (`&` → `&amp;`, `<` →
+`&lt;`, `>` → `&gt;`) so a candidate containing `<!channel>` /
+`<@U…>` / `<#C…>` can never trigger real pings when posted.
 
 The ✅ handler chain in `route.ts` is: issue batch →
 `executeKbBatchSave` → issue tombstone → KB tombstone (silent return)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -213,6 +213,36 @@ A dedicated cron tick (every 5 minutes, `maxDuration` 240 s) keeps the stable `{
 | `src_index_tick_failed` | The tick threw (infrastructure/KV error or contract violation; also `Sentry.captureException` tagged `flow: cron_code_index`) | errorMessage |
 | `src_index_unauthorized` | Request without a valid `Bearer $CRON_SECRET` header | — |
 
+### Passive KB Events (lib/kb-extract.ts + lib/kb-runner.ts) — #136
+
+Passive KB learning runs as phase 2 of `/api/cron/sweep` (own
+try/catch — a KB failure never fails recovery). Threads bump
+`kb-extract:index` on every posted answer; quiet threads get one
+fast-model extraction pass whose candidates pass a deterministic
+provenance gate before landing as a proposal. Nothing writes to the KB
+without a human ✅ / "confirm all". See
+[features/passive-kb-learning.md](features/passive-kb-learning.md).
+
+| Event | When | Key data |
+|-------|------|----------|
+| `kb_extraction_complete` | The extractor call returned a valid payload | candidateCount, duration_ms, model |
+| `kb_extraction_error` | The extractor call failed — the attempt counts toward the retry cap | reason (`timeout` \| `api_error` \| `malformed_json` \| `invalid_shape`), message, duration_ms, model |
+| `kb_extraction_skipped` | A claimed/scanned thread was skipped without extracting | reason (`private_channel` — fail-closed publicness, `idle_recheck`, `pending_correction`, `pending_kb_batch`, `empty_thread`), channel, threadTs |
+| `kb_candidates_gated` | The provenance gate ran on an extraction's output | candidateCount, eligibleCount, droppedCount, dropReasons, channel, threadTs |
+| `kb_batch_proposed` | A proposal message was posted + its pending-kb-batch record written | count, channel, threadTs, firstTs, kinds, sampleEntries |
+| `kb_batch_confirmed` | A user claimed a pending KB batch (✅ or "confirm all") | count, confirmVia, confirmingUser, latencyMs, channel, threadTs |
+| `kb_batch_saved` | The claimed batch finished saving | totalCount, successCount, failureCount, supersededTotal, durationMs |
+| `kb_save_error` | One entry in a claimed batch failed to save (batch continues) | entrySample, errorClass, errorMessage |
+| `kb_batch_claim_lost` | A racing confirmation won the DEL claim — benign skip | channel, firstTs, confirmVia |
+| `kb_batch_reaction_after_claim` | A second ✅ hit an already-claimed KB proposal (tombstone) — silent return | channel, messageTs |
+| `kb_extract_claim_lost` | Another sweep instance holds the NX claim (`kb-extract:claim:*`, 120 s TTL) — benign skip | channel, threadTs |
+| `kb_extract_pruned` | An index member was dropped (quiet period consumed, malformed member, or confirmed-private channel) | channel, threadTs (or member), reason |
+| `kb_extraction_gave_up` | Attempt cap reached — the thread won't be retried until new activity | channel, threadTs, attempt |
+| `kb_extract_member_failed` | One index member threw mid-sweep (sweep continues; index + state intact) | member, errorMessage |
+| `kb_extract_sweep_complete` | End of every KB extraction phase | scanned, extracted, proposed, pruned, gaveUp, skipped |
+| `kb_extract_sweep_failed` | The whole KB phase aborted (recovery phase 1 unaffected) | errorMessage |
+| `kb_activity_record_failed` | The best-effort index bump after an answer failed (reply flow unaffected) | channel, threadTs, errorMessage |
+
 ### Error Events (all flows)
 
 Renamed in #125 (previously a single generic `error` event) so severity routing and dashboards can distinguish agent-turn failures from webhook plumbing failures. Any event name containing `error` or `failed` is routed to `console.error` by the logger.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -233,6 +233,7 @@ without a human ✅ / "confirm all". See
 | `kb_batch_confirmed` | A user claimed a pending KB batch (✅ or "confirm all") | count, confirmVia, confirmingUser, latencyMs, channel, threadTs |
 | `kb_batch_saved` | The claimed batch finished saving | totalCount, successCount, failureCount, supersededTotal, durationMs |
 | `kb_save_error` | One entry in a claimed batch failed to save (batch continues) | entrySample, errorClass, errorMessage |
+| `kb_supersede_error` | A flagged entry failed to retire AFTER its correction saved — the save still reports success (best-effort, mirrors `correction_supersede_error`) | channel, threadTs, entrySample, flaggedSample, errorMessage |
 | `kb_batch_claim_lost` | A racing confirmation won the DEL claim — benign skip | channel, firstTs, confirmVia |
 | `kb_batch_reaction_after_claim` | A second ✅ hit an already-claimed KB proposal (tombstone) — silent return | channel, messageTs |
 | `kb_extract_claim_lost` | Another sweep instance holds the NX claim (`kb-extract:claim:*`, 120 s TTL) — benign skip | channel, threadTs |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -74,12 +74,14 @@ From your app's settings page:
 |-------|-----|
 | `app_mentions:read` | Detect when someone @mentions the bot |
 | `channels:history` | Read thread messages for follow-up context |
-| `channels:read` | Access channel info |
+| `channels:read` | Access channel info — also required by passive KB learning to positively confirm a channel is public before extracting from it |
 | `chat:write` | Post replies in threads |
 | `groups:history` | Same as channels:history but for private channels |
 | `groups:read` | Same as channels:read but for private channels |
 | `reactions:read` | Detect thumbs up/down and checkmark reactions |
 | `reactions:write` | Add brain emoji to acknowledge positive feedback |
+
+> **Passive KB learning and channel privacy (#136):** the extraction sweep only runs against channels it can positively confirm are PUBLIC via `conversations.info`. If the app lacks `channels:read` (or the info call fails), the sweep **fails closed** — it skips the channel and logs `kb_extraction_skipped` with reason `private_channel`. Private channels, DMs, and group DMs are never extracted from. See [features/passive-kb-learning.md](features/passive-kb-learning.md).
 
 ## 2. Create a GitHub Fine-Grained PAT
 

--- a/src/app/api/cron/sweep/route.ts
+++ b/src/app/api/cron/sweep/route.ts
@@ -13,6 +13,10 @@
 //   give_up → the retry also died: post a visible failure notice so
 //             the user is never left with silence.
 //
+// Phase 2 (#136): after recovery, the same sweep runs passive KB
+// extraction (see src/lib/kb-runner.ts) under its own try/catch — a KB
+// failure never fails recovery.
+//
 // Auth: Vercel Cron sends `Authorization: Bearer $CRON_SECRET`. Exact
 // match, fail closed (unset secret denies everything).
 
@@ -35,6 +39,7 @@ import {
   type ProcessingMarker,
 } from "@/lib/recovery";
 import { runMentionTurn, runFollowupTurn } from "@/lib/turn-runner";
+import { runKbExtractionSweep, type KbSweepSummary } from "@/lib/kb-runner";
 
 // A retried turn is a full agent run — give the sweep the same budget
 // as the Slack route.
@@ -205,8 +210,22 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    rlog("recovery_sweep_complete", { scanned, retried, gaveUp, orphaned });
-    return NextResponse.json({ ok: true, scanned, retried, gaveUp, orphaned });
+    // ── Phase 2: passive KB extraction (#136) ─────────────────────────
+    // Piggybacks on the same cron cadence. Own try/catch — a KB-side
+    // failure must NEVER fail recovery: phase 1's results stand and the
+    // sweep still returns 200 so Vercel Cron doesn't flag the job.
+    let kb: KbSweepSummary | null = null;
+    try {
+      kb = await runKbExtractionSweep(rlog);
+    } catch (err) {
+      rlog("kb_extract_sweep_failed", {
+        errorMessage: err instanceof Error ? err.message.slice(0, 200) : String(err),
+      });
+      Sentry.captureException(err, { tags: { flow: "kb_extract_sweep" } });
+    }
+
+    rlog("recovery_sweep_complete", { scanned, retried, gaveUp, orphaned, kb });
+    return NextResponse.json({ ok: true, scanned, retried, gaveUp, orphaned, kb });
   } catch (err) {
     rlog("recovery_sweep_failed", {
       errorMessage: err instanceof Error ? err.message.slice(0, 200) : String(err),

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -26,6 +26,8 @@ import {
   batchTombstoneKey,
   type PendingCorrection,
 } from "@/lib/turn-runner";
+import { executeKbBatchSave } from "@/lib/kb-runner";
+import { kbBatchTombstoneKey } from "@/lib/kb-proposals";
 
 // Give the after() bodies the full Fluid-compute budget. Next.js reads
 // this statically, so it must be a literal — SLACK_ROUTE_MAX_DURATION_SEC
@@ -227,6 +229,19 @@ export async function POST(request: NextRequest) {
         );
         if (outcome.claimed) return;
 
+        // KB proposal batch (#136): the reacted-on message may be a
+        // passive-KB proposal instead of an issue proposal. Same claim
+        // protocol, checked second so issue batches keep precedence.
+        const kbOutcome = await executeKbBatchSave(
+          channel,
+          threadTs,
+          messageTs,
+          reactingUser,
+          "reaction",
+          rlog,
+        );
+        if (kbOutcome.claimed) return;
+
         // Tombstone guard: a prior confirmation already claimed this
         // message's batch. Without this check, a second ✅ on the same
         // post-#122 single-proposal message would fall through to the
@@ -237,6 +252,16 @@ export async function POST(request: NextRequest) {
         const tombstone = await kv.get(batchTombstoneKey(channel, messageTs));
         if (tombstone) {
           rlog("issue_batch_reaction_after_claim", { channel, messageTs });
+          return;
+        }
+
+        // KB tombstone (#136): a second ✅ on an already-claimed KB
+        // proposal returns SILENTLY — there is deliberately no
+        // text-parse fallback for KB proposals (K-P4), so nothing
+        // below this line may act on one.
+        const kbTombstone = await kv.get(kbBatchTombstoneKey(channel, messageTs));
+        if (kbTombstone) {
+          rlog("kb_batch_reaction_after_claim", { channel, messageTs });
           return;
         }
 

--- a/src/lib/kb-extract.test.ts
+++ b/src/lib/kb-extract.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  KB_EXTRACTION_PROMPT,
+  KB_EXTRACTOR_TIMEOUT_MS,
+  MAX_KB_CANDIDATES,
+  buildExtractionTranscript,
+  parseExtractorOutput,
+  extractKbCandidates,
+  type KbCandidate,
+} from "./kb-extract";
+
+const VALID: KbCandidate = {
+  entry: "The auth module lives in app/Services/Auth",
+  kind: "correction",
+  evidence: [0, 1],
+  confidence: 0.9,
+};
+const payload = (candidates: unknown) => JSON.stringify({ candidates });
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("KB_EXTRACTION_PROMPT", () => {
+  it("carries the transcript placeholder and demands JSON with the exact candidate keys", () => {
+    expect(KB_EXTRACTION_PROMPT).toContain("<TRANSCRIPT>");
+    for (const key of ["entry", "kind", "evidence", "confidence"]) {
+      expect(KB_EXTRACTION_PROMPT).toContain(key);
+    }
+    expect(KB_EXTRACTION_PROMPT).toMatch(/JSON/);
+  });
+  it("names all three candidate kinds", () => {
+    for (const kind of ["correction", "fact", "decision"]) {
+      expect(KB_EXTRACTION_PROMPT).toContain(`"${kind}"`);
+    }
+  });
+});
+
+describe("buildExtractionTranscript", () => {
+  const BOT = "UBOT";
+  it("numbers entries after skipping empty-after-clean messages, so indices match the entries array", () => {
+    const { rendered, entries } = buildExtractionTranscript(
+      [
+        { user: "U1", text: "how does auth work?", ts: "1751970000.000100" },
+        { user: "U1", text: "<@UBOT>", ts: "1751970001.000100" }, // empty after mention strip → skipped
+        { user: BOT, text: "Auth uses JWT.", ts: "1751970060.000200" },
+      ],
+      BOT,
+    );
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toEqual({ index: 1, author: "bot", ts: "1751970060.000200", text: "Auth uses JWT." });
+    expect(rendered).toBe("[0] human: how does auth work?\n[1] bot: Auth uses JWT.");
+  });
+  it("marks bot_id messages as bot", () => {
+    const { entries } = buildExtractionTranscript([{ bot_id: "B1", text: "hi", ts: "1.0" }], BOT);
+    expect(entries[0].author).toBe("bot");
+  });
+  it("truncates long messages at 1000 chars with a trailing ellipsis", () => {
+    const { entries } = buildExtractionTranscript([{ user: "U1", text: "a".repeat(1500), ts: "1.0" }], BOT);
+    expect(entries[0].text).toBe("a".repeat(1000) + "...");
+  });
+  it("keeps only the most recent MAX messages", () => {
+    const msgs = Array.from({ length: 70 }, (_, i) => ({ user: "U1", text: `m${i}`, ts: `${i}.0` }));
+    const { entries } = buildExtractionTranscript(msgs, BOT);
+    expect(entries).toHaveLength(60);
+    expect(entries[0].text).toBe("m10");
+    expect(entries[59].index).toBe(59);
+  });
+  it("returns empty results for an empty thread", () => {
+    expect(buildExtractionTranscript([], BOT)).toEqual({ rendered: "", entries: [] });
+  });
+});
+
+describe("parseExtractorOutput — envelope (shape strictness)", () => {
+  it("parses a valid payload", () => {
+    expect(parseExtractorOutput(payload([VALID]))).toEqual([VALID]);
+  });
+  it("strips a markdown code fence", () => {
+    expect(parseExtractorOutput("```json\n" + payload([VALID]) + "\n```")).toEqual([VALID]);
+  });
+  it("returns null for malformed JSON", () => {
+    expect(parseExtractorOutput("not json {")).toBeNull();
+  });
+  it.each([["a bare array", "[]"], ["a string envelope", '"hi"'], ["missing candidates", "{}"], ["non-array candidates", '{"candidates": 3}']])(
+    "returns null for %s",
+    (_label, raw) => {
+      expect(parseExtractorOutput(raw)).toBeNull();
+    },
+  );
+  it("returns [] for an empty candidates array (valid: nothing learned)", () => {
+    expect(parseExtractorOutput(payload([]))).toEqual([]);
+  });
+  it("truncates to MAX_KB_CANDIDATES", () => {
+    const many = Array.from({ length: MAX_KB_CANDIDATES + 2 }, (_, i) => ({ ...VALID, entry: `fact ${i}` }));
+    expect(parseExtractorOutput(payload(many))).toHaveLength(MAX_KB_CANDIDATES);
+  });
+});
+
+describe("parseExtractorOutput — per-candidate filtering", () => {
+  it.each([
+    ["non-string entry", { ...VALID, entry: 7 }],
+    ["unknown kind", { ...VALID, kind: "opinion" }],
+    ["non-array evidence", { ...VALID, evidence: "0,1" }],
+    ["non-integer evidence element", { ...VALID, evidence: [0, 1.5] }],
+    ["confidence above 1 (rejected, never clamped)", { ...VALID, confidence: 1.5 }],
+    ["negative confidence", { ...VALID, confidence: -0.1 }],
+    ["NaN confidence", { ...VALID, confidence: Number.NaN }],
+  ])("filters a candidate with %s but keeps valid siblings", (_label, bad) => {
+    expect(parseExtractorOutput(payload([bad, VALID]))).toEqual([VALID]);
+  });
+  it("accepts confidence boundaries 0 and 1", () => {
+    expect(parseExtractorOutput(payload([{ ...VALID, confidence: 0 }, { ...VALID, confidence: 1 }]))).toHaveLength(2);
+  });
+});
+
+describe("extractKbCandidates — injected-call contract (never throws)", () => {
+  const input = { transcript: "[0] human: the limit is 120" };
+
+  it("returns candidates on a valid call and logs kb_extraction_complete", async () => {
+    const events: [string, Record<string, unknown> | undefined][] = [];
+    const result = await extractKbCandidates(input, {
+      call: async () => payload([VALID]),
+      log: (e, d) => events.push([e, d]),
+    });
+    expect(result).toEqual([VALID]);
+    expect(events.some(([e]) => e === "kb_extraction_complete")).toBe(true);
+  });
+
+  it("substitutes the transcript literally even when it contains $& patterns", async () => {
+    let seen = "";
+    await extractKbCandidates(
+      { transcript: "[0] human: costs $& more" },
+      { call: async (prompt) => ((seen = prompt), payload([])) , log: () => {} },
+    );
+    expect(seen).toContain("costs $& more");
+  });
+
+  it("returns null with reason api_error on a rejecting call", async () => {
+    const events: [string, Record<string, unknown> | undefined][] = [];
+    const result = await extractKbCandidates(input, {
+      call: async () => { throw new Error("boom"); },
+      log: (e, d) => events.push([e, d]),
+    });
+    expect(result).toBeNull();
+    expect(events).toContainEqual(["kb_extraction_error", expect.objectContaining({ reason: "api_error" })]);
+  });
+
+  it("converts a synchronously-throwing injected call into api_error, not an escaping throw", async () => {
+    const result = await extractKbCandidates(input, {
+      call: () => { throw new Error("sync"); },
+      log: () => {},
+    });
+    expect(result).toBeNull();
+  });
+
+  it("times out a hung call, aborts it, and returns null with reason timeout", async () => {
+    vi.useFakeTimers();
+    let aborted = false;
+    const events: [string, Record<string, unknown> | undefined][] = [];
+    const pending = extractKbCandidates(input, {
+      call: (_p, signal) =>
+        new Promise<string>(() => { signal?.addEventListener("abort", () => { aborted = true; }); }),
+      log: (e, d) => events.push([e, d]),
+    });
+    await vi.advanceTimersByTimeAsync(KB_EXTRACTOR_TIMEOUT_MS);
+    expect(await pending).toBeNull();
+    expect(aborted).toBe(true);
+    expect(events).toContainEqual(["kb_extraction_error", expect.objectContaining({ reason: "timeout" })]);
+  });
+
+  it("returns null with reason malformed_json on unparseable output", async () => {
+    const events: [string, Record<string, unknown> | undefined][] = [];
+    expect(await extractKbCandidates(input, { call: async () => "{{nope", log: (e, d) => events.push([e, d]) })).toBeNull();
+    expect(events).toContainEqual(["kb_extraction_error", expect.objectContaining({ reason: "malformed_json" })]);
+  });
+
+  it("returns null with reason invalid_shape on a wrong envelope", async () => {
+    const events: [string, Record<string, unknown> | undefined][] = [];
+    expect(await extractKbCandidates(input, { call: async () => '{"answers": []}', log: (e, d) => events.push([e, d]) })).toBeNull();
+    expect(events).toContainEqual(["kb_extraction_error", expect.objectContaining({ reason: "invalid_shape" })]);
+  });
+});

--- a/src/lib/kb-extract.ts
+++ b/src/lib/kb-extract.ts
@@ -1,0 +1,318 @@
+/**
+ * Passive KB extraction (#136) — transcript preparation + fast-model
+ * extractor call.
+ *
+ * After a thread goes quiet (see kb-proposals.ts for the idle gate), the
+ * sweep asks a fast model to propose knowledge-base candidates from the
+ * thread transcript. Every candidate MUST cite transcript message
+ * indices as evidence — the deterministic provenance gate (kb-gate.ts)
+ * rejects anything it can't verify against those citations.
+ *
+ * Injection idiom copied from effort-routing.ts / compaction.ts:
+ * `ExtractDeps { call?, log? }` with a private default Haiku call, an
+ * AbortController-backed timeout, and a NEVER-throws contract — every
+ * failure mode logs `kb_extraction_error` with a stable reason
+ * (timeout | api_error | malformed_json | invalid_shape) and returns
+ * null. The orchestrator (kb-runner.ts) interprets null as a failed
+ * attempt subject to the retry cap.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { FAST_MODEL } from "@/lib/claude";
+import { log as defaultLog, type LogFn } from "@/lib/logger";
+
+// Shared client. Same singleton pattern as effort-routing.ts — reads
+// ANTHROPIC_API_KEY from env at module-eval time.
+const anthropic = new Anthropic();
+
+/** Hard wall-clock cap on the extractor call. The extraction runs inside
+ *  the cron sweep's budget alongside recovery work — a hung call must
+ *  not eat the sweep. */
+export const KB_EXTRACTOR_TIMEOUT_MS = 10_000;
+
+/** Upper bound on candidates per extraction — the proposal message must
+ *  stay skimmable, and anything past a handful is noise. */
+export const MAX_KB_CANDIDATES = 5;
+
+/** Most recent messages considered. Long threads keep their tail — the
+ *  conclusions live at the end. */
+export const MAX_EXTRACTION_MESSAGES = 60;
+
+/** Per-message character cap in the rendered transcript. */
+const MAX_ENTRY_TEXT_CHARS = 1000;
+
+export type KbCandidateKind = "correction" | "fact" | "decision";
+
+export interface KbCandidate {
+  /** The proposed knowledge-base entry text. */
+  entry: string;
+  kind: KbCandidateKind;
+  /** Transcript indices (see TranscriptEntry.index) that prove the claim. */
+  evidence: number[];
+  confidence: number;
+}
+
+/** One numbered transcript line, as both the model and the gate see it. */
+export interface TranscriptEntry {
+  index: number;
+  author: "human" | "bot";
+  /** Slack message timestamp of the underlying message. */
+  ts: string;
+  text: string;
+}
+
+export const KB_EXTRACTION_PROMPT = `You are a knowledge extractor for a Slack bot (@bm) that answers engineering questions about a GitHub repository. Read the thread transcript below and extract durable, reusable facts worth saving to the bot's knowledge base.
+
+Candidate kinds:
+- "correction": a human contradicted or corrected something the bot asserted.
+- "fact": a durable project fact a human stated (conventions, file locations, limits, ownership).
+- "decision": a decision the team reached in this thread.
+
+Rules:
+- Extract ONLY claims a HUMAN stated or confirmed in the transcript. Never extract the bot's own unconfirmed assertions.
+- Every candidate MUST cite the transcript message indices (the [i] numbers) that prove it.
+- Prefer a few high-confidence candidates over many weak ones. Skip pleasantries, status chatter, and one-off details.
+- Each entry must be a single self-contained statement under 500 characters.
+
+Thread transcript (each line is "[index] author: text"):
+---
+<TRANSCRIPT>
+---
+
+Respond with ONLY a JSON object — no prose, no code fences — of exactly this shape:
+{"candidates": [{"entry": "...", "kind": "correction"|"fact"|"decision", "evidence": [message indices], "confidence": 0.0-1.0}]}
+Return {"candidates": []} if nothing qualifies.`;
+
+// ── Transcript preparation ────────────────────────────────────────────
+
+/** Minimal message shape — structurally compatible with slack.ts's
+ *  ThreadMessage. */
+export interface ExtractionSourceMessage {
+  user?: string;
+  text?: string;
+  bot_id?: string;
+  ts?: string;
+}
+
+/**
+ * Render a thread into the numbered transcript the extractor prompt
+ * embeds. Pure function.
+ *
+ * Order of operations matters (and is pinned by tests):
+ * 1. clean each message (strip Slack mention tokens, trim);
+ * 2. SKIP empty-after-clean messages BEFORE numbering, so the indices
+ *    the model cites always land on real entries;
+ * 3. keep only the most recent MAX_EXTRACTION_MESSAGES;
+ * 4. number 0..N-1 and cap each entry at 1000 chars + "...".
+ */
+export function buildExtractionTranscript(
+  messages: ExtractionSourceMessage[],
+  botUserId: string,
+): { rendered: string; entries: TranscriptEntry[] } {
+  const cleaned = messages
+    .map((m) => ({
+      author: (m.bot_id || m.user === botUserId ? "bot" : "human") as "human" | "bot",
+      ts: m.ts ?? "",
+      text: (m.text ?? "").replace(/<@[A-Z0-9]+>/g, "").trim(),
+    }))
+    .filter((m) => m.text.length > 0)
+    .slice(-MAX_EXTRACTION_MESSAGES);
+
+  const entries: TranscriptEntry[] = cleaned.map((m, index) => ({
+    index,
+    author: m.author,
+    ts: m.ts,
+    text:
+      m.text.length > MAX_ENTRY_TEXT_CHARS
+        ? m.text.slice(0, MAX_ENTRY_TEXT_CHARS) + "..."
+        : m.text,
+  }));
+
+  const rendered = entries
+    .map((e) => `[${e.index}] ${e.author}: ${e.text}`)
+    .join("\n");
+  return { rendered, entries };
+}
+
+// ── Output parsing ────────────────────────────────────────────────────
+
+// Belt-and-braces: the prompt demands bare JSON, but fast models
+// occasionally wrap output in a markdown fence anyway. Strip one if
+// present. (Same guard as effort-routing.ts.)
+function stripCodeFence(raw: string): string {
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  return fenced ? fenced[1] : trimmed;
+}
+
+function isConfidence(v: unknown): v is number {
+  // Out-of-range or NaN confidences are REJECTED, never clamped — a
+  // model emitting 1.5 is a model we shouldn't act on.
+  return typeof v === "number" && Number.isFinite(v) && v >= 0 && v <= 1;
+}
+
+function toCandidate(v: unknown): KbCandidate | null {
+  if (typeof v !== "object" || v === null) return null;
+  const o = v as Record<string, unknown>;
+  if (typeof o.entry !== "string") return null;
+  if (o.kind !== "correction" && o.kind !== "fact" && o.kind !== "decision") return null;
+  if (!Array.isArray(o.evidence) || !o.evidence.every((i) => Number.isInteger(i))) return null;
+  if (!isConfidence(o.confidence)) return null;
+  return {
+    entry: o.entry,
+    kind: o.kind,
+    evidence: o.evidence as number[],
+    confidence: o.confidence,
+  };
+}
+
+/**
+ * Validate an already-parsed extractor envelope. Null only for a
+ * malformed envelope (the whole payload is untrustworthy); individual
+ * bad candidates are FILTERED so one hallucinated shape doesn't discard
+ * valid siblings. Truncates to MAX_KB_CANDIDATES after filtering.
+ */
+function validateExtractorEnvelope(parsed: unknown): KbCandidate[] | null {
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+  const candidates = (parsed as Record<string, unknown>).candidates;
+  if (!Array.isArray(candidates)) return null;
+  return candidates
+    .map(toCandidate)
+    .filter((c): c is KbCandidate => c !== null)
+    .slice(0, MAX_KB_CANDIDATES);
+}
+
+/**
+ * Parse raw extractor output. Returns null ONLY for a malformed
+ * envelope (unparseable JSON or a wrong top-level shape); per-candidate
+ * problems filter that candidate and keep the rest. Pure function.
+ */
+export function parseExtractorOutput(raw: string): KbCandidate[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripCodeFence(raw));
+  } catch {
+    return null;
+  }
+  return validateExtractorEnvelope(parsed);
+}
+
+// ── Extractor call ────────────────────────────────────────────────────
+
+export interface ExtractInput {
+  /** Rendered transcript from buildExtractionTranscript. */
+  transcript: string;
+}
+
+export interface ExtractDeps {
+  /**
+   * Injectable model call for tests. In prod defaults to a FAST_MODEL
+   * call. The signal aborts when the extractor timeout fires so a slow
+   * request doesn't keep running (and billing) after we've given up.
+   */
+  call?: (prompt: string, signal?: AbortSignal) => Promise<string>;
+  /** Logger for kb_extraction_complete / kb_extraction_error events. */
+  log?: LogFn;
+}
+
+// Internal sentinel so the catch block can distinguish our own timeout
+// from a real API failure without string-matching error messages.
+class ExtractorTimeoutError extends Error {
+  constructor() {
+    super(`kb extractor timed out after ${KB_EXTRACTOR_TIMEOUT_MS}ms`);
+  }
+}
+
+/**
+ * One fast-model extraction call. NEVER throws — every failure mode
+ * (API error, sync throw from an injected call, timeout, malformed
+ * JSON, invalid envelope) logs `kb_extraction_error` with a stable
+ * reason and returns null. Success logs `kb_extraction_complete`.
+ */
+export async function extractKbCandidates(
+  input: ExtractInput,
+  deps: ExtractDeps = {},
+): Promise<KbCandidate[] | null> {
+  const log = deps.log ?? defaultLog;
+  const call = deps.call ?? defaultCall;
+  const start = Date.now();
+
+  // Replacer FUNCTION, not a bare string — String.replace treats `$&`
+  // and friends in a string replacement as substitution patterns, so a
+  // transcript containing `$&` would garble the prompt.
+  const prompt = KB_EXTRACTION_PROMPT.replace("<TRANSCRIPT>", () => input.transcript);
+
+  let raw: string;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const controller = new AbortController();
+  try {
+    raw = await Promise.race([
+      // Promise.resolve().then(...) converts a synchronously-throwing
+      // injected call into a rejection instead of an escaping throw.
+      Promise.resolve().then(() => call(prompt, controller.signal)),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          // Abort the losing request too — Promise.race alone would let
+          // the model call keep running after we've moved on.
+          controller.abort();
+          reject(new ExtractorTimeoutError());
+        }, KB_EXTRACTOR_TIMEOUT_MS);
+      }),
+    ]);
+  } catch (err) {
+    log("kb_extraction_error", {
+      reason: err instanceof ExtractorTimeoutError ? "timeout" : "api_error",
+      message: err instanceof Error ? err.message : String(err),
+      duration_ms: Date.now() - start,
+      model: FAST_MODEL,
+    });
+    return null;
+  } finally {
+    // Clear on the win path too — a live timer would hold the
+    // serverless event loop open for the full 10s after a fast response.
+    if (timer !== undefined) clearTimeout(timer);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripCodeFence(raw));
+  } catch (err) {
+    log("kb_extraction_error", {
+      reason: "malformed_json",
+      message: err instanceof Error ? err.message : String(err),
+      duration_ms: Date.now() - start,
+      model: FAST_MODEL,
+    });
+    return null;
+  }
+
+  const candidates = validateExtractorEnvelope(parsed);
+  if (candidates === null) {
+    log("kb_extraction_error", {
+      reason: "invalid_shape",
+      message: `unexpected extractor payload: ${JSON.stringify(parsed).slice(0, 200)}`,
+      duration_ms: Date.now() - start,
+      model: FAST_MODEL,
+    });
+    return null;
+  }
+
+  log("kb_extraction_complete", {
+    candidateCount: candidates.length,
+    duration_ms: Date.now() - start,
+    model: FAST_MODEL,
+  });
+  return candidates;
+}
+
+async function defaultCall(prompt: string, signal?: AbortSignal): Promise<string> {
+  const resp = await anthropic.messages.create(
+    {
+      model: FAST_MODEL,
+      max_tokens: 1024,
+      messages: [{ role: "user", content: prompt }],
+    },
+    { signal },
+  );
+  return resp.content.map((b) => (b.type === "text" ? b.text : "")).join("");
+}

--- a/src/lib/kb-gate.test.ts
+++ b/src/lib/kb-gate.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeKbText,
+  kbCandidateHash,
+  gateKbCandidates,
+  matchContradictedEntries,
+  isExtractableChannel,
+  KB_CANDIDATE_MIN_CONFIDENCE,
+  MAX_KB_ENTRY_CHARS,
+  KB_SAVED_CONFIRMATION_PREFIX,
+} from "./kb-gate";
+import type { KbCandidate, TranscriptEntry } from "./kb-extract";
+import type { KnowledgeEntry } from "./knowledge";
+
+// Pinned fixtures — stable literals, no faker, no clock.
+const T: TranscriptEntry[] = [
+  { index: 0, author: "human", ts: "1751970000.000100", text: "how does auth work?" },
+  { index: 1, author: "bot",   ts: "1751970060.000200", text: "Auth uses JWT in app/Http/Auth." },
+  { index: 2, author: "human", ts: "1751970120.000300", text: "wrong — auth moved to app/Services/Auth last quarter" },
+  { index: 3, author: "bot",   ts: "1751970180.000400", text: `${KB_SAVED_CONFIRMATION_PREFIX} _"The rate limit is 120 req/min"_` },
+];
+
+const BASE: KbCandidate = {
+  entry: "The auth module lives in app/Services/Auth, not app/Http/Auth",
+  kind: "correction",
+  evidence: [1, 2],
+  confidence: 0.9,
+};
+
+function gate(overrides: Partial<Parameters<typeof gateKbCandidates>[0]> = {}) {
+  return gateKbCandidates({
+    candidates: [BASE],
+    transcript: T,
+    visibleKb: [],
+    alreadyProposedHashes: [],
+    ...overrides,
+  });
+}
+
+describe("normalizeKbText", () => {
+  it("lowercases, strips punctuation, collapses whitespace, trims", () => {
+    expect(normalizeKbText("  The API   limit is 120!! ")).toBe("the api limit is 120");
+  });
+  it("maps a punctuation-only string to empty", () => {
+    expect(normalizeKbText("?!.,;")).toBe("");
+  });
+});
+
+describe("kbCandidateHash", () => {
+  it("is deterministic and normalization-insensitive", () => {
+    expect(kbCandidateHash("The API limit is 120")).toBe(kbCandidateHash("  the api limit is 120!! "));
+  });
+  it("differs for different facts", () => {
+    expect(kbCandidateHash("limit is 120")).not.toBe(kbCandidateHash("limit is 60"));
+  });
+});
+
+describe("gateKbCandidates — eligibility", () => {
+  it("passes a human-evidenced correction and carries hash + evidence quotes", () => {
+    const { eligible, dropped } = gate();
+    expect(dropped).toEqual([]);
+    expect(eligible).toHaveLength(1);
+    expect(eligible[0].hash).toBe(kbCandidateHash(BASE.entry));
+    expect(eligible[0].evidenceQuotes).toHaveLength(2);
+    expect(eligible[0].evidenceQuotes[1]).toContain("app/Services/Auth");
+  });
+
+  it("correction-shaped evidence (human contradicting bot) is eligible via its human index", () => {
+    const { eligible } = gate({ candidates: [{ ...BASE, evidence: [1, 2] }] });
+    expect(eligible).toHaveLength(1);
+  });
+});
+
+describe("gateKbCandidates — drop reasons", () => {
+  it("drops empty_entry (whitespace-only)", () => {
+    const { eligible, dropped } = gate({ candidates: [{ ...BASE, entry: "   " }] });
+    expect(eligible).toEqual([]);
+    expect(dropped[0].reason).toBe("empty_entry");
+  });
+
+  it("drops entry_too_long above the cap; exactly MAX passes", () => {
+    const atCap = gate({ candidates: [{ ...BASE, entry: "x".repeat(MAX_KB_ENTRY_CHARS) }] });
+    expect(atCap.eligible).toHaveLength(1);
+    const over = gate({ candidates: [{ ...BASE, entry: "x".repeat(MAX_KB_ENTRY_CHARS + 1) }] });
+    expect(over.dropped[0].reason).toBe("entry_too_long");
+  });
+
+  it("drops low_confidence below threshold; exactly threshold passes (>= semantics)", () => {
+    expect(gate({ candidates: [{ ...BASE, confidence: KB_CANDIDATE_MIN_CONFIDENCE }] }).eligible).toHaveLength(1);
+    expect(gate({ candidates: [{ ...BASE, confidence: 0.74 }] }).dropped[0].reason).toBe("low_confidence");
+  });
+
+  it("drops no_evidence on an empty evidence array", () => {
+    expect(gate({ candidates: [{ ...BASE, evidence: [] }] }).dropped[0].reason).toBe("no_evidence");
+  });
+
+  it("drops evidence_out_of_range fail-closed: one bad index kills the candidate", () => {
+    for (const bad of [[2, 4], [-1, 2], [2, 1.5]]) {
+      const { eligible, dropped } = gate({ candidates: [{ ...BASE, evidence: bad as number[] }] });
+      expect(eligible).toEqual([]);
+      expect(dropped[0].reason).toBe("evidence_out_of_range");
+    }
+  });
+
+  it("drops no_human_evidence for bot-only-sourced claims", () => {
+    const { dropped } = gate({ candidates: [{ ...BASE, evidence: [1, 3] }] });
+    expect(dropped[0].reason).toBe("no_human_evidence");
+  });
+
+  it("drops already_saved_in_thread when a bot saved-confirmation covers the candidate", () => {
+    const { dropped } = gate({
+      candidates: [{ ...BASE, entry: "The rate limit is 120 req/min", kind: "fact", evidence: [2] }],
+    });
+    expect(dropped[0].reason).toBe("already_saved_in_thread");
+  });
+
+  it("drops duplicate_kb on normalized exact match against a visible entry", () => {
+    const kb: KnowledgeEntry[] = [{ id: "k1", entry: "the auth module lives in app/services/auth, not app/http/auth", timestamp: "2026-07-01" }];
+    expect(gate({ visibleKb: kb }).dropped[0].reason).toBe("duplicate_kb");
+  });
+
+  it("drops duplicate_kb on normalized containment (either direction)", () => {
+    const kb: KnowledgeEntry[] = [{ id: "k1", entry: "Note: the auth module lives in app/Services/Auth, not app/Http/Auth (moved Q2).", timestamp: "2026-07-01" }];
+    expect(gate({ visibleKb: kb }).dropped[0].reason).toBe("duplicate_kb");
+  });
+
+  it("does NOT treat a superseded/archived entry as a duplicate (caller passes visible set only)", () => {
+    // Contract note: gateKbCandidates receives the VISIBLE set; retired entries never block re-learning.
+    expect(gate({ visibleKb: [] }).eligible).toHaveLength(1);
+  });
+
+  it("drops already_proposed when the hash was proposed in a prior quiet period", () => {
+    const { dropped } = gate({ alreadyProposedHashes: [kbCandidateHash(BASE.entry)] });
+    expect(dropped[0].reason).toBe("already_proposed");
+  });
+
+  it("dedups within a single batch: second candidate with the same normalized text drops as already_proposed", () => {
+    const twin = { ...BASE, entry: BASE.entry.toUpperCase() + "!" };
+    const { eligible, dropped } = gate({ candidates: [BASE, twin] });
+    expect(eligible).toHaveLength(1);
+    expect(dropped).toEqual([{ candidate: twin, reason: "already_proposed" }]);
+  });
+
+  it("applies reasons in pinned precedence: empty_entry wins over no_evidence", () => {
+    const { dropped } = gate({ candidates: [{ ...BASE, entry: " ", evidence: [] }] });
+    expect(dropped[0].reason).toBe("empty_entry");
+  });
+
+  it("low_confidence wins over evidence_out_of_range", () => {
+    const { dropped } = gate({ candidates: [{ ...BASE, confidence: 0.1, evidence: [99] }] });
+    expect(dropped[0].reason).toBe("low_confidence");
+  });
+});
+
+describe("gateKbCandidates — #124 composition annotation", () => {
+  it("annotates correction-kind candidates with keyword-matched stale KB entries (flaggedKbEntries)", () => {
+    const kb: KnowledgeEntry[] = [
+      { id: "k1", entry: "Auth uses JWT in app/Http/Auth", timestamp: "2026-06-01" },
+      { id: "k2", entry: "Deploys run on Fridays", timestamp: "2026-06-01" },
+    ];
+    const { eligible } = gate({ visibleKb: kb });
+    expect(eligible[0].flaggedKbEntries).toEqual(["Auth uses JWT in app/Http/Auth"]);
+  });
+
+  it("never annotates fact-kind candidates", () => {
+    const kb: KnowledgeEntry[] = [{ id: "k1", entry: "Auth uses JWT in app/Http/Auth", timestamp: "2026-06-01" }];
+    const { eligible } = gate({
+      candidates: [{ entry: "CI auth tokens rotate monthly", kind: "fact", evidence: [2], confidence: 0.9 }],
+      visibleKb: kb,
+    });
+    expect(eligible[0].flaggedKbEntries).toEqual([]);
+  });
+});
+
+describe("matchContradictedEntries", () => {
+  it("matches on meaningful keyword overlap, skipping common words", () => {
+    const kb: KnowledgeEntry[] = [{ id: "k1", entry: "The rate limit is 60 req/min", timestamp: "2026-06-01" }];
+    expect(matchContradictedEntries("The rate limit is 120 req/min, not 60", kb)).toHaveLength(1);
+  });
+  it("returns [] when nothing overlaps", () => {
+    expect(matchContradictedEntries("Deploys run from main", [{ id: "k1", entry: "The rate limit is 60", timestamp: "2026-06-01" }])).toEqual([]);
+  });
+  it("returns [] for empty KB", () => {
+    expect(matchContradictedEntries("anything", [])).toEqual([]);
+  });
+});
+
+describe("isExtractableChannel", () => {
+  it("allows a public channel", () => {
+    expect(isExtractableChannel({ is_private: false, is_im: false, is_mpim: false })).toBe(true);
+  });
+  it.each([
+    ["private", { is_private: true, is_im: false, is_mpim: false }],
+    ["DM", { is_private: false, is_im: true, is_mpim: false }],
+    ["MPIM", { is_private: false, is_im: false, is_mpim: true }],
+  ])("rejects a %s conversation", (_label, info) => {
+    expect(isExtractableChannel(info)).toBe(false);
+  });
+});

--- a/src/lib/kb-gate.ts
+++ b/src/lib/kb-gate.ts
@@ -1,0 +1,256 @@
+/**
+ * Deterministic provenance gate for passive KB candidates (#136).
+ *
+ * The extractor (kb-extract.ts) is a fast model and therefore
+ * untrusted: it can hallucinate entries, cite indices that don't exist,
+ * or "learn" something the bot itself said. This module is the
+ * NON-LLM gate between the extractor and the proposal message — every
+ * rule here is a pure, exhaustively unit-tested predicate.
+ *
+ * Keep this file side-effect-free: no KV, no Slack, no clock. All
+ * imports from stateful modules are type-only.
+ */
+
+import { createHash } from "crypto";
+import type { KbCandidate, TranscriptEntry } from "./kb-extract";
+import type { KnowledgeEntry } from "./knowledge";
+
+/** Minimum extractor confidence to survive the gate. `>=` passes. */
+export const KB_CANDIDATE_MIN_CONFIDENCE = 0.75;
+
+/** Maximum entry length (inclusive) — KB entries are single durable
+ *  statements, not essays. */
+export const MAX_KB_ENTRY_CHARS = 500;
+
+/**
+ * Prefix of the bot's "correction saved" confirmation reply (posted by
+ * turn-runner.ts). The gate scans bot transcript lines for this prefix
+ * to avoid re-proposing something the thread already saved explicitly.
+ * turn-runner imports this constant so the two stay in lock-step.
+ */
+export const KB_SAVED_CONFIRMATION_PREFIX =
+  ":white_check_mark: Saved to knowledge base:";
+
+// ── Normalization + hashing ───────────────────────────────────────────
+
+/**
+ * Canonical text form for dedup: lowercase, punctuation → space,
+ * whitespace collapsed, trimmed. Pure function.
+ */
+export function normalizeKbText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Content hash of the NORMALIZED entry text — the stable identity a
+ *  candidate keeps across re-extractions and cosmetic rewording. */
+export function kbCandidateHash(text: string): string {
+  return createHash("sha256").update(normalizeKbText(text)).digest("hex");
+}
+
+// ── Contradiction matching (#124 composition) ─────────────────────────
+
+// Words too common to signal topical overlap. Mirrors the list in
+// auto-correct.ts's identifyStaleKBEntries.
+const COMMON_WORDS = new Set([
+  "the", "is", "in", "not", "and", "or", "a", "an", "to", "of", "for",
+  "it", "was", "that", "with",
+]);
+
+function meaningfulWords(text: string): string[] {
+  return normalizeKbText(text)
+    .split(" ")
+    .filter((w) => w.length > 2 && !COMMON_WORDS.has(w));
+}
+
+/**
+ * Visible KB entries a correction-shaped candidate likely contradicts,
+ * matched on meaningful keyword overlap (identifyStaleKBEntries style).
+ * This is an ANNOTATION for the save flow (mark superseded on confirm),
+ * never a drop reason. Pure function.
+ */
+export function matchContradictedEntries(
+  candidateEntry: string,
+  visibleKb: KnowledgeEntry[],
+): KnowledgeEntry[] {
+  if (visibleKb.length === 0) return [];
+  const keywords = new Set(meaningfulWords(candidateEntry));
+  if (keywords.size === 0) return [];
+  return visibleKb.filter((e) =>
+    meaningfulWords(e.entry).some((w) => keywords.has(w)),
+  );
+}
+
+// ── Channel eligibility ───────────────────────────────────────────────
+
+/**
+ * Only PUBLIC channels are extractable — passive learning must never
+ * lift content out of private channels, DMs, or group DMs into a KB
+ * that surfaces everywhere. FAIL CLOSED: publicness must be positively
+ * confirmed (all three flags present and false); missing flags reject.
+ * Pure function — the orchestrator fetches conversations.info.
+ */
+export function isExtractableChannel(info: {
+  is_private?: boolean;
+  is_im?: boolean;
+  is_mpim?: boolean;
+}): boolean {
+  return info.is_private === false && info.is_im === false && info.is_mpim === false;
+}
+
+// ── The gate ──────────────────────────────────────────────────────────
+
+export type KbDropReason =
+  | "empty_entry"
+  | "entry_too_long"
+  | "low_confidence"
+  | "no_evidence"
+  | "evidence_out_of_range"
+  | "no_human_evidence"
+  | "already_saved_in_thread"
+  | "duplicate_kb"
+  | "already_proposed";
+
+export interface EligibleKbCandidate extends KbCandidate {
+  /** kbCandidateHash of the entry — dedup identity across quiet periods. */
+  hash: string;
+  /** Verbatim transcript texts of the cited evidence indices. */
+  evidenceQuotes: string[];
+  /** For correction-kind candidates: visible KB entry TEXTS this
+   *  candidate likely contradicts (retired on confirm, #124). Always []
+   *  for fact/decision kinds. */
+  flaggedKbEntries: string[];
+}
+
+export interface GateKbCandidatesParams {
+  candidates: KbCandidate[];
+  transcript: TranscriptEntry[];
+  /** VISIBLE KB entries only — retired (superseded/archived) entries
+   *  must never block re-learning, so the caller filters first. */
+  visibleKb: KnowledgeEntry[];
+  /** Hashes already proposed for this thread in prior quiet periods. */
+  alreadyProposedHashes: string[];
+}
+
+export interface GateKbCandidatesResult {
+  eligible: EligibleKbCandidate[];
+  dropped: { candidate: KbCandidate; reason: KbDropReason }[];
+}
+
+/**
+ * Extract the saved-entry snippets from bot "saved to knowledge base"
+ * confirmations in the transcript, normalized. The confirmation itself
+ * truncates the entry to 100 chars, so callers must match by
+ * containment, not equality.
+ */
+function savedConfirmationSnippets(transcript: TranscriptEntry[]): string[] {
+  const snippets: string[] = [];
+  for (const entry of transcript) {
+    if (entry.author !== "bot") continue;
+    const at = entry.text.indexOf(KB_SAVED_CONFIRMATION_PREFIX);
+    if (at === -1) continue;
+    const normalized = normalizeKbText(
+      entry.text.slice(at + KB_SAVED_CONFIRMATION_PREFIX.length),
+    );
+    if (normalized.length > 0) snippets.push(normalized);
+  }
+  return snippets;
+}
+
+/** Containment in either direction — covers KB entries that embed the
+ *  candidate in extra framing AND truncated confirmation snippets. */
+function eitherContains(a: string, b: string): boolean {
+  return a.includes(b) || b.includes(a);
+}
+
+/**
+ * Apply the deterministic provenance rules to a batch of extractor
+ * candidates. Drop-reason precedence is PINNED (tests assert it):
+ *
+ *   empty_entry → entry_too_long → low_confidence → no_evidence →
+ *   evidence_out_of_range → no_human_evidence → already_saved_in_thread
+ *   → duplicate_kb → already_proposed
+ *
+ * Pure function — no clock, no I/O.
+ */
+export function gateKbCandidates(
+  params: GateKbCandidatesParams,
+): GateKbCandidatesResult {
+  const { candidates, transcript, visibleKb, alreadyProposedHashes } = params;
+  const eligible: EligibleKbCandidate[] = [];
+  const dropped: { candidate: KbCandidate; reason: KbDropReason }[] = [];
+
+  const savedSnippets = savedConfirmationSnippets(transcript);
+  const visibleNormalized = visibleKb
+    .map((e) => normalizeKbText(e.entry))
+    .filter((t) => t.length > 0);
+  const seenHashes = new Set(alreadyProposedHashes);
+
+  const drop = (candidate: KbCandidate, reason: KbDropReason) =>
+    dropped.push({ candidate, reason });
+
+  for (const candidate of candidates) {
+    if (candidate.entry.trim().length === 0) {
+      drop(candidate, "empty_entry");
+      continue;
+    }
+    if (candidate.entry.length > MAX_KB_ENTRY_CHARS) {
+      drop(candidate, "entry_too_long");
+      continue;
+    }
+    if (candidate.confidence < KB_CANDIDATE_MIN_CONFIDENCE) {
+      drop(candidate, "low_confidence");
+      continue;
+    }
+    if (candidate.evidence.length === 0) {
+      drop(candidate, "no_evidence");
+      continue;
+    }
+    // Fail closed: ONE bad index kills the candidate — a model that
+    // fabricates any citation can't be trusted on the others.
+    const outOfRange = candidate.evidence.some(
+      (i) => !Number.isInteger(i) || i < 0 || i >= transcript.length,
+    );
+    if (outOfRange) {
+      drop(candidate, "evidence_out_of_range");
+      continue;
+    }
+    const cited = candidate.evidence.map((i) => transcript[i]);
+    if (!cited.some((e) => e.author === "human")) {
+      drop(candidate, "no_human_evidence");
+      continue;
+    }
+
+    const normalized = normalizeKbText(candidate.entry);
+    if (savedSnippets.some((s) => eitherContains(s, normalized))) {
+      drop(candidate, "already_saved_in_thread");
+      continue;
+    }
+    if (visibleNormalized.some((v) => eitherContains(v, normalized))) {
+      drop(candidate, "duplicate_kb");
+      continue;
+    }
+
+    const hash = kbCandidateHash(candidate.entry);
+    if (seenHashes.has(hash)) {
+      drop(candidate, "already_proposed");
+      continue;
+    }
+    seenHashes.add(hash);
+
+    eligible.push({
+      ...candidate,
+      hash,
+      evidenceQuotes: cited.map((e) => e.text),
+      flaggedKbEntries:
+        candidate.kind === "correction"
+          ? matchContradictedEntries(candidate.entry, visibleKb).map((e) => e.entry)
+          : [],
+    });
+  }
+
+  return { eligible, dropped };
+}

--- a/src/lib/kb-proposals.test.ts
+++ b/src/lib/kb-proposals.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   decideKbExtraction,
+  escapeSlackMentions,
   formatKbProposalMessage,
   summarizeKbSaveResult,
   kbStateKey,
@@ -111,6 +112,59 @@ describe("formatKbProposalMessage", () => {
     const msg = formatKbProposalMessage([C]);
     expect(msg).not.toContain(SINGLE_PROPOSAL_ANCHOR);
     expect(msg).not.toContain(BATCH_PROPOSAL_HEADER);
+  });
+});
+
+describe("escapeSlackMentions", () => {
+  it("escapes & FIRST, then < and > (pre-existing entities double-escape predictably)", () => {
+    expect(escapeSlackMentions("a & b")).toBe("a &amp; b");
+    expect(escapeSlackMentions("&lt;")).toBe("&amp;lt;");
+    expect(escapeSlackMentions("a < b > c & d")).toBe("a &lt; b &gt; c &amp; d");
+  });
+  it("neutralizes every Slack control sequence", () => {
+    expect(escapeSlackMentions("<!channel> <!here> <@U123> <#C42|general>")).toBe(
+      "&lt;!channel&gt; &lt;!here&gt; &lt;@U123&gt; &lt;#C42|general&gt;",
+    );
+  });
+  it("leaves plain text untouched", () => {
+    expect(escapeSlackMentions("The auth module lives in app/Services/Auth")).toBe(
+      "The auth module lives in app/Services/Auth",
+    );
+  });
+});
+
+describe("formatKbProposalMessage — mention-token escaping", () => {
+  const HOSTILE: EligibleKbCandidate = {
+    entry: "Ping <!channel> when deploys fail",
+    kind: "correction",
+    evidence: [1],
+    confidence: 0.9,
+    hash: "h1",
+    flaggedKbEntries: ["Notify <!here> on rollback"],
+    evidenceQuotes: ["ask <@U123> about the deploy pings"],
+  };
+
+  it("renders entry, quotes, and flagged entries with escaped tokens — no raw control sequences", () => {
+    const msg = formatKbProposalMessage([HOSTILE]);
+    expect(msg).not.toContain("<!channel>");
+    expect(msg).not.toContain("<@U123>");
+    expect(msg).not.toContain("<!here>");
+    expect(msg).toContain("&lt;!channel&gt;");
+    expect(msg).toContain("&lt;@U123&gt;");
+    expect(msg).toContain("&lt;!here&gt;");
+  });
+});
+
+describe("summarizeKbSaveResult — mention-token escaping", () => {
+  it("escapes model-produced entry text in both saved and failed lines", () => {
+    const msg = summarizeKbSaveResult([
+      { status: "saved", entry: "Ping <!channel> on deploys", id: "id-1", supersededCount: 0 },
+      { status: "error", entry: "Ask <@U123> first", errorMessage: "kv down" },
+    ]);
+    expect(msg).not.toContain("<!channel>");
+    expect(msg).not.toContain("<@U123>");
+    expect(msg).toContain("&lt;!channel&gt;");
+    expect(msg).toContain("&lt;@U123&gt;");
   });
 });
 

--- a/src/lib/kb-proposals.test.ts
+++ b/src/lib/kb-proposals.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  decideKbExtraction,
+  formatKbProposalMessage,
+  summarizeKbSaveResult,
+  kbStateKey,
+  kbClaimKey,
+  kbBatchKey,
+  kbBatchThreadPointerKey,
+  kbBatchTombstoneKey,
+  KB_EXTRACT_INDEX_KEY,
+  KB_EXTRACT_IDLE_MS,
+  MAX_KB_EXTRACTION_ATTEMPTS,
+  type KbThreadState,
+} from "./kb-proposals";
+import { SINGLE_PROPOSAL_ANCHOR, BATCH_PROPOSAL_HEADER } from "./issue-batch";
+import type { EligibleKbCandidate } from "./kb-gate";
+
+// Pinned clock values — no Date.now() anywhere in these tests.
+const NOW = 1_752_000_000_000;
+const IDLE = KB_EXTRACT_IDLE_MS;
+const covered = (over: Partial<KbThreadState> = {}): KbThreadState => ({
+  status: "covered", extractedAt: NOW - 2 * IDLE, attempt: 0, proposedHashes: [], ...over,
+});
+
+describe("key builders", () => {
+  it("build namespaced keys", () => {
+    expect(KB_EXTRACT_INDEX_KEY).toBe("kb-extract:index");
+    expect(kbStateKey("C1", "17.1")).toBe("kb-extract:state:C1:17.1");
+    expect(kbClaimKey("C1", "17.1")).toBe("kb-extract:claim:C1:17.1");
+    expect(kbBatchKey("C1", "17.2")).toBe("pending-kb-batch:C1:17.2");
+    expect(kbBatchThreadPointerKey("C1", "17.1")).toBe("pending-kb-batch:thread:C1:17.1");
+    expect(kbBatchTombstoneKey("C1", "17.2")).toBe("pending-kb-batch:done:C1:17.2");
+  });
+});
+
+describe("decideKbExtraction — idle gate", () => {
+  it("waits while activity is recent (age < idle)", () => {
+    expect(decideKbExtraction(null, NOW - IDLE + 1, NOW)).toBe("wait");
+  });
+  it("waits at exactly the idle boundary (age === idle → wait; strict > required to extract)", () => {
+    expect(decideKbExtraction(null, NOW - IDLE, NOW)).toBe("wait");
+  });
+  it("extracts one ms past the boundary", () => {
+    expect(decideKbExtraction(null, NOW - IDLE - 1, NOW)).toBe("extract");
+  });
+  it("waits on a FUTURE activity score (clock skew must never trigger extraction)", () => {
+    expect(decideKbExtraction(null, NOW + 60_000, NOW)).toBe("wait");
+  });
+});
+
+describe("decideKbExtraction — state transitions", () => {
+  const IDLE_ACTIVITY = NOW - 2 * IDLE; // comfortably past idle
+
+  it("extracts a never-extracted idle thread (null state)", () => {
+    expect(decideKbExtraction(null, IDLE_ACTIVITY, NOW)).toBe("extract");
+  });
+  it("prunes a covered thread with no activity since extraction (extractedAt >= lastActivityAt)", () => {
+    expect(decideKbExtraction(covered({ extractedAt: IDLE_ACTIVITY }), IDLE_ACTIVITY, NOW)).toBe("prune");
+    expect(decideKbExtraction(covered({ extractedAt: IDLE_ACTIVITY + 5 }), IDLE_ACTIVITY, NOW)).toBe("prune");
+  });
+  it("re-extracts a covered thread after NEW activity + a fresh quiet period (at most once PER quiet period)", () => {
+    expect(decideKbExtraction(covered({ extractedAt: NOW - 3 * IDLE }), IDLE_ACTIVITY, NOW)).toBe("extract");
+  });
+  it("retries a failed thread below the attempt cap", () => {
+    expect(
+      decideKbExtraction(covered({ status: "failed", attempt: MAX_KB_EXTRACTION_ATTEMPTS - 1 }), IDLE_ACTIVITY, NOW),
+    ).toBe("extract");
+  });
+  it("gives up at exactly the attempt cap (>= semantics)", () => {
+    expect(
+      decideKbExtraction(covered({ status: "failed", attempt: MAX_KB_EXTRACTION_ATTEMPTS }), IDLE_ACTIVITY, NOW),
+    ).toBe("give_up");
+  });
+  it("prunes a gave_up thread with no new activity", () => {
+    expect(decideKbExtraction(covered({ status: "gave_up", extractedAt: IDLE_ACTIVITY }), IDLE_ACTIVITY, NOW)).toBe("prune");
+  });
+  it("re-arms a gave_up thread when new activity arrives", () => {
+    expect(decideKbExtraction(covered({ status: "gave_up", extractedAt: NOW - 3 * IDLE }), IDLE_ACTIVITY, NOW)).toBe("extract");
+  });
+});
+
+describe("formatKbProposalMessage", () => {
+  const C: EligibleKbCandidate = {
+    entry: "The auth module lives in app/Services/Auth",
+    kind: "correction",
+    evidence: [2],
+    confidence: 0.9,
+    hash: "abc123",
+    flaggedKbEntries: ["Auth uses JWT in app/Http/Auth"],
+    evidenceQuotes: ["wrong — auth moved to app/Services/Auth last quarter"],
+  };
+
+  it("returns empty string for zero candidates (empty fan-out posts nothing)", () => {
+    expect(formatKbProposalMessage([])).toBe("");
+  });
+  it("renders a numbered list with entry text, kind, and evidence quote", () => {
+    const msg = formatKbProposalMessage([C, { ...C, entry: "Deploys run from main", kind: "fact", flaggedKbEntries: [] }]);
+    expect(msg).toContain("1. ");
+    expect(msg).toContain("2. ");
+    expect(msg).toContain("The auth module lives in app/Services/Auth");
+    expect(msg).toContain("wrong — auth moved to app/Services/Auth last quarter");
+    expect(msg).toContain("correction");
+  });
+  it("includes the confirm instruction (✅ or confirm all)", () => {
+    const msg = formatKbProposalMessage([C]);
+    expect(msg).toContain(":white_check_mark:");
+    expect(msg).toContain("confirm all");
+  });
+  it("NEVER contains the issue-proposal anchors — the legacy ✅ parser must not match a KB proposal", () => {
+    const msg = formatKbProposalMessage([C]);
+    expect(msg).not.toContain(SINGLE_PROPOSAL_ANCHOR);
+    expect(msg).not.toContain(BATCH_PROPOSAL_HEADER);
+  });
+});
+
+describe("summarizeKbSaveResult", () => {
+  it("returns empty string for no outcomes", () => {
+    expect(summarizeKbSaveResult([])).toBe("");
+  });
+  it("lists saved entries with the superseded count and failures with their errors", () => {
+    const msg = summarizeKbSaveResult([
+      { status: "saved", entry: "The auth module lives in app/Services/Auth", id: "id-1", supersededCount: 1 },
+      { status: "error", entry: "Deploys run from main", errorMessage: "kv down" },
+    ]);
+    expect(msg).toContain("Saved 1");
+    expect(msg).toContain("app/Services/Auth");
+    expect(msg).toContain("retired 1");
+    expect(msg).toContain("kv down");
+  });
+});

--- a/src/lib/kb-proposals.ts
+++ b/src/lib/kb-proposals.ts
@@ -35,6 +35,13 @@ export const KB_EXTRACT_IDLE_MS = 14_400_000;
  *  10s cap, and the sweep shares its budget with recovery work. */
 export const MAX_KB_EXTRACT_PER_SWEEP = 3;
 
+/** Discovery-scan window per sweep (PR #139): the sweep reads only the
+ *  first N zset members ASCENDING by score. Score = last activity, so
+ *  the window holds the oldest/most-idle threads — exactly the
+ *  extract/prune candidates. Recent members past the window are simply
+ *  untouched until they age into it; a full (0, -1) scan is O(n). */
+export const KB_EXTRACT_SCAN_LIMIT = 50;
+
 /** Failed extraction attempts before the thread is given up on
  *  (until new activity re-arms it). `>=` gives up. */
 export const MAX_KB_EXTRACTION_ATTEMPTS = 2;
@@ -137,6 +144,28 @@ export interface PendingKbBatch {
   messageFirstTs: string;
 }
 
+// ── Slack mention-token escaping (PR #139 security finding) ─────────
+
+/**
+ * Neutralize Slack control sequences in model-produced / user-quoted
+ * text before it is posted. Candidate entries, evidence quotes, and
+ * flagged KB texts come from an untrusted extractor reading arbitrary
+ * thread content — a literal `<!channel>`, `<!here>`, `<@U…>`, or
+ * `<#C…>` in any of them would trigger real pings when posted.
+ *
+ * Per Slack's escaping rules only three characters need encoding, and
+ * `&` MUST go first so pre-existing entities double-escape predictably:
+ * `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`. This neutralizes ALL
+ * `<…>` control sequences (mentions, broadcasts, channel links, URLs).
+ * Pure function.
+ */
+export function escapeSlackMentions(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 // ── Proposal message formatter ────────────────────────────────────────
 
 const DIVIDER = "───────────────────";
@@ -162,13 +191,15 @@ export function formatKbProposalMessage(
     "",
   ];
   candidates.forEach((c, i) => {
-    lines.push(`${i + 1}. _"${c.entry}"_ (${c.kind})`);
+    // Everything model-produced or thread-quoted is escaped — see
+    // escapeSlackMentions above (PR #139 security finding).
+    lines.push(`${i + 1}. _"${escapeSlackMentions(c.entry)}"_ (${c.kind})`);
     for (const quote of c.evidenceQuotes) {
-      lines.push(`    > ${quote}`);
+      lines.push(`    > ${escapeSlackMentions(quote)}`);
     }
     if (c.flaggedKbEntries.length > 0) {
       lines.push(
-        `    ↳ retires: ${c.flaggedKbEntries.map((e) => `_"${e}"_`).join(", ")}`,
+        `    ↳ retires: ${c.flaggedKbEntries.map((e) => `_"${escapeSlackMentions(e)}"_`).join(", ")}`,
       );
     }
   });
@@ -202,7 +233,7 @@ export function summarizeKbSaveResult(outcomes: KbSaveOutcome[]): string {
         s.supersededCount > 0
           ? ` — retired ${s.supersededCount} stale ${s.supersededCount === 1 ? "entry" : "entries"}`
           : "";
-      lines.push(`  • _"${s.entry}"_${retired}`);
+      lines.push(`  • _"${escapeSlackMentions(s.entry)}"_${retired}`);
     }
   }
   if (failed.length > 0) {
@@ -210,7 +241,7 @@ export function summarizeKbSaveResult(outcomes: KbSaveOutcome[]): string {
     const noun = failed.length === 1 ? "entry" : "entries";
     lines.push(`:warning: ${failed.length} ${noun} failed to save:`);
     for (const f of failed) {
-      lines.push(`  • _"${f.entry}"_ — ${f.errorMessage}`);
+      lines.push(`  • _"${escapeSlackMentions(f.entry)}"_ — ${f.errorMessage}`);
     }
   }
   return lines.join("\n");

--- a/src/lib/kb-proposals.ts
+++ b/src/lib/kb-proposals.ts
@@ -1,0 +1,217 @@
+/**
+ * Passive KB learning — pure proposal-lifecycle helpers (#136).
+ *
+ * Key builders, the per-thread extraction decision, and the two Slack
+ * message formatters. Keep this file side-effect-free — kb-runner.ts
+ * owns all KV/Slack I/O; this module only produces strings and
+ * classifies state, mirroring the issue-batch.ts / recovery.ts split.
+ *
+ * Storage model (all keys namespaced away from processing:* and
+ * pending-issue-batch:*):
+ *
+ * - `kb-extract:index` — discovery zset, member `<channel>:<threadTs>`
+ *   (recovery.ts indexMember format), score = last bot-answer time.
+ *   Bumped best-effort by recordKbThreadActivity after every
+ *   answer_posted; NEVER bumped by the KB proposal post itself.
+ * - `kb-extract:state:{ch}:{ts}` — per-thread extraction state, 30d TTL.
+ * - `kb-extract:claim:{ch}:{ts}` — non-destructive SET NX sweep claim
+ *   (clone of recovery.ts acquireSweepClaim), 120s TTL.
+ * - `pending-kb-batch:{ch}:{firstTs}` — proposed batch awaiting human
+ *   confirmation, 24h TTL. `:thread:` pointer enables "confirm all"
+ *   text; `:done:` tombstone (1h) absorbs double-tap ✅.
+ */
+
+import type { EligibleKbCandidate } from "./kb-gate";
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+/** Discovery zset: member `<channel>:<threadTs>`, score last-activity ms. */
+export const KB_EXTRACT_INDEX_KEY = "kb-extract:index";
+
+/** A thread is "concluded" after this much quiet time: 4 hours. */
+export const KB_EXTRACT_IDLE_MS = 14_400_000;
+
+/** Extraction budget per sweep — each extraction is a model call with a
+ *  10s cap, and the sweep shares its budget with recovery work. */
+export const MAX_KB_EXTRACT_PER_SWEEP = 3;
+
+/** Failed extraction attempts before the thread is given up on
+ *  (until new activity re-arms it). `>=` gives up. */
+export const MAX_KB_EXTRACTION_ATTEMPTS = 2;
+
+/** TTL on the per-thread extraction state record: 30 days. */
+export const KB_STATE_TTL_SEC = 2_592_000;
+
+/** TTL on the sweep's per-thread NX claim — mirrors recovery.ts's
+ *  SWEEP_CLAIM_TTL_SEC rationale: covers one extraction (10s model cap
+ *  + gate + Slack post) with slack, and an abandoned claim delays the
+ *  thread by at most one sweep cadence. */
+export const KB_EXTRACT_CLAIM_TTL_SEC = 120;
+
+/** TTL on a pending KB proposal batch: 24h, matching issue batches. */
+export const KB_BATCH_TTL_SEC = 86_400;
+
+/** Tombstone TTL after a batch is claimed — absorbs double-tap ✅
+ *  (same rationale as issue-batch tombstones, PR #123). */
+export const KB_BATCH_TOMBSTONE_TTL_SEC = 3_600;
+
+// ── Key builders (pure) ───────────────────────────────────────────────
+
+export function kbStateKey(channel: string, threadTs: string): string {
+  return `kb-extract:state:${channel}:${threadTs}`;
+}
+export function kbClaimKey(channel: string, threadTs: string): string {
+  return `kb-extract:claim:${channel}:${threadTs}`;
+}
+export function kbBatchKey(channel: string, firstTs: string): string {
+  return `pending-kb-batch:${channel}:${firstTs}`;
+}
+export function kbBatchThreadPointerKey(channel: string, threadTs: string): string {
+  return `pending-kb-batch:thread:${channel}:${threadTs}`;
+}
+export function kbBatchTombstoneKey(channel: string, firstTs: string): string {
+  return `pending-kb-batch:done:${channel}:${firstTs}`;
+}
+
+// ── Per-thread state + extraction decision ───────────────────────────
+
+export interface KbThreadState {
+  /** covered — extraction ran and this quiet period is handled;
+   *  failed — the extractor returned null, retry next sweep (< cap);
+   *  gave_up — attempt cap reached; re-arms only on new activity. */
+  status: "covered" | "failed" | "gave_up";
+  /** When the last extraction attempt ran (ms epoch). */
+  extractedAt: number;
+  /** Consecutive failed attempts for the CURRENT quiet period. */
+  attempt: number;
+  /** kbCandidateHash of every candidate ever proposed for this thread —
+   *  the already_proposed gate input across quiet periods. */
+  proposedHashes: string[];
+}
+
+export type KbExtractionAction = "wait" | "extract" | "prune" | "give_up";
+
+/**
+ * Classify one indexed thread for the sweep. Pure function.
+ *
+ * Rule order (pinned by tests):
+ * - age <= idleMs — INCLUDING a future lastActivityAt (clock skew must
+ *   never trigger extraction)                                → "wait"
+ * - no state (never extracted, now idle)                     → "extract"
+ * - failed, attempt >= maxAttempts                           → "give_up"
+ * - failed, attempt < maxAttempts                            → "extract"
+ * - covered/gave_up with no activity since the last attempt
+ *   (extractedAt >= lastActivityAt)                          → "prune"
+ * - covered/gave_up with NEW activity + a fresh quiet period → "extract"
+ *   (at most once per quiet period; the runner carries proposedHashes
+ *   forward and resets attempt on a gave_up re-arm)
+ */
+export function decideKbExtraction(
+  state: KbThreadState | null,
+  lastActivityAt: number,
+  now: number,
+  idleMs: number = KB_EXTRACT_IDLE_MS,
+  maxAttempts: number = MAX_KB_EXTRACTION_ATTEMPTS,
+): KbExtractionAction {
+  const age = now - lastActivityAt;
+  if (age <= idleMs) return "wait";
+  if (!state) return "extract";
+  if (state.status === "failed") {
+    return state.attempt >= maxAttempts ? "give_up" : "extract";
+  }
+  // covered | gave_up: prune once the quiet period is consumed;
+  // re-extract (re-arm) when the thread saw activity after the attempt.
+  return state.extractedAt >= lastActivityAt ? "prune" : "extract";
+}
+
+// ── Pending-batch record ──────────────────────────────────────────────
+
+/** Stored under pending-kb-batch:{channel}:{firstTs}. Mirrors
+ *  PendingIssueBatch (turn-runner.ts). */
+export interface PendingKbBatch {
+  candidates: EligibleKbCandidate[];
+  proposedAt: number;
+  channel: string;
+  threadTs: string;
+  /** ts of the proposal message (the ✅ target and batch key). */
+  messageFirstTs: string;
+}
+
+// ── Proposal message formatter ────────────────────────────────────────
+
+const DIVIDER = "───────────────────";
+const KB_CONFIRM_LINE =
+  "React with :white_check_mark: or say *confirm all* to save these to the knowledge base. Ignore to discard.";
+
+/**
+ * Render a KB proposal batch for Slack. Returns "" for zero candidates
+ * (empty fan-out posts nothing).
+ *
+ * MUST NOT contain issue-batch.ts's SINGLE_PROPOSAL_ANCHOR or
+ * BATCH_PROPOSAL_HEADER — the legacy ✅ text parser keys on those, and
+ * a KB proposal must never be mistaken for an issue proposal (tested).
+ */
+export function formatKbProposalMessage(
+  candidates: EligibleKbCandidate[],
+): string {
+  if (candidates.length === 0) return "";
+
+  const lines: string[] = [
+    DIVIDER,
+    `:books: *Proposed knowledge-base entries* — learned from this thread. ${KB_CONFIRM_LINE}`,
+    "",
+  ];
+  candidates.forEach((c, i) => {
+    lines.push(`${i + 1}. _"${c.entry}"_ (${c.kind})`);
+    for (const quote of c.evidenceQuotes) {
+      lines.push(`    > ${quote}`);
+    }
+    if (c.flaggedKbEntries.length > 0) {
+      lines.push(
+        `    ↳ retires: ${c.flaggedKbEntries.map((e) => `_"${e}"_`).join(", ")}`,
+      );
+    }
+  });
+  return lines.join("\n");
+}
+
+// ── Save-result summary formatter ────────────────────────────────────
+
+export type KbSaveOutcome =
+  | { status: "saved"; entry: string; id: string; supersededCount: number }
+  | { status: "error"; entry: string; errorMessage: string };
+
+/** Summarize per-entry save outcomes for the confirmation reply.
+ *  Returns "" for no outcomes. */
+export function summarizeKbSaveResult(outcomes: KbSaveOutcome[]): string {
+  if (outcomes.length === 0) return "";
+
+  const saved = outcomes.filter(
+    (o): o is Extract<KbSaveOutcome, { status: "saved" }> => o.status === "saved",
+  );
+  const failed = outcomes.filter(
+    (o): o is Extract<KbSaveOutcome, { status: "error" }> => o.status === "error",
+  );
+
+  const lines: string[] = [];
+  if (saved.length > 0) {
+    const noun = saved.length === 1 ? "entry" : "entries";
+    lines.push(`:white_check_mark: Saved ${saved.length} ${noun} to the knowledge base:`);
+    for (const s of saved) {
+      const retired =
+        s.supersededCount > 0
+          ? ` — retired ${s.supersededCount} stale ${s.supersededCount === 1 ? "entry" : "entries"}`
+          : "";
+      lines.push(`  • _"${s.entry}"_${retired}`);
+    }
+  }
+  if (failed.length > 0) {
+    if (lines.length > 0) lines.push("");
+    const noun = failed.length === 1 ? "entry" : "entries";
+    lines.push(`:warning: ${failed.length} ${noun} failed to save:`);
+    for (const f of failed) {
+      lines.push(`  • _"${f.entry}"_ — ${f.errorMessage}`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/src/lib/kb-runner.test.ts
+++ b/src/lib/kb-runner.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// PR #139 review findings — orchestration-level pins:
+// - the sweep scans a BOUNDED window of the discovery zset;
+// - a supersession failure never misreports a durably-saved entry.
+
+const mocks = vi.hoisted(() => ({
+  kv: {
+    get: vi.fn(),
+    set: vi.fn(),
+    del: vi.fn(),
+    zadd: vi.fn(),
+    zrange: vi.fn(),
+    zrem: vi.fn(),
+    zscore: vi.fn(),
+  },
+  replyInThread: vi.fn(),
+  fetchThreadMessages: vi.fn(),
+  fetchThreadTail: vi.fn(),
+  getBotUserId: vi.fn(),
+  conversationsInfo: vi.fn(),
+  saveKnowledgeEntry: vi.fn(),
+  markKnowledgeSuperseded: vi.fn(),
+  getAllKnowledge: vi.fn(),
+}));
+
+vi.mock("./kv", () => ({ kv: mocks.kv }));
+vi.mock("./slack", () => ({
+  slack: { conversations: { info: mocks.conversationsInfo } },
+  replyInThread: mocks.replyInThread,
+  fetchThreadMessages: mocks.fetchThreadMessages,
+  fetchThreadTail: mocks.fetchThreadTail,
+  getBotUserId: mocks.getBotUserId,
+}));
+vi.mock("./knowledge", () => ({
+  saveKnowledgeEntry: mocks.saveKnowledgeEntry,
+  markKnowledgeSuperseded: mocks.markKnowledgeSuperseded,
+  getAllKnowledge: mocks.getAllKnowledge,
+}));
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+
+import { runKbExtractionSweep, executeKbBatchSave } from "./kb-runner";
+import {
+  KB_EXTRACT_INDEX_KEY,
+  KB_EXTRACT_SCAN_LIMIT,
+  type PendingKbBatch,
+} from "./kb-proposals";
+import type { RequestLogger } from "./logger";
+
+function makeRlog(): { rlog: RequestLogger; events: [string, Record<string, unknown> | undefined][] } {
+  const events: [string, Record<string, unknown> | undefined][] = [];
+  const fn = (event: string, data?: Record<string, unknown>) => {
+    events.push([event, data]);
+  };
+  return { rlog: Object.assign(fn, { requestId: "req-test" }), events };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("runKbExtractionSweep — bounded index scan (PR #139)", () => {
+  it("reads only the first KB_EXTRACT_SCAN_LIMIT members, oldest-activity first", async () => {
+    mocks.kv.zrange.mockResolvedValue([]);
+    const { rlog } = makeRlog();
+
+    await runKbExtractionSweep(rlog);
+
+    // zrange default order is ascending by score (= last activity), so
+    // the window holds the MOST IDLE threads — exactly the extract/
+    // prune candidates. A full-index (0, -1) scan is O(n) per sweep.
+    expect(mocks.kv.zrange).toHaveBeenCalledWith(
+      KB_EXTRACT_INDEX_KEY,
+      0,
+      KB_EXTRACT_SCAN_LIMIT - 1,
+    );
+  });
+
+  it("KB_EXTRACT_SCAN_LIMIT is 50", () => {
+    expect(KB_EXTRACT_SCAN_LIMIT).toBe(50);
+  });
+});
+
+describe("executeKbBatchSave — supersession failure is best-effort (PR #139)", () => {
+  const BATCH: PendingKbBatch = {
+    candidates: [
+      {
+        entry: "The auth module lives in app/Services/Auth",
+        kind: "correction",
+        evidence: [1],
+        confidence: 0.9,
+        hash: "h1",
+        flaggedKbEntries: ["Auth uses JWT in app/Http/Auth"],
+        evidenceQuotes: ["moved last quarter"],
+      },
+    ],
+    proposedAt: 1_752_000_000_000,
+    channel: "C1",
+    threadTs: "17.1",
+    messageFirstTs: "17.2",
+  };
+
+  function armKv() {
+    mocks.kv.get.mockImplementation(async (key: string) => {
+      if (key.startsWith("pending-kb-batch:C1:")) return BATCH;
+      return null; // state key, etc.
+    });
+    mocks.kv.del.mockResolvedValue(1);
+    mocks.kv.set.mockResolvedValue("OK");
+  }
+
+  it("still reports the entry as SAVED when markKnowledgeSuperseded throws, and logs kb_supersede_error", async () => {
+    armKv();
+    mocks.saveKnowledgeEntry.mockResolvedValue("id-1");
+    mocks.markKnowledgeSuperseded.mockRejectedValue(new Error("kv down"));
+    const { rlog, events } = makeRlog();
+
+    const result = await executeKbBatchSave("C1", "17.1", "17.2", "U1", "reaction", rlog);
+
+    expect(result).toEqual({ claimed: true });
+    // The entry WAS durably saved — a retire failure must not flip the
+    // outcome to error (mirrors the 👎 flow's best-effort semantics).
+    const saved = events.find(([e]) => e === "kb_batch_saved");
+    expect(saved?.[1]).toMatchObject({ successCount: 1, failureCount: 0 });
+    expect(events).toContainEqual([
+      "kb_supersede_error",
+      expect.objectContaining({ channel: "C1", threadTs: "17.1" }),
+    ]);
+    const summary = mocks.replyInThread.mock.calls.at(-1)?.[2] as string;
+    expect(summary).toContain("Saved 1");
+    expect(summary).not.toContain(":warning:");
+    expect(summary).not.toContain("retired");
+  });
+
+  it("counts only successful supersessions when some flagged entries fail", async () => {
+    armKv();
+    const batch: PendingKbBatch = {
+      ...BATCH,
+      candidates: [
+        {
+          ...BATCH.candidates[0],
+          flaggedKbEntries: ["stale one", "stale two"],
+        },
+      ],
+    };
+    mocks.kv.get.mockImplementation(async (key: string) => {
+      if (key.startsWith("pending-kb-batch:C1:")) return batch;
+      return null;
+    });
+    mocks.saveKnowledgeEntry.mockResolvedValue("id-1");
+    mocks.markKnowledgeSuperseded
+      .mockResolvedValueOnce(true)
+      .mockRejectedValueOnce(new Error("boom"));
+    const { rlog, events } = makeRlog();
+
+    await executeKbBatchSave("C1", "17.1", "17.2", "U1", "text", rlog);
+
+    const saved = events.find(([e]) => e === "kb_batch_saved");
+    expect(saved?.[1]).toMatchObject({ successCount: 1, supersededTotal: 1 });
+    const summary = mocks.replyInThread.mock.calls.at(-1)?.[2] as string;
+    expect(summary).toContain("retired 1");
+  });
+});

--- a/src/lib/kb-runner.ts
+++ b/src/lib/kb-runner.ts
@@ -28,13 +28,14 @@ import { log as defaultLog, type LogFn, type RequestLogger } from "./logger";
 import {
   slack,
   replyInThread,
-  fetchThreadMessages,
+  fetchThreadTail,
   getBotUserId,
 } from "./slack";
 import { indexMember, parseIndexMember } from "./recovery";
 import {
   extractKbCandidates,
   buildExtractionTranscript,
+  MAX_EXTRACTION_MESSAGES,
 } from "./kb-extract";
 import {
   gateKbCandidates,
@@ -51,6 +52,7 @@ import {
   kbBatchThreadPointerKey,
   kbBatchTombstoneKey,
   KB_EXTRACT_INDEX_KEY,
+  KB_EXTRACT_SCAN_LIMIT,
   MAX_KB_EXTRACT_PER_SWEEP,
   MAX_KB_EXTRACTION_ATTEMPTS,
   KB_STATE_TTL_SEC,
@@ -187,7 +189,14 @@ export async function runKbExtractionSweep(
     skipped: 0,
   };
 
-  const members = (await kv.zrange(KB_EXTRACT_INDEX_KEY, 0, -1)) as string[];
+  // Bounded window (PR #139): ascending score = oldest activity first,
+  // so the first KB_EXTRACT_SCAN_LIMIT members are the most-idle
+  // threads — the extract/prune candidates. Never a full (0, -1) scan.
+  const members = (await kv.zrange(
+    KB_EXTRACT_INDEX_KEY,
+    0,
+    KB_EXTRACT_SCAN_LIMIT - 1,
+  )) as string[];
   const now = Date.now();
   // conversations.info once per channel per sweep.
   const publicnessCache = new Map<string, "public" | "non_public" | "unknown">();
@@ -308,7 +317,14 @@ export async function runKbExtractionSweep(
       // ── Extract ───────────────────────────────────────────────────
       const priorHashes = state?.proposedHashes ?? [];
       const botId = await getBotUserId();
-      const threadMsgs = await fetchThreadMessages(channel, threadTs);
+      // Paginated tail (PR #139): fetchThreadMessages caps at 50
+      // unpaginated, below the 60-message extraction window — the tail
+      // helper follows next_cursor and keeps the most recent messages.
+      const threadMsgs = await fetchThreadTail(
+        channel,
+        threadTs,
+        MAX_EXTRACTION_MESSAGES,
+      );
       const { rendered, entries } = buildExtractionTranscript(threadMsgs, botId ?? "");
 
       if (entries.length === 0) {
@@ -499,9 +515,26 @@ export async function executeKbBatchSave(
       const id = await saveKnowledgeEntry(c.entry);
       let supersededCount = 0;
       if (c.kind === "correction") {
+        // Best-effort retirement (PR #139): the entry IS durably saved
+        // at this point — a KV flake while retiring flagged entries
+        // must never reject this promise and misreport the save as a
+        // failure. Mirrors the 👎 correction flow's semantics
+        // (correction_supersede_error in turn-runner.ts). Worst case a
+        // stale entry stays visible — observable via the count below.
         for (const flaggedText of c.flaggedKbEntries) {
-          if (await markKnowledgeSuperseded(flaggedText, id)) {
-            supersededCount++;
+          try {
+            if (await markKnowledgeSuperseded(flaggedText, id)) {
+              supersededCount++;
+            }
+          } catch (err) {
+            rlog("kb_supersede_error", {
+              channel,
+              threadTs,
+              entrySample: c.entry.slice(0, 80),
+              flaggedSample: flaggedText.slice(0, 80),
+              errorMessage:
+                err instanceof Error ? err.message.slice(0, 200) : String(err),
+            });
           }
         }
       }

--- a/src/lib/kb-runner.ts
+++ b/src/lib/kb-runner.ts
@@ -1,0 +1,576 @@
+/**
+ * Passive KB learning — orchestration (#136).
+ *
+ * Side-effect layer over the pure trio (kb-extract / kb-gate /
+ * kb-proposals). Two flows live here:
+ *
+ * 1. `runKbExtractionSweep` — phase 2 of /api/cron/sweep. Walks the
+ *    kb-extract:index zset, classifies each quiet thread via
+ *    decideKbExtraction, wins a non-destructive NX claim (structural
+ *    clone of recovery.ts acquireSweepClaim), extracts candidates with
+ *    the fast model, gates them deterministically, and posts a proposal
+ *    message. NOTHING writes to the KB here — proposals only.
+ *
+ * 2. `executeKbBatchSave` — the confirmation side (✅ reaction or
+ *    "confirm all" text). Structural clone of turn-runner.ts's
+ *    executeBatchCreation claim protocol: get → atomic del claim →
+ *    tombstone → pointer cleanup → allSettled saves → summary post.
+ *    There is deliberately NO text-parse fallback for KB proposals
+ *    (invariant K-P4): the KV record is the only path to a save.
+ *
+ * Plus `recordKbThreadActivity`, the best-effort discovery-index bump
+ * the turn runner calls after every posted answer.
+ */
+
+import * as Sentry from "@sentry/nextjs";
+import { kv } from "./kv";
+import { log as defaultLog, type LogFn, type RequestLogger } from "./logger";
+import {
+  slack,
+  replyInThread,
+  fetchThreadMessages,
+  getBotUserId,
+} from "./slack";
+import { indexMember, parseIndexMember } from "./recovery";
+import {
+  extractKbCandidates,
+  buildExtractionTranscript,
+} from "./kb-extract";
+import {
+  gateKbCandidates,
+  isExtractableChannel,
+  KB_SAVED_CONFIRMATION_PREFIX, // re-exported for the turn runner's reply
+} from "./kb-gate";
+import {
+  decideKbExtraction,
+  formatKbProposalMessage,
+  summarizeKbSaveResult,
+  kbStateKey,
+  kbClaimKey,
+  kbBatchKey,
+  kbBatchThreadPointerKey,
+  kbBatchTombstoneKey,
+  KB_EXTRACT_INDEX_KEY,
+  MAX_KB_EXTRACT_PER_SWEEP,
+  MAX_KB_EXTRACTION_ATTEMPTS,
+  KB_STATE_TTL_SEC,
+  KB_EXTRACT_CLAIM_TTL_SEC,
+  KB_BATCH_TTL_SEC,
+  KB_BATCH_TOMBSTONE_TTL_SEC,
+  type KbThreadState,
+  type KbSaveOutcome,
+  type PendingKbBatch,
+} from "./kb-proposals";
+import {
+  saveKnowledgeEntry,
+  markKnowledgeSuperseded,
+  getAllKnowledge,
+} from "./knowledge";
+
+export { KB_SAVED_CONFIRMATION_PREFIX };
+
+// ── Activity recording ────────────────────────────────────────────────
+
+/**
+ * Bump the KB discovery index for a thread the bot just answered in.
+ * Best-effort: a KV flake must never break the reply flow. Called by
+ * turn-runner after every answer_posted (mention + follow-up, answer +
+ * proposal paths) — and deliberately NOT after posting a KB proposal,
+ * which would re-arm extraction on the extractor's own output.
+ */
+export async function recordKbThreadActivity(
+  channel: string,
+  threadTs: string,
+  log: LogFn = defaultLog,
+): Promise<void> {
+  try {
+    await kv.zadd(KB_EXTRACT_INDEX_KEY, {
+      score: Date.now(),
+      member: indexMember(channel, threadTs),
+    });
+  } catch (err) {
+    log("kb_activity_record_failed", {
+      channel,
+      threadTs,
+      errorMessage: err instanceof Error ? err.message.slice(0, 200) : String(err),
+    });
+  }
+}
+
+// ── Sweep claim (structural clone of recovery.ts acquireSweepClaim) ──
+
+/**
+ * Non-destructive extraction claim: SET NX with a short TTL on a
+ * SEPARATE key. The index entry and state survive any failure after a
+ * won claim — the next sweep (once the claim TTL expires) simply
+ * retries the decision. The losing racer gets false and skips.
+ */
+async function acquireKbExtractClaim(
+  channel: string,
+  threadTs: string,
+  requestId: string,
+): Promise<boolean> {
+  const result = await kv.set(
+    kbClaimKey(channel, threadTs),
+    { claimedAt: Date.now(), requestId },
+    { nx: true, ex: KB_EXTRACT_CLAIM_TTL_SEC },
+  );
+  // Upstash SET NX returns null when the key already exists.
+  return result !== null;
+}
+
+// ── Channel publicness (fail closed) ─────────────────────────────────
+
+/**
+ * Positively confirm a channel is PUBLIC via conversations.info.
+ * Returns:
+ * - "public"     — extraction may proceed;
+ * - "non_public" — confirmed private/DM/MPIM: prune the index entry,
+ *                  this thread can never become extractable;
+ * - "unknown"    — info unavailable (missing channels:read scope, API
+ *                  error): FAIL CLOSED, skip WITHOUT pruning.
+ */
+async function classifyChannelPublicness(
+  channel: string,
+): Promise<"public" | "non_public" | "unknown"> {
+  try {
+    const info = await slack.conversations.info({ channel });
+    const c = info.channel;
+    if (!c) return "unknown";
+    if (isExtractableChannel(c)) return "public";
+    // Distinguish "flags present and say non-public" from "flags
+    // missing" — only a positive non-public reading justifies pruning.
+    if (c.is_private === true || c.is_im === true || c.is_mpim === true) {
+      return "non_public";
+    }
+    return "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+// ── Extraction sweep (phase 2 of /api/cron/sweep) ─────────────────────
+
+export interface KbSweepSummary {
+  scanned: number;
+  extracted: number;
+  proposed: number;
+  pruned: number;
+  gaveUp: number;
+  skipped: number;
+}
+
+async function writeKbState(
+  channel: string,
+  threadTs: string,
+  state: KbThreadState,
+): Promise<void> {
+  await kv.set(kbStateKey(channel, threadTs), state, { ex: KB_STATE_TTL_SEC });
+}
+
+/**
+ * Walk the kb-extract:index and run at most MAX_KB_EXTRACT_PER_SWEEP
+ * extractions. Per-member failures are contained (the member stays
+ * intact for the next sweep); the function itself never throws for a
+ * member-level error, but the caller still wraps it — a KB failure
+ * must never fail recovery (phase 1).
+ */
+export async function runKbExtractionSweep(
+  rlog: RequestLogger,
+): Promise<KbSweepSummary> {
+  const summary: KbSweepSummary = {
+    scanned: 0,
+    extracted: 0,
+    proposed: 0,
+    pruned: 0,
+    gaveUp: 0,
+    skipped: 0,
+  };
+
+  const members = (await kv.zrange(KB_EXTRACT_INDEX_KEY, 0, -1)) as string[];
+  const now = Date.now();
+  // conversations.info once per channel per sweep.
+  const publicnessCache = new Map<string, "public" | "non_public" | "unknown">();
+
+  for (const member of members) {
+    summary.scanned++;
+    try {
+      const parsed = parseIndexMember(member);
+      if (!parsed) {
+        await kv.zrem(KB_EXTRACT_INDEX_KEY, member);
+        rlog("kb_extract_pruned", { member: member.slice(0, 40), reason: "malformed" });
+        summary.pruned++;
+        continue;
+      }
+      const { channel, threadTs } = parsed;
+
+      const lastActivityAt = await kv.zscore(KB_EXTRACT_INDEX_KEY, member);
+      if (lastActivityAt === null) continue; // removed by a racer — skip
+
+      const state = await kv.get<KbThreadState>(kbStateKey(channel, threadTs));
+      const action = decideKbExtraction(state, lastActivityAt, now);
+
+      if (action === "wait") continue;
+
+      if (action === "prune") {
+        await kv.zrem(KB_EXTRACT_INDEX_KEY, member);
+        rlog("kb_extract_pruned", { channel, threadTs, reason: "quiet_period_consumed" });
+        summary.pruned++;
+        continue;
+      }
+
+      if (action === "give_up") {
+        await writeKbState(channel, threadTs, {
+          status: "gave_up",
+          extractedAt: now,
+          attempt: state?.attempt ?? MAX_KB_EXTRACTION_ATTEMPTS,
+          proposedHashes: state?.proposedHashes ?? [],
+        });
+        await kv.zrem(KB_EXTRACT_INDEX_KEY, member);
+        rlog("kb_extraction_gave_up", {
+          channel,
+          threadTs,
+          attempt: state?.attempt ?? null,
+        });
+        summary.gaveUp++;
+        continue;
+      }
+
+      // action === "extract"
+      if (summary.extracted >= MAX_KB_EXTRACT_PER_SWEEP) {
+        // Budget spent — leave the member for the next sweep.
+        summary.skipped++;
+        continue;
+      }
+
+      // Channel publicness — FAIL CLOSED (#136): extraction only runs
+      // when the channel is positively confirmed public.
+      let publicness = publicnessCache.get(channel);
+      if (!publicness) {
+        publicness = await classifyChannelPublicness(channel);
+        publicnessCache.set(channel, publicness);
+      }
+      if (publicness !== "public") {
+        if (publicness === "non_public") {
+          // Confirmed private/DM/MPIM — never extractable; drop it.
+          await kv.zrem(KB_EXTRACT_INDEX_KEY, member);
+          summary.pruned++;
+        } else {
+          summary.skipped++;
+        }
+        rlog("kb_extraction_skipped", {
+          reason: "private_channel",
+          confirmed: publicness === "non_public",
+          channel,
+          threadTs,
+        });
+        continue;
+      }
+
+      const claimed = await acquireKbExtractClaim(channel, threadTs, rlog.requestId);
+      if (!claimed) {
+        rlog("kb_extract_claim_lost", { channel, threadTs });
+        continue;
+      }
+
+      // ── Pre-checks inside the claimed section ─────────────────────
+      // Idle re-check: the score may have moved between the scan and
+      // the claim (a user replied). Re-read and re-decide.
+      const freshActivityAt = await kv.zscore(KB_EXTRACT_INDEX_KEY, member);
+      if (
+        freshActivityAt === null ||
+        decideKbExtraction(state, freshActivityAt, Date.now()) !== "extract"
+      ) {
+        rlog("kb_extraction_skipped", { reason: "idle_recheck", channel, threadTs });
+        summary.skipped++;
+        continue;
+      }
+      // A pending 👎-correction owns this thread's next reply — the
+      // explicit correction flow outranks passive learning.
+      const pendingCorrection = await kv.get(
+        `pending-correction:${channel}:${threadTs}`,
+      );
+      if (pendingCorrection) {
+        rlog("kb_extraction_skipped", { reason: "pending_correction", channel, threadTs });
+        summary.skipped++;
+        continue;
+      }
+      // An unconfirmed KB proposal already sits in this thread.
+      const pendingBatch = await kv.get<string>(
+        kbBatchThreadPointerKey(channel, threadTs),
+      );
+      if (pendingBatch) {
+        rlog("kb_extraction_skipped", { reason: "pending_kb_batch", channel, threadTs });
+        summary.skipped++;
+        continue;
+      }
+
+      // ── Extract ───────────────────────────────────────────────────
+      const priorHashes = state?.proposedHashes ?? [];
+      const botId = await getBotUserId();
+      const threadMsgs = await fetchThreadMessages(channel, threadTs);
+      const { rendered, entries } = buildExtractionTranscript(threadMsgs, botId ?? "");
+
+      if (entries.length === 0) {
+        // Nothing to learn from — mark the quiet period covered.
+        await writeKbState(channel, threadTs, {
+          status: "covered",
+          extractedAt: Date.now(),
+          attempt: 0,
+          proposedHashes: priorHashes,
+        });
+        rlog("kb_extraction_skipped", { reason: "empty_thread", channel, threadTs });
+        summary.skipped++;
+        continue;
+      }
+
+      summary.extracted++;
+      const candidates = await extractKbCandidates({ transcript: rendered }, { log: rlog });
+
+      if (candidates === null) {
+        // Failure — extractKbCandidates already logged the reason.
+        // Attempt resets on a gave_up re-arm (new activity), so a
+        // gave_up state counts as attempt 0 here.
+        const attempt = (state?.status === "gave_up" ? 0 : state?.attempt ?? 0) + 1;
+        await writeKbState(channel, threadTs, {
+          status: "failed",
+          extractedAt: Date.now(),
+          attempt,
+          proposedHashes: priorHashes,
+        });
+        continue;
+      }
+
+      // ── Gate ──────────────────────────────────────────────────────
+      const visibleKb = await getAllKnowledge();
+      const { eligible, dropped } = gateKbCandidates({
+        candidates,
+        transcript: entries,
+        visibleKb,
+        alreadyProposedHashes: priorHashes,
+      });
+      rlog("kb_candidates_gated", {
+        channel,
+        threadTs,
+        candidateCount: candidates.length,
+        eligibleCount: eligible.length,
+        droppedCount: dropped.length,
+        dropReasons: dropped.map((d) => d.reason),
+      });
+
+      if (eligible.length === 0) {
+        await writeKbState(channel, threadTs, {
+          status: "covered",
+          extractedAt: Date.now(),
+          attempt: 0,
+          proposedHashes: priorHashes,
+        });
+        continue;
+      }
+
+      // ── Propose (post → record → state; K-P ordering) ─────────────
+      // The proposal post itself must NOT bump kb-extract:index — we
+      // post via replyInThread directly, never through the turn runner.
+      const message = formatKbProposalMessage(eligible);
+      const firstTs = await replyInThread(channel, threadTs, message);
+      if (!firstTs) {
+        // Post failed silently — treat as a failed attempt.
+        const attempt = (state?.status === "gave_up" ? 0 : state?.attempt ?? 0) + 1;
+        await writeKbState(channel, threadTs, {
+          status: "failed",
+          extractedAt: Date.now(),
+          attempt,
+          proposedHashes: priorHashes,
+        });
+        continue;
+      }
+
+      const record: PendingKbBatch = {
+        candidates: eligible,
+        proposedAt: Date.now(),
+        channel,
+        threadTs,
+        messageFirstTs: firstTs,
+      };
+      await kv.set(kbBatchKey(channel, firstTs), record, { ex: KB_BATCH_TTL_SEC });
+      await kv.set(kbBatchThreadPointerKey(channel, threadTs), firstTs, {
+        ex: KB_BATCH_TTL_SEC,
+      });
+
+      await writeKbState(channel, threadTs, {
+        status: "covered",
+        extractedAt: Date.now(),
+        attempt: 0,
+        // Recorded at PROPOSAL time so an ignored (unconfirmed)
+        // proposal is never re-proposed in a later quiet period.
+        proposedHashes: [...new Set([...priorHashes, ...eligible.map((c) => c.hash)])],
+      });
+
+      rlog("kb_batch_proposed", {
+        count: eligible.length,
+        channel,
+        threadTs,
+        firstTs,
+        kinds: eligible.map((c) => c.kind),
+        sampleEntries: eligible.slice(0, 3).map((c) => c.entry.slice(0, 80)),
+      });
+      summary.proposed++;
+    } catch (err) {
+      // One bad member must not abort the rest — and because the claim
+      // is non-destructive, index + state stay recoverable BY DESIGN.
+      rlog("kb_extract_member_failed", {
+        member: member.slice(0, 60),
+        errorMessage: err instanceof Error ? err.message.slice(0, 200) : String(err),
+      });
+      Sentry.captureException(err, { tags: { flow: "kb_extract_sweep" } });
+    }
+  }
+
+  rlog("kb_extract_sweep_complete", { ...summary });
+  return summary;
+}
+
+// ── Confirmation: save a claimed batch ────────────────────────────────
+
+/**
+ * Atomically claim and execute a pending KB batch. Structural clone of
+ * turn-runner.ts's executeBatchCreation protocol:
+ *
+ * get → atomic del claim (Redis DEL — only the first caller sees 1) →
+ * tombstone → thread-pointer cleanup → Promise.allSettled saves →
+ * summary post. Racing handlers (double ✅, ✅ + "confirm all") see
+ * deleted === 0 and abort without writing to the KB.
+ *
+ * Correction-kind candidates run saveKnowledgeEntry then
+ * markKnowledgeSuperseded for each flagged entry (#124 supersession).
+ */
+export async function executeKbBatchSave(
+  channel: string,
+  threadTs: string,
+  firstTs: string,
+  confirmingUser: string,
+  confirmVia: "reaction" | "text",
+  rlog: RequestLogger,
+): Promise<{ claimed: boolean }> {
+  const primaryKey = kbBatchKey(channel, firstTs);
+
+  const batch = await kv.get<PendingKbBatch>(primaryKey);
+  if (!batch) {
+    return { claimed: false };
+  }
+
+  const deleted = await kv.del(primaryKey);
+  if (deleted === 0) {
+    rlog("kb_batch_claim_lost", { channel, firstTs, confirmVia });
+    return { claimed: false };
+  }
+
+  // Tombstone the claim so a second ✅ on the same message returns
+  // silently instead of falling anywhere else. There is NO text-parse
+  // fallback for KB proposals (K-P4) — the tombstone only guards
+  // duplicate user feedback, never a re-save.
+  try {
+    await kv.set(kbBatchTombstoneKey(channel, firstTs), 1, {
+      ex: KB_BATCH_TOMBSTONE_TTL_SEC,
+    });
+  } catch {
+    // Non-fatal; Sentry already captured via the kv wrapper.
+  }
+
+  // Best-effort cleanup of the thread pointer.
+  try {
+    await kv.del(kbBatchThreadPointerKey(channel, threadTs));
+  } catch {
+    // Non-fatal; Sentry already captured via the kv wrapper.
+  }
+
+  rlog("kb_batch_confirmed", {
+    count: batch.candidates.length,
+    confirmVia,
+    confirmingUser,
+    latencyMs: Date.now() - batch.proposedAt,
+    channel,
+    threadTs,
+  });
+
+  const saveStart = Date.now();
+  const settled = await Promise.allSettled(
+    batch.candidates.map(async (c) => {
+      const id = await saveKnowledgeEntry(c.entry);
+      let supersededCount = 0;
+      if (c.kind === "correction") {
+        for (const flaggedText of c.flaggedKbEntries) {
+          if (await markKnowledgeSuperseded(flaggedText, id)) {
+            supersededCount++;
+          }
+        }
+      }
+      return { id, supersededCount };
+    }),
+  );
+
+  const outcomes: KbSaveOutcome[] = settled.map((res, i) => {
+    const candidate = batch.candidates[i];
+    if (res.status === "fulfilled") {
+      return {
+        status: "saved",
+        entry: candidate.entry,
+        id: res.value.id,
+        supersededCount: res.value.supersededCount,
+      };
+    }
+    const errorMessage =
+      res.reason instanceof Error ? res.reason.message : String(res.reason);
+    Sentry.captureException(res.reason, {
+      tags: { flow: "kb_save", batchSize: String(batch.candidates.length) },
+      extra: { entrySample: candidate.entry.slice(0, 80) },
+    });
+    rlog("kb_save_error", {
+      channel,
+      threadTs,
+      entrySample: candidate.entry.slice(0, 80),
+      errorClass:
+        res.reason instanceof Error ? res.reason.constructor.name : "Unknown",
+      errorMessage: errorMessage.slice(0, 200),
+    });
+    return { status: "error", entry: candidate.entry, errorMessage };
+  });
+
+  // Append the batch hashes to the thread state (idempotent union —
+  // proposal time already recorded them; this covers state records
+  // that were rewritten in between). Best-effort.
+  try {
+    const state = await kv.get<KbThreadState>(kbStateKey(channel, threadTs));
+    await writeKbState(channel, threadTs, {
+      status: state?.status ?? "covered",
+      extractedAt: state?.extractedAt ?? Date.now(),
+      attempt: state?.attempt ?? 0,
+      proposedHashes: [
+        ...new Set([
+          ...(state?.proposedHashes ?? []),
+          ...batch.candidates.map((c) => c.hash),
+        ]),
+      ],
+    });
+  } catch {
+    // Non-fatal — the gate's duplicate_kb rule still blocks re-proposal
+    // of anything that actually saved.
+  }
+
+  const successCount = outcomes.filter((o) => o.status === "saved").length;
+  rlog("kb_batch_saved", {
+    totalCount: outcomes.length,
+    successCount,
+    failureCount: outcomes.length - successCount,
+    supersededTotal: outcomes.reduce(
+      (s, o) => s + (o.status === "saved" ? o.supersededCount : 0),
+      0,
+    ),
+    durationMs: Date.now() - saveStart,
+    channel,
+    threadTs,
+  });
+
+  await replyInThread(channel, threadTs, summarizeKbSaveResult(outcomes));
+  return { claimed: true };
+}

--- a/src/lib/slack.test.ts
+++ b/src/lib/slack.test.ts
@@ -4,8 +4,12 @@ import {
   SLACK_MESSAGE_CHAR_LIMIT,
   SlackMessageOversizeError,
   postReplyInChunks,
+  fetchThreadTail,
+  THREAD_TAIL_PAGE_LIMIT,
+  MAX_THREAD_TAIL_PAGES,
   slack,
 } from "./slack";
+import { MAX_EXTRACTION_MESSAGES } from "./kb-extract";
 
 describe("requireSlackMessageText (fail-loud boundary guard)", () => {
   it("returns the text unchanged when under the limit", () => {
@@ -145,5 +149,76 @@ describe("postReplyInChunks returns every posted TS", () => {
       text: bigText,
     });
     expect(result.allTs.length).toBe(result.chunks);
+  });
+});
+
+// ── Paginated thread-tail fetch (#136 / PR #139 review) ─────────────
+// conversations.replies pages OLDEST-first, capped per request. The
+// passive-KB extraction window (MAX_EXTRACTION_MESSAGES = 60) exceeds
+// the old single-page fetch of 50, so the extraction path uses this
+// helper: follow next_cursor to the thread end (bounded) and keep only
+// the most recent `maxMessages`.
+describe("fetchThreadTail (paginated, most-recent tail)", () => {
+  const msg = (i: number) => ({ user: "U1", text: `m${i}`, ts: `${i}.0` });
+  const range = (from: number, to: number) =>
+    Array.from({ length: to - from }, (_, k) => msg(from + k));
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("follows next_cursor to the thread end and returns the most recent maxMessages", async () => {
+    const pages = [
+      { messages: range(0, 50), response_metadata: { next_cursor: "c1" } },
+      { messages: range(50, 100), response_metadata: { next_cursor: "c2" } },
+      { messages: range(100, 130), response_metadata: { next_cursor: "" } },
+    ];
+    const seenCursors: (string | undefined)[] = [];
+    let call = 0;
+    vi.spyOn(slack.conversations, "replies").mockImplementation((async (args: {
+      cursor?: string;
+    }) => {
+      seenCursors.push(args.cursor);
+      return pages[call++];
+    }) as never);
+
+    const tail = await fetchThreadTail("C1", "17.1", 60);
+    expect(seenCursors).toEqual([undefined, "c1", "c2"]);
+    expect(tail).toHaveLength(60);
+    // The tail of a 130-message thread is m70..m129 — NOT the first page.
+    expect(tail[0].text).toBe("m70");
+    expect(tail[59].text).toBe("m129");
+  });
+
+  it("returns the whole thread when it is shorter than maxMessages", async () => {
+    vi.spyOn(slack.conversations, "replies").mockResolvedValue({
+      messages: range(0, 3),
+      response_metadata: { next_cursor: "" },
+    } as never);
+    const tail = await fetchThreadTail("C1", "17.1", 60);
+    expect(tail.map((m) => m.text)).toEqual(["m0", "m1", "m2"]);
+  });
+
+  it("stops after MAX_THREAD_TAIL_PAGES even when a cursor remains (bounded traversal)", async () => {
+    const replies = vi
+      .spyOn(slack.conversations, "replies")
+      .mockResolvedValue({
+        messages: range(0, THREAD_TAIL_PAGE_LIMIT),
+        response_metadata: { next_cursor: "more" },
+      } as never);
+    const tail = await fetchThreadTail("C1", "17.1", 60);
+    expect(replies).toHaveBeenCalledTimes(MAX_THREAD_TAIL_PAGES);
+    expect(tail).toHaveLength(60);
+  });
+
+  it("returns [] on API error (same degradation as fetchThreadMessages)", async () => {
+    vi.spyOn(slack.conversations, "replies").mockRejectedValue(new Error("boom"));
+    expect(await fetchThreadTail("C1", "17.1", 60)).toEqual([]);
+  });
+
+  it("pins the constant relation: one page covers the extraction window", () => {
+    // If MAX_EXTRACTION_MESSAGES ever grows past the per-page fetch
+    // size, the tail could silently under-fill from a single page.
+    expect(THREAD_TAIL_PAGE_LIMIT).toBeGreaterThanOrEqual(MAX_EXTRACTION_MESSAGES);
   });
 });

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -230,6 +230,57 @@ export async function fetchThreadMessages(
   }
 }
 
+// ── Paginated thread-tail fetch (#136 / PR #139 review) ──────────────
+// conversations.replies pages OLDEST-first. fetchThreadMessages above
+// deliberately keeps its single-page/50 behavior for the turn flows;
+// passive-KB extraction needs the MOST RECENT MAX_EXTRACTION_MESSAGES
+// (60 > 50), so this helper follows next_cursor to the thread end
+// (bounded) and keeps a rolling tail.
+
+/** Per-page fetch size. Must stay >= kb-extract's
+ *  MAX_EXTRACTION_MESSAGES (pinned by a test) so one page can always
+ *  fill the extraction window. */
+export const THREAD_TAIL_PAGE_LIMIT = 200;
+
+/** Traversal bound: at most this many pages are followed (5 × 200 =
+ *  1000 messages). A pathological mega-thread returns the tail of the
+ *  traversed window instead of hanging the sweep. */
+export const MAX_THREAD_TAIL_PAGES = 5;
+
+export async function fetchThreadTail(
+  channel: string,
+  threadTs: string,
+  maxMessages: number,
+): Promise<ThreadMessage[]> {
+  try {
+    const tail: ThreadMessage[] = [];
+    let cursor: string | undefined;
+    for (let page = 0; page < MAX_THREAD_TAIL_PAGES; page++) {
+      const result = await slack.conversations.replies({
+        channel,
+        ts: threadTs,
+        limit: THREAD_TAIL_PAGE_LIMIT,
+        cursor,
+      });
+      for (const m of result.messages ?? []) {
+        tail.push({ user: m.user, text: m.text ?? "", bot_id: m.bot_id, ts: m.ts });
+      }
+      // Keep only the most recent maxMessages — pages arrive
+      // oldest-first, so trimming the head preserves the tail.
+      if (tail.length > maxMessages) {
+        tail.splice(0, tail.length - maxMessages);
+      }
+      cursor = result.response_metadata?.next_cursor || undefined;
+      if (!cursor) break;
+    }
+    return tail;
+  } catch {
+    // Same degradation contract as fetchThreadMessages: an API error
+    // yields an empty transcript, never a throw.
+    return [];
+  }
+}
+
 // ── Check if bot is participating in a thread ────────────────────────
 export async function isBotInThread(
   channel: string,

--- a/src/lib/turn-runner.ts
+++ b/src/lib/turn-runner.ts
@@ -27,6 +27,12 @@ import {
   summarizeBatchResult,
   type BatchCreationOutcome,
 } from "@/lib/issue-batch";
+import {
+  recordKbThreadActivity,
+  executeKbBatchSave,
+  KB_SAVED_CONFIRMATION_PREFIX,
+} from "@/lib/kb-runner";
+import { kbBatchThreadPointerKey } from "@/lib/kb-proposals";
 import { storeQAContext, saveFeedback, deriveReferenceTypes } from "@/lib/feedback";
 import { formatReferences, rankReferences } from "@/lib/references";
 import { toSlackMrkdwn } from "@/lib/mrkdwn";
@@ -411,6 +417,12 @@ export async function runMentionTurn(params: MentionTurnParams): Promise<void> {
         kind: "proposal",
         proposalCount: proposals.length,
       });
+      // Passive-KB discovery bump (#136): every posted answer marks the
+      // thread active. Best-effort — never blocks the reply flow. The
+      // KB proposal post itself (kb-runner) deliberately does NOT bump.
+      if (posted.chunks > 0) {
+        await recordKbThreadActivity(channel, threadTs, rlog);
+      }
     } else {
       const finalBody = text + refsFooter + replyFooter;
       const posted = await postReplyInChunks({
@@ -421,6 +433,10 @@ export async function runMentionTurn(params: MentionTurnParams): Promise<void> {
       });
       if (posted.chunks > 0) thinkingTs = undefined;
       rlog("answer_posted", { channel, threadTs, chunks: posted.chunks });
+      // Passive-KB discovery bump (#136) — see the proposal branch.
+      if (posted.chunks > 0) {
+        await recordKbThreadActivity(channel, threadTs, rlog);
+      }
 
       // Store Q&A context for EVERY chunk ts (see #114). Reactions
       // on any chunk resolve to the same question/answer pair.
@@ -555,10 +571,13 @@ export async function runFollowupTurn(params: FollowupTurnParams): Promise<void>
         correctionSample: correctionText.slice(0, 100),
       });
 
+      // KB_SAVED_CONFIRMATION_PREFIX is shared with the passive-KB gate
+      // (kb-gate.ts), which scans thread transcripts for this exact
+      // prefix to avoid re-proposing an already-saved correction (#136).
       await replyInThread(
         channel,
         threadTs,
-        `:white_check_mark: Saved to knowledge base: _"${correctionText.slice(0, 100)}"_`,
+        `${KB_SAVED_CONFIRMATION_PREFIX} _"${correctionText.slice(0, 100)}"_`,
       );
       return;
     }
@@ -585,6 +604,25 @@ export async function runFollowupTurn(params: FollowupTurnParams): Promise<void>
         // Not claimed → either the batch expired or another handler
         // consumed it. Fall through to the normal agent flow so the
         // user still gets a response.
+      }
+
+      // KB proposal pointer (#136): same interception for a pending
+      // passive-KB batch in this thread. Checked AFTER the issue batch
+      // — mirrors the ✅ chain order in route.ts.
+      const kbFirstTs = await kv.get<string>(
+        kbBatchThreadPointerKey(channel, threadTs),
+      );
+      if (kbFirstTs) {
+        const kbOutcome = await executeKbBatchSave(
+          channel,
+          threadTs,
+          kbFirstTs,
+          user,
+          "text",
+          rlog,
+        );
+        if (kbOutcome.claimed) return;
+        // Not claimed → expired or consumed; fall through as above.
       }
     }
 
@@ -730,6 +768,12 @@ export async function runFollowupTurn(params: FollowupTurnParams): Promise<void>
         kind: "proposal",
         proposalCount: proposals.length,
       });
+      // Passive-KB discovery bump (#136): every posted answer marks the
+      // thread active. Best-effort — never blocks the reply flow. The
+      // KB proposal post itself (kb-runner) deliberately does NOT bump.
+      if (posted.chunks > 0) {
+        await recordKbThreadActivity(channel, threadTs, rlog);
+      }
     } else {
       const finalBody = text + refsFooter + replyFooter;
       const posted = await postReplyInChunks({
@@ -740,6 +784,10 @@ export async function runFollowupTurn(params: FollowupTurnParams): Promise<void>
       });
       if (posted.chunks > 0) thinkTs = undefined;
       rlog("answer_posted", { channel, threadTs, chunks: posted.chunks });
+      // Passive-KB discovery bump (#136) — see the proposal branch.
+      if (posted.chunks > 0) {
+        await recordKbThreadActivity(channel, threadTs, rlog);
+      }
 
       if (posted.firstTs && posted.allTs.length > 0) {
         const postedAt = Date.now();


### PR DESCRIPTION
## Summary

Second leg of epic #128. After a thread goes quiet (4h idle), a fast-model extraction pass proposes KB candidates — but the model only *nominates*; a deterministic gate decides eligibility and a human decides storage.

- **Trigger**: piggybacks the existing recovery sweep (phase 2, own try/catch — a KB failure can never affect crash recovery). A new `kb-extract:index` zset records bot-answered activity; `decideKbExtraction` (pure) walks wait/extract/prune/give_up with clock-skew-safe boundaries. Max 3 threads per tick, 2 attempts per quiet period, re-armed by new activity.
- **Provenance gate** (the heart): nine drop reasons with pinned precedence — empty/too-long/low-confidence/no-evidence/out-of-range-evidence (one bad index kills the candidate, fail-closed)/no-human-evidence (bot-only claims never survive)/already-saved-in-thread/duplicate-of-visible-KB/already-proposed. Every eligible candidate carries its evidence quotes from cited human messages. Correction-shaped candidates get annotated with the stale KB entries they contradict — confirmed saves supersede those via #124's machinery, preserving history.
- **Confirmation-before-write, structurally**: the extractor is a raw FAST_MODEL call with no tools; the only save path is `executeKbBatchSave`, a clone of the battle-tested issue-batch claim protocol (atomic DEL claim, tombstone, allSettled). No message-text fallback exists for KB proposals — and the proposal formatter is test-forbidden from containing the issue-proposal anchors, closing a real hazard where the legacy ✅ parser could have turned a KB proposal into a GitHub issue.
- **Privacy fail-closed**: private channels/DMs/MPIMs are never extracted; channels whose publicness can't be positively confirmed (missing `channels:read`/`groups:read` scopes) are skipped, not guessed. Scope requirement documented in setup.md.
- The 👎 flow keeps ownership of explicit corrections: threads with a pending correction are deferred, and the saved-confirmation prefix is now a shared exported constant so the gate rule and the reply text can never drift.

## Testing

TDD: 78 new tests materialized verbatim from the architect's spec and observed RED before any implementation — including the full drop-reason precedence matrix, boundary tests at every threshold (0.74/0.75 confidence, 500/501 chars, idle-boundary ±1ms, future-clock skew), and the extractor's never-throws failure matrix with abort propagation. Full suite **829 passing**, typecheck clean.

Closes #136 (epic #128)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
