### PR TITLE
fix: Compaction prompt survives $-patterns in turn content (closes #132)

### DIFF
--- a/src/lib/compaction.test.ts
+++ b/src/lib/compaction.test.ts
@@ -94,6 +94,26 @@ describe("compactThread", () => {
     expect(result.slice(1)).toEqual(originalPreserved.slice(1));
   });
 
+  it("passes $-replacement patterns in turn content through to the prompt verbatim (#132)", async () => {
+    // String.replace(string, replacement) interprets $&, $`, $', $1..$9 in
+    // the REPLACEMENT — a pasted shell/regex snippet in a compacted turn
+    // must not garble the summarizer prompt.
+    const history = makeTurns(MIN_PRESERVED_TURNS + 6, 100);
+    history[0] = {
+      role: "user",
+      content: "regex tip: use $& for the match, $` before, $1 for group one, and $$ for a dollar",
+    };
+    const compactor = vi.fn().mockResolvedValue("summary");
+
+    await compactThread(history, { compactor, log: vi.fn() });
+
+    const prompt = compactor.mock.calls[0][0] as string;
+    expect(prompt).toContain(
+      "regex tip: use $& for the match, $` before, $1 for group one, and $$ for a dollar",
+    );
+    expect(prompt).not.toContain("<TRANSCRIPT>");
+  });
+
   it("embeds summary into the first preserved turn with the marker", async () => {
     const history = makeTurns(MIN_PRESERVED_TURNS + 6, 100);
     const compactor = vi.fn().mockResolvedValue("summary of early turns");

--- a/src/lib/compaction.ts
+++ b/src/lib/compaction.ts
@@ -114,7 +114,10 @@ export async function compactThread(
     .map((t) => `${t.role === "user" ? "User" : "Assistant"}: ${t.content}`)
     .join("\n\n");
 
-  const prompt = COMPACTION_PROMPT.replace("<TRANSCRIPT>", transcript);
+  // Replacer FUNCTION, not a string — turn content containing $-patterns
+  // ($&, $`, $1, …) must arrive in the prompt verbatim, not be expanded
+  // as replacement directives. See #132 (same fix as effort-routing.ts).
+  const prompt = COMPACTION_PROMPT.replace("<TRANSCRIPT>", () => transcript);
 
   let summary: string;
   try {


### PR DESCRIPTION
One-line fix + regression test for #132: the thread-compaction prompt was built with `String.replace(placeholder, transcript)`, so $-replacement patterns (`$&`, \`$\`\`, `$1`…) inside compacted turn content were expanded instead of passed through, subtly garbling the summarizer prompt for long threads containing pasted shell/regex snippets. Now a replacer function, matching the pattern already used in `effort-routing.ts` and `kb-extract.ts` (this was the last substitution site doing it the fragile way).

TDD: regression test written first (RED confirmed), pinning verbatim passthrough of `$&`, \`$\`\`, `$1`, and `$$`. Full suite **943 passing**, typecheck clean.

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where certain `$`-style text sequences in conversation content could be altered when generating the compaction prompt.
  * Ensured the original transcript text is inserted exactly as written, so special character patterns are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->