### PR TITLE
fix: Vector namespaces must not contain slashes (Fixes BATTLE-MAGE-4)

### DIFF
--- a/src/lib/code-index.test.ts
+++ b/src/lib/code-index.test.ts
@@ -52,9 +52,9 @@ vi.mock("./logger", () => ({
 
 vi.mock("./vector", () => ({
   isVectorConfigured: (...args: unknown[]) => h.isVectorConfiguredMock(...args),
-  srcNamespace: () => "acme/backend:src",
-  docsNamespace: (sha: string) => `acme/backend:docs:${sha}`,
-  kbNamespace: () => "acme/backend:kb",
+  srcNamespace: () => "acme_backend:src",
+  docsNamespace: (sha: string) => `acme_backend:docs:${sha}`,
+  kbNamespace: () => "acme_backend:kb",
   vectorUpsert: (...args: unknown[]) => h.vectorUpsertSpy(...args),
   vectorDelete: (...args: unknown[]) => h.vectorDeleteSpy(...args),
   vectorDeleteNamespace: vi.fn(async () => true),
@@ -219,7 +219,7 @@ describe("runCodeIndexTick", () => {
     // S5: content read pinned to the snapshot sha
     expect(readFileSpy).toHaveBeenCalledWith("src/a.ts", "sha-2");
     expect(vectorUpsertSpy).toHaveBeenCalledWith(
-      "acme/backend:src",
+      "acme_backend:src",
       [expect.objectContaining({ id: "src/a.ts#0", metadata: expect.objectContaining({ path: "src/a.ts", startLine: 1 }) })],
     );
     expect(kvData.get("srcindex:manifest")).toEqual({ "src/a.ts": { sha: "blob-a", chunks: 1 } });
@@ -263,7 +263,7 @@ describe("runCodeIndexTick", () => {
     });
     readFileSpy.mockResolvedValue({ path: "src/b.ts", content: "export const b = 2;\n" });
     await runCodeIndexTick();
-    expect(vectorDeleteSpy).toHaveBeenCalledWith("acme/backend:src", ["src/b.ts#1", "src/b.ts#2"]);
+    expect(vectorDeleteSpy).toHaveBeenCalledWith("acme_backend:src", ["src/b.ts#1", "src/b.ts#2"]);
     expect(callOrder.indexOf("vectorUpsert")).toBeLessThan(callOrder.indexOf("vectorDelete"));
     expect(kvData.get("srcindex:manifest")).toEqual({ "src/b.ts": { sha: "blob-b-new", chunks: 1 } });
   });
@@ -274,7 +274,7 @@ describe("runCodeIndexTick", () => {
     getRepoTreeSnapshotSpy.mockResolvedValue({ sha: "sha-4", truncated: false, blobs: [] });
     const result = await runCodeIndexTick();
     expect(result).toMatchObject({ status: "complete", deleted: 1 });
-    expect(vectorDeleteSpy).toHaveBeenCalledWith("acme/backend:src", ["src/gone.ts#0", "src/gone.ts#1"]);
+    expect(vectorDeleteSpy).toHaveBeenCalledWith("acme_backend:src", ["src/gone.ts#0", "src/gone.ts#1"]);
     expect(readFileSpy).not.toHaveBeenCalled();
     expect(kvData.get("srcindex:manifest")).toEqual({});
   });

--- a/src/lib/knowledge.test.ts
+++ b/src/lib/knowledge.test.ts
@@ -59,7 +59,7 @@ vi.mock("./vector", () => ({
   vectorUpsert: (...a: unknown[]) => vectorUpsertSpy(...a),
   vectorDelete: (...a: unknown[]) => vectorDeleteSpy(...a),
   vectorQuery: (...a: unknown[]) => vectorQuerySpy(...a),
-  kbNamespace: () => "acme/backend:kb",
+  kbNamespace: () => "acme_backend:kb",
 }));
 
 import {
@@ -319,7 +319,7 @@ describe("getKnowledgeAsMarkdown", () => {
 describe("saveKnowledgeEntry — vector embedding (#127)", () => {
   it("upserts the entry into the KB namespace keyed by its id, with text and timestamp metadata", async () => {
     const id = await saveKnowledgeEntry("Auth lives in src/lib/auth.ts");
-    expect(vectorUpsertSpy).toHaveBeenCalledWith("acme/backend:kb", [
+    expect(vectorUpsertSpy).toHaveBeenCalledWith("acme_backend:kb", [
       expect.objectContaining({
         id,
         text: "Auth lives in src/lib/auth.ts",
@@ -351,13 +351,13 @@ describe("retire flows remove KB vectors (#127)", () => {
   it("supersedeKnowledgeEntry best-effort-deletes the OLD entry's vector", async () => {
     const oldId = await saveKnowledgeEntry("stale fact");
     await supersedeKnowledgeEntry(oldId, "fresh fact");
-    expect(vectorDeleteSpy).toHaveBeenCalledWith("acme/backend:kb", [oldId]);
+    expect(vectorDeleteSpy).toHaveBeenCalledWith("acme_backend:kb", [oldId]);
   });
 
   it("archiveKnowledgeEntry best-effort-deletes the entry's vector", async () => {
     const id = await saveKnowledgeEntry("obsolete fact");
     await archiveKnowledgeEntry(id, "cleanup");
-    expect(vectorDeleteSpy).toHaveBeenCalledWith("acme/backend:kb", [id]);
+    expect(vectorDeleteSpy).toHaveBeenCalledWith("acme_backend:kb", [id]);
   });
 
   it("retire still succeeds when vector delete fails", async () => {
@@ -403,7 +403,7 @@ describe("getKnowledgeRecallAsMarkdown (#127)", () => {
     injectSixEntries();
     await getKnowledgeRecallAsMarkdown("where is the redis wrapper");
     expect(vectorQuerySpy).toHaveBeenCalledWith(
-      "acme/backend:kb",
+      "acme_backend:kb",
       "where is the redis wrapper",
       10, // MAX_ARM_RESULTS
     );

--- a/src/lib/repo-index.test.ts
+++ b/src/lib/repo-index.test.ts
@@ -40,7 +40,7 @@ vi.mock("./kv", () => ({
 
 vi.mock("./vector", () => ({
   isVectorConfigured: () => true,
-  docsNamespace: (sha: string) => `acme/backend:docs:${sha}`,
+  docsNamespace: (sha: string) => `acme_backend:docs:${sha}`,
   vectorUpsert: (...a: unknown[]) => vectorUpsertSpy(...a),
   vectorDeleteNamespace: (...a: unknown[]) => vectorDeleteNamespaceSpy(...a),
 }));
@@ -590,7 +590,7 @@ describe("getOrRebuildIndex — doc embedding hook (#127)", () => {
 
   it("SHA changed → upserts chunks into the new SHA namespace, THEN repoints, THEN deletes the previous namespace (N1 order)", async () => {
     kvData.set("index:sha", "old-sha");
-    kvData.set("index:vector_docs_ns", "acme/backend:docs:old-sha");
+    kvData.set("index:vector_docs_ns", "acme_backend:docs:old-sha");
     getHeadShaSpy.mockResolvedValue("new-sha");
     getRepoTreeSpy.mockResolvedValue([
       treeBlob("docs/setup.md"),
@@ -610,12 +610,12 @@ describe("getOrRebuildIndex — doc embedding hook (#127)", () => {
       expect(logSpy).toHaveBeenCalledWith("docs_embedded", expect.anything()),
     );
 
-    expect(vectorUpsertSpy).toHaveBeenCalledWith("acme/backend:docs:new-sha", [
+    expect(vectorUpsertSpy).toHaveBeenCalledWith("acme_backend:docs:new-sha", [
       expect.objectContaining({ id: "docs/setup.md#0" }),
     ]);
-    expect(kvData.get("index:vector_docs_ns")).toBe("acme/backend:docs:new-sha");
+    expect(kvData.get("index:vector_docs_ns")).toBe("acme_backend:docs:new-sha");
     expect(vectorDeleteNamespaceSpy).toHaveBeenCalledWith(
-      "acme/backend:docs:old-sha",
+      "acme_backend:docs:old-sha",
     );
     // N1: upsert → pointer swap → old-namespace cleanup, in that order.
     const upsertIdx = callOrder.indexOf("vectorUpsert");
@@ -632,7 +632,7 @@ describe("getOrRebuildIndex — doc embedding hook (#127)", () => {
 
   it("upsert failure → pointer untouched, docs_embed_failed logged, rebuild still succeeds", async () => {
     kvData.set("index:sha", "old-sha");
-    kvData.set("index:vector_docs_ns", "acme/backend:docs:old-sha");
+    kvData.set("index:vector_docs_ns", "acme_backend:docs:old-sha");
     getHeadShaSpy.mockResolvedValue("new-sha");
     getRepoTreeSpy.mockResolvedValue([treeBlob("docs/setup.md")]);
     readFileSpy.mockImplementation(async (path: string) => {
@@ -654,7 +654,7 @@ describe("getOrRebuildIndex — doc embedding hook (#127)", () => {
       ),
     );
 
-    expect(kvData.get("index:vector_docs_ns")).toBe("acme/backend:docs:old-sha");
+    expect(kvData.get("index:vector_docs_ns")).toBe("acme_backend:docs:old-sha");
     expect(vectorDeleteNamespaceSpy).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith("index_rebuilt", expect.anything());
     expect(typeof summary).toBe("string");
@@ -662,7 +662,7 @@ describe("getOrRebuildIndex — doc embedding hook (#127)", () => {
 
   it("empty chunk set (all doc reads fail) → docs_embed_empty, pointer untouched, previous namespace NOT deleted (#127 review)", async () => {
     kvData.set("index:sha", "old-sha");
-    kvData.set("index:vector_docs_ns", "acme/backend:docs:old-sha");
+    kvData.set("index:vector_docs_ns", "acme_backend:docs:old-sha");
     getHeadShaSpy.mockResolvedValue("new-sha");
     getRepoTreeSpy.mockResolvedValue([
       treeBlob("docs/a.md"),
@@ -681,7 +681,7 @@ describe("getOrRebuildIndex — doc embedding hook (#127)", () => {
     );
 
     expect(vectorUpsertSpy).not.toHaveBeenCalled();
-    expect(kvData.get("index:vector_docs_ns")).toBe("acme/backend:docs:old-sha");
+    expect(kvData.get("index:vector_docs_ns")).toBe("acme_backend:docs:old-sha");
     expect(vectorDeleteNamespaceSpy).not.toHaveBeenCalled();
   });
 
@@ -743,7 +743,7 @@ describe("getOrRebuildIndex — doc embedding hook (#127)", () => {
 describe("getDocsVectorNamespace (#127)", () => {
   it("returns the stored pointer, or null when the index has never embedded docs", async () => {
     expect(await getDocsVectorNamespace()).toBeNull();
-    kvData.set("index:vector_docs_ns", "acme/backend:docs:abc");
-    expect(await getDocsVectorNamespace()).toBe("acme/backend:docs:abc");
+    kvData.set("index:vector_docs_ns", "acme_backend:docs:abc");
+    expect(await getDocsVectorNamespace()).toBe("acme_backend:docs:abc");
   });
 });

--- a/src/lib/vector.test.ts
+++ b/src/lib/vector.test.ts
@@ -42,6 +42,8 @@ function makeFakeStore(overrides: Partial<VectorStore> = {}): VectorStore {
 function stubVectorEnv(): void {
   vi.stubEnv("UPSTASH_VECTOR_REST_URL", "https://example-vector.upstash.io");
   vi.stubEnv("UPSTASH_VECTOR_REST_TOKEN", "test-token");
+  vi.stubEnv("GITHUB_OWNER", "acme");
+  vi.stubEnv("GITHUB_REPO", "backend");
 }
 
 beforeEach(() => {
@@ -101,6 +103,17 @@ describe("isVectorConfigured", () => {
   it("true when both are set", () => {
     stubVectorEnv();
     expect(isVectorConfigured()).toBe(true);
+  });
+
+  it("false when Upstash creds are set but the GitHub repo identity is missing — prevents a shared undefined_undefined:* namespace", () => {
+    vi.stubEnv("UPSTASH_VECTOR_REST_URL", "https://example-vector.upstash.io");
+    vi.stubEnv("UPSTASH_VECTOR_REST_TOKEN", "test-token");
+    vi.stubEnv("GITHUB_OWNER", "");
+    vi.stubEnv("GITHUB_REPO", "backend");
+    expect(isVectorConfigured()).toBe(false);
+    vi.stubEnv("GITHUB_OWNER", "acme");
+    vi.stubEnv("GITHUB_REPO", "");
+    expect(isVectorConfigured()).toBe(false);
   });
 });
 

--- a/src/lib/vector.test.ts
+++ b/src/lib/vector.test.ts
@@ -58,22 +58,30 @@ afterEach(() => {
 });
 
 describe("namespace helpers (pure given env)", () => {
-  it("kbNamespace is {owner}/{repo}:kb", () => {
+  it("kbNamespace is {owner}_{repo}:kb (slash-free — a slash 404s Upstash REST paths, BATTLE-MAGE-4)", () => {
     vi.stubEnv("GITHUB_OWNER", "acme");
     vi.stubEnv("GITHUB_REPO", "backend");
-    expect(kbNamespace()).toBe("acme/backend:kb");
+    expect(kbNamespace()).toBe("acme_backend:kb");
   });
 
-  it("docsNamespace is {owner}/{repo}:docs:{sha}", () => {
+  it("docsNamespace is {owner}_{repo}:docs:{sha}", () => {
     vi.stubEnv("GITHUB_OWNER", "acme");
     vi.stubEnv("GITHUB_REPO", "backend");
-    expect(docsNamespace("abc1234")).toBe("acme/backend:docs:abc1234");
+    expect(docsNamespace("abc1234")).toBe("acme_backend:docs:abc1234");
   });
 
-  it("srcNamespace is the stable owner/repo:src namespace (no SHA suffix)", () => {
+  it("srcNamespace is the stable {owner}_{repo}:src namespace (no SHA suffix)", () => {
     vi.stubEnv("GITHUB_OWNER", "acme");
     vi.stubEnv("GITHUB_REPO", "backend");
-    expect(srcNamespace()).toBe("acme/backend:src");
+    expect(srcNamespace()).toBe("acme_backend:src");
+  });
+
+  it("no namespace ever contains a slash — Upstash routes it as a path segment (BATTLE-MAGE-4)", () => {
+    vi.stubEnv("GITHUB_OWNER", "acme");
+    vi.stubEnv("GITHUB_REPO", "backend");
+    for (const ns of [kbNamespace(), docsNamespace("abc1234"), srcNamespace()]) {
+      expect(ns).not.toContain("/");
+    }
   });
 });
 
@@ -106,7 +114,7 @@ describe("degradation: not configured", () => {
     const factory = vi.fn(() => makeFakeStore());
     __setVectorStoreFactoryForTests(factory);
 
-    const result = await vectorQuery("acme/backend:kb", "how does auth work", 10);
+    const result = await vectorQuery("acme_backend:kb", "how does auth work", 10);
     expect(result).toBeNull();
     expect(factory).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith(
@@ -119,7 +127,7 @@ describe("degradation: not configured", () => {
     const factory = vi.fn(() => makeFakeStore());
     __setVectorStoreFactoryForTests(factory);
 
-    const ok = await vectorUpsert("acme/backend:kb", [{ id: "e1", text: "fact" }]);
+    const ok = await vectorUpsert("acme_backend:kb", [{ id: "e1", text: "fact" }]);
     expect(ok).toBe(false);
     expect(factory).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith(
@@ -140,7 +148,7 @@ describe("happy path observability", () => {
 
   it("vectorQuery returns matches and logs vector_op with op/namespace/durationMs/count", async () => {
     __setVectorStoreFactoryForTests(() => makeFakeStore());
-    const matches = await vectorQuery("acme/backend:docs:abc", "deployment flow", 10);
+    const matches = await vectorQuery("acme_backend:docs:abc", "deployment flow", 10);
     expect(matches).toHaveLength(2);
     expect(matches![0]).toEqual(
       expect.objectContaining({ id: "doc-1", score: 0.91 }),
@@ -149,7 +157,7 @@ describe("happy path observability", () => {
     expect(call).toBeDefined();
     const payload = call![1] as Record<string, unknown>;
     expect(payload.op).toBe("query");
-    expect(payload.namespace).toBe("acme/backend:docs:abc");
+    expect(payload.namespace).toBe("acme_backend:docs:abc");
     expect(payload.count).toBe(2);
     expect(typeof payload.durationMs).toBe("number");
   });
@@ -178,9 +186,9 @@ describe("happy path observability", () => {
       { id: "e1", text: "fact one", metadata: { timestamp: "2026-07-01" } },
       { id: "e2", text: "fact two", metadata: { timestamp: "2026-07-02" } },
     ];
-    const ok = await vectorUpsert("acme/backend:kb", items);
+    const ok = await vectorUpsert("acme_backend:kb", items);
     expect(ok).toBe(true);
-    expect(store.upsert).toHaveBeenCalledWith("acme/backend:kb", items);
+    expect(store.upsert).toHaveBeenCalledWith("acme_backend:kb", items);
     expect(logSpy).toHaveBeenCalledWith(
       "vector_op",
       expect.objectContaining({ op: "upsert", count: 2 }),
@@ -190,7 +198,7 @@ describe("happy path observability", () => {
   it("vectorUpsert with an empty item list short-circuits true without touching the store", async () => {
     const store = makeFakeStore();
     __setVectorStoreFactoryForTests(() => store);
-    const ok = await vectorUpsert("acme/backend:kb", []);
+    const ok = await vectorUpsert("acme_backend:kb", []);
     expect(ok).toBe(true);
     expect(store.upsert).not.toHaveBeenCalled();
   });
@@ -198,10 +206,10 @@ describe("happy path observability", () => {
   it("vectorDelete and vectorDeleteNamespace return true and log their ops", async () => {
     const store = makeFakeStore();
     __setVectorStoreFactoryForTests(() => store);
-    expect(await vectorDelete("acme/backend:kb", ["e1"])).toBe(true);
-    expect(await vectorDeleteNamespace("acme/backend:docs:old")).toBe(true);
-    expect(store.delete).toHaveBeenCalledWith("acme/backend:kb", ["e1"]);
-    expect(store.deleteNamespace).toHaveBeenCalledWith("acme/backend:docs:old");
+    expect(await vectorDelete("acme_backend:kb", ["e1"])).toBe(true);
+    expect(await vectorDeleteNamespace("acme_backend:docs:old")).toBe(true);
+    expect(store.delete).toHaveBeenCalledWith("acme_backend:kb", ["e1"]);
+    expect(store.deleteNamespace).toHaveBeenCalledWith("acme_backend:docs:old");
   });
 });
 
@@ -213,7 +221,7 @@ describe("degradation: store errors never throw", () => {
     __setVectorStoreFactoryForTests(() =>
       makeFakeStore({ query: vi.fn(async () => { throw err; }) }),
     );
-    const result = await vectorQuery("acme/backend:kb", "q", 10);
+    const result = await vectorQuery("acme_backend:kb", "q", 10);
     expect(result).toBeNull();
     expect(logSpy).toHaveBeenCalledWith(
       "vector_error",
@@ -264,7 +272,7 @@ describe("degradation: timeout", () => {
     __setVectorStoreFactoryForTests(() =>
       makeFakeStore({ query: () => new Promise(() => {}) }), // never resolves
     );
-    const pending = vectorQuery("acme/backend:kb", "slow question", 10);
+    const pending = vectorQuery("acme_backend:kb", "slow question", 10);
     await vi.advanceTimersByTimeAsync(VECTOR_OP_TIMEOUT_MS + 1);
     await expect(pending).resolves.toBeNull();
     expect(logSpy).toHaveBeenCalledWith(
@@ -279,8 +287,8 @@ describe("privacy: content never reaches logs", () => {
 
   it("neither query text nor upserted text appears in any log payload", async () => {
     __setVectorStoreFactoryForTests(() => makeFakeStore());
-    await vectorQuery("acme/backend:kb", "SECRET_QUESTION_TEXT", 10);
-    await vectorUpsert("acme/backend:kb", [
+    await vectorQuery("acme_backend:kb", "SECRET_QUESTION_TEXT", 10);
+    await vectorUpsert("acme_backend:kb", [
       { id: "e1", text: "SECRET_KB_ENTRY_BODY" },
     ]);
     for (const call of logSpy.mock.calls) {

--- a/src/lib/vector.ts
+++ b/src/lib/vector.ts
@@ -64,9 +64,22 @@ export function isVectorConfigured(): boolean {
   );
 }
 
+/**
+ * Owner/repo prefix shared by every namespace. Joined with `_`, NOT `/`:
+ * the Upstash Vector REST client inserts the namespace into the URL path
+ * verbatim, so a slash splits the route and every operation 404s
+ * ("Endpoint POST /upsert-data/<owner> not found" — Sentry BATTLE-MAGE-4).
+ * GitHub owner/repo names can't contain `_`-vs-`/` ambiguity collisions
+ * in practice for a single-target bot, and nothing was ever successfully
+ * written under the slashed namespaces, so no migration is needed.
+ */
+function namespacePrefix(): string {
+  return `${process.env.GITHUB_OWNER}_${process.env.GITHUB_REPO}`;
+}
+
 /** Namespace holding one embedding per visible KB entry. */
 export function kbNamespace(): string {
-  return `${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}:kb`;
+  return `${namespacePrefix()}:kb`;
 }
 
 /**
@@ -74,7 +87,7 @@ export function kbNamespace(): string {
  * writes a fresh namespace and atomically repoints (see repo-index.ts).
  */
 export function docsNamespace(sha: string): string {
-  return `${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}:docs:${sha}`;
+  return `${namespacePrefix()}:docs:${sha}`;
 }
 
 /**
@@ -84,7 +97,7 @@ export function docsNamespace(sha: string): string {
  * survive across ticks instead of being rebuilt per generation.
  */
 export function srcNamespace(): string {
-  return `${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}:src`;
+  return `${namespacePrefix()}:src`;
 }
 
 // ── Store construction (lazy + memoized; SDK confined here) ──────────

--- a/src/lib/vector.ts
+++ b/src/lib/vector.ts
@@ -59,8 +59,15 @@ export interface VectorStore {
  * (not at module load) so tests and late-injected env both work.
  */
 export function isVectorConfigured(): boolean {
+  // GitHub identity is part of "configured": namespaces are derived from
+  // GITHUB_OWNER/GITHUB_REPO, and running vector ops without them would
+  // silently read/write a shared "undefined_undefined:*" namespace. A
+  // missing identity degrades exactly like missing Upstash creds.
   return Boolean(
-    process.env.UPSTASH_VECTOR_REST_URL && process.env.UPSTASH_VECTOR_REST_TOKEN,
+    process.env.UPSTASH_VECTOR_REST_URL &&
+      process.env.UPSTASH_VECTOR_REST_TOKEN &&
+      process.env.GITHUB_OWNER &&
+      process.env.GITHUB_REPO,
   );
 }
 

--- a/src/tools/search-repo.test.ts
+++ b/src/tools/search-repo.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/lib/github", () => ({
 }));
 vi.mock("@/lib/vector", () => ({
   vectorQuery: (...a: unknown[]) => vectorQuerySpy(...a),
-  srcNamespace: () => "acme/backend:src",
+  srcNamespace: () => "acme_backend:src",
 }));
 vi.mock("@/lib/repo-index", () => ({
   getDocsVectorNamespace: (...a: unknown[]) => getDocsVectorNamespaceSpy(...a),
@@ -55,7 +55,7 @@ function mockVectorArms(arms: {
   src?: FakeMatch[] | null;
 }): void {
   vectorQuerySpy.mockImplementation(async (namespace: string) =>
-    namespace === "acme/backend:src" ? arms.src ?? null : arms.docs ?? null,
+    namespace === "acme_backend:src" ? arms.src ?? null : arms.docs ?? null,
   );
 }
 
@@ -79,7 +79,7 @@ describe("executeSearchRepo — hybrid fusion", () => {
     // wins ties by enumeration order — hand-computed:
     //   code:a 1/61, doc:x 1/61, code:b 1/62, doc:y 1/62.
     searchCodeSpy.mockResolvedValue([codeResult("src/a.ts"), codeResult("src/b.ts")]);
-    getDocsVectorNamespaceSpy.mockResolvedValue("acme/backend:docs:sha1");
+    getDocsVectorNamespaceSpy.mockResolvedValue("acme_backend:docs:sha1");
     mockVectorArms({
       docs: [
         docMatch("docs/x.md#0", 0.9, "X Heading", "x excerpt"),
@@ -98,22 +98,22 @@ describe("executeSearchRepo — hybrid fusion", () => {
   });
 
   it("queries the docs namespace from the pointer with MAX_ARM_RESULTS", async () => {
-    getDocsVectorNamespaceSpy.mockResolvedValue("acme/backend:docs:sha1");
+    getDocsVectorNamespaceSpy.mockResolvedValue("acme_backend:docs:sha1");
     vectorQuerySpy.mockResolvedValue([]);
     await executeSearchRepo({ query: "deployment" });
     expect(vectorQuerySpy).toHaveBeenCalledWith(
-      "acme/backend:docs:sha1",
+      "acme_backend:docs:sha1",
       "deployment",
       MAX_ARM_RESULTS,
     );
   });
 
   it("queries the src namespace with MAX_ARM_RESULTS alongside the docs arm", async () => {
-    getDocsVectorNamespaceSpy.mockResolvedValue("acme/backend:docs:sha1");
+    getDocsVectorNamespaceSpy.mockResolvedValue("acme_backend:docs:sha1");
     vectorQuerySpy.mockResolvedValue([]);
     await executeSearchRepo({ query: "auth flow" });
     expect(vectorQuerySpy).toHaveBeenCalledWith(
-      "acme/backend:src",
+      "acme_backend:src",
       "auth flow",
       MAX_ARM_RESULTS,
     );
@@ -142,7 +142,7 @@ describe("executeSearchRepo — hybrid fusion", () => {
   });
 
   it("semantic arm merges docs and src by score before fusion", async () => {
-    getDocsVectorNamespaceSpy.mockResolvedValue("acme/backend:docs:sha1");
+    getDocsVectorNamespaceSpy.mockResolvedValue("acme_backend:docs:sha1");
     mockVectorArms({
       docs: [
         docMatch("docs/x.md#0", 0.9, "X Heading", "x excerpt"),
@@ -161,7 +161,7 @@ describe("executeSearchRepo — hybrid fusion", () => {
 
   it("src-arm degradation collapses to docs-only; both semantic arms degraded collapses to lexical-only (never throws)", async () => {
     // src arm degraded (null), docs arm healthy → doc lines still present.
-    getDocsVectorNamespaceSpy.mockResolvedValue("acme/backend:docs:sha1");
+    getDocsVectorNamespaceSpy.mockResolvedValue("acme_backend:docs:sha1");
     mockVectorArms({
       docs: [docMatch("docs/x.md#0", 0.9, "X Heading", "x excerpt")],
       src: null,
@@ -224,7 +224,7 @@ describe("executeSearchRepo — degradation", () => {
     // The src arm queries its STABLE namespace regardless of the docs
     // pointer — only the docs namespace must stay untouched (#135).
     for (const call of vectorQuerySpy.mock.calls) {
-      expect(call[0]).toBe("acme/backend:src");
+      expect(call[0]).toBe("acme_backend:src");
     }
   });
 


### PR DESCRIPTION
## Summary

Production bug caught by Sentry on the **first live code-index cron tick** (BATTLE-MAGE-4): every Upstash Vector operation was 404ing because our namespaces embed `{owner}/{repo}` and the SDK inserts the namespace into the REST path verbatim — `POST /upsert-data/wealthbot-io/webo:src` routes as endpoint `/upsert-data/wealthbot-io` + stray segment → `Endpoint not found`.

**Blast radius**: all three semantic arms — KB entry embedding, doc-chunk embedding, and the new code index — have been silently degrading to lexical-only in production since #134 deployed (each path is non-throwing by design, which is why only the cron tick surfaced it via Sentry). The provisioning-time round-trip verification passed because its scratch namespace had no slash.

**Reproduced against the live index before fixing**: slash namespace → the exact 404; underscore → works.

## Fix

- Shared `namespacePrefix()` = `{owner}_{repo}`; all three builders use it.
- Regression test: no namespace builder can ever emit a `/`.
- No migration needed: nothing was ever successfully written under the slashed namespaces — the fixed ones populate fresh on the next cron ticks / KB saves / index rebuild.

TDD: namespace pins flipped + regression test confirmed RED against the old builders, then the fix. Full suite **943 passing**, typecheck clean.

Fixes BATTLE-MAGE-4 (Sentry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
