### PR TITLE
docs: Hygiene sweep — architecture correctness, cross-doc drift, comment cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@ A Slack agent with Claude AI intelligence and full GitHub repo access — reads 
 - **Slack**: Webhook mode via Next.js API route (`/api/slack`), ack-then-process via `after()`
 - **AI**: Anthropic Claude API with tool use (8 tools, adaptive per-turn round budget: quick 4 / standard 10 / deep 15)
 - **GitHub**: Octokit REST API (fine-grained PAT, read-only for code/PRs, read-write for issues)
-- **Knowledge**: Vercel KV (corrections, feedback, repo index cache) + Upstash Vector (semantic recall for KB + docs + source code, graceful lexical-only degradation)
+- **Knowledge**: Upstash Redis (Vercel Marketplace — corrections, feedback, repo index cache) + Upstash Vector (semantic recall for KB + docs + source code, graceful lexical-only degradation)
 - **Context**: CLAUDE.md + KB + feedback + repo index + source hierarchy + search strategy + recency/brevity rules
-- **Progress**: Live thinking messages with contextual emoji, deleted on answer
+- **Progress**: Live thinking messages with contextual emoji, reused in place as the first chunk of the answer
 - **Formatting**: Markdown-to-Slack mrkdwn conversion, typed references with emoji (📄📖🎫🔀📜), ranked by source-of-truth hierarchy, capped at 7
 - **Auto-correct**: Thumbs-down flags stale KB entries for user confirmation, stores pending correction state
 
@@ -51,13 +51,22 @@ src/
     slack.ts              — Slack client, signature verification, message helpers
     claude.ts             — Anthropic client, system prompt assembly, agent loop
     github.ts             — Octokit client (search, read, issues, PRs, commits, tree)
-    knowledge.ts          — Knowledge base (Vercel KV sorted set)
-    feedback.ts           — Feedback storage (Vercel KV) and Q&A context
+    knowledge.ts          — Knowledge base (Upstash Redis sorted set)
+    feedback.ts           — Feedback storage (Upstash Redis) and Q&A context
     issue-batch.ts        — Pure helpers for multi-proposal formatting and bulk-confirm matching
     effort-routing.ts     — Turn classifier (follow-up shouldReply gate + effort buckets → round/answer budgets)
     idempotency.ts        — Content-addressed idempotent execution (issue creation, #125)
     recovery.ts           — Processing markers + sweep decisions for died turns (#125)
     turn-runner.ts        — Mention/follow-up turn bodies (shared by webhook route + sweep)
+    compaction.ts         — Thread-history compaction (Haiku one-shot summary inside first preserved turn)
+    thread-filter.ts      — Pure follow-up gating + multi-turn history building from Slack threads
+    slack-throttle.ts     — Coalesces progress updates (~1 Slack edit / 1.2 s, serialized flushes)
+    slack-users.ts        — Slack user ID → display name resolution with KV caching
+    time-budget.ts        — Per-turn wall-clock budget (warn at 80%, force-stop at 100%)
+    topic-match.ts        — Question → repo-index topic pre-matching (injects starting paths)
+    path-filter.ts        — Excludes tooling/metadata paths from search, reads, and indexing
+    api-error.ts          — Anthropic API error classification + user-facing messages
+    reply-footer.ts       — Opt-in telemetry footer for replies (BM_REPLY_FOOTER=1)
     kb-extract.ts         — Passive-KB transcript rendering + fast-model extractor (#136)
     kb-gate.ts            — Deterministic provenance gate for passive KB candidates (pure)
     kb-proposals.ts       — Pure passive-KB lifecycle helpers (KV keys, idle decision, formatters)
@@ -84,7 +93,7 @@ src/
     list-commits.ts       — Recent commits on main (with dates)
     list-prs.ts           — Recent pull requests (open/merged/closed)
     create-issue.ts       — GitHub issue proposal + parser
-    save-knowledge.ts     — Knowledge base save (Vercel KV)
+    save-knowledge.ts     — Knowledge base save (Upstash Redis)
   evals/
     behavior/
       harness/            — Record/replay harness: cassette hashing, contracts, fakes, scenario runner
@@ -96,14 +105,17 @@ docs/
   architecture.md         — How the internals work (agent loop, prompt, tools)
   contributing.md         — Contributing guide (TDD, CI, fork workflow)
   troubleshooting.md      — Common issues and fixes
+  observability.md        — Structured JSON logs, Sentry integration, event catalog
+  evals.md                — Judge-lite output-contract rubric harness
   features/
     repo-index.md         — Lazy-rebuilt topic map (KV-cached)
-    knowledge-base.md     — Vercel KV knowledge base
+    knowledge-base.md     — Upstash Redis knowledge base (supersession lifecycle, top-k recall)
     source-hierarchy.md   — Source-of-truth hierarchy (5 levels)
     auto-correction.md    — Auto-correction on 👎 reactions
     progress-ux.md        — Live progress updates (emoji + status)
     message-splitting.md  — Long-reply chunking architecture (split-reply + boundary guard)
     issue-creation.md     — Batch issue proposals + bulk-confirm flow
+    config.md             — .battle-mage.json path annotations (graduated trust)
     effort-routing.md     — Fast-model follow-up gate + per-turn effort budgets
     hybrid-retrieval.md   — Lexical + semantic retrieval (Upstash Vector, RRF fusion, degradation)
     code-index.md         — Incremental semantic code index (manifest cursor, cron tick, src arm)
@@ -149,6 +161,9 @@ npm run eval:behavior:record  # Re-record against live APIs (local only; refuses
 | `GITHUB_PAT_BM` | Fine-grained PAT for target repo |
 | `GITHUB_OWNER` | GitHub org/user |
 | `GITHUB_REPO` | Repository name |
-| `CRON_SECRET` | Bearer token for `/api/cron/sweep` (unset = sweep denies all requests) |
+| `CRON_SECRET` | Bearer token for `/api/cron/*` (sweep + code-index; unset = deny all requests) |
+| `UPSTASH_REDIS_REST_URL` | Upstash Redis endpoint (Vercel Marketplace integration; legacy `KV_REST_API_*` also read) |
+| `UPSTASH_REDIS_REST_TOKEN` | Upstash Redis token |
 | `UPSTASH_VECTOR_REST_URL` | Optional — Upstash Vector index (built-in embedding model) for hybrid retrieval |
 | `UPSTASH_VECTOR_REST_TOKEN` | Optional — Vector index token; unset pair degrades to lexical-only |
+| `SENTRY_DSN` | Optional — overrides the hardcoded DSN for structured log capture (see `docs/observability.md`) |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Slack agent powered by Claude AI that reads your GitHub repo in real time — 
 - **Issue and PR awareness** — lists recent issues, PRs, and commits sorted by date
 - **Issue creation** — drafts issues with a preview; creates only after ✅ reaction
 - **Thread conversations** — follow up without re-mentioning the bot
-- **Persistent knowledge base** — remembers corrections across conversations (Vercel KV)
+- **Persistent knowledge base** — remembers corrections across conversations (Upstash Redis via the Vercel Marketplace)
 - **Repo index** — auto-built topic map for fast navigation, rebuilt lazily on push
 - **Source-of-truth hierarchy** — weights code over docs over KB when sources conflict
 - **Auto-correction** — flags possibly stale knowledge entries on 👎, saves corrections directly to KB
@@ -55,6 +55,11 @@ See the [full setup guide](docs/setup.md) for Slack app creation, GitHub PAT, Ve
 | Hybrid Retrieval (lexical + semantic) | [docs/features/hybrid-retrieval.md](docs/features/hybrid-retrieval.md) |
 | Path Annotations (.battle-mage.json) | [docs/features/config.md](docs/features/config.md) |
 | Adaptive Effort Routing | [docs/features/effort-routing.md](docs/features/effort-routing.md) |
+| Message Splitting (long replies) | [docs/features/message-splitting.md](docs/features/message-splitting.md) |
+| Issue Creation (batch + bulk confirm) | [docs/features/issue-creation.md](docs/features/issue-creation.md) |
+| Incremental Code Index | [docs/features/code-index.md](docs/features/code-index.md) |
+| Passive KB Learning | [docs/features/passive-kb-learning.md](docs/features/passive-kb-learning.md) |
+| Behavior Evals (record/replay) | [docs/features/behavior-evals.md](docs/features/behavior-evals.md) |
 
 ## Environment Variables
 
@@ -66,17 +71,21 @@ See the [full setup guide](docs/setup.md) for Slack app creation, GitHub PAT, Ve
 | `GITHUB_PAT_BM` | Fine-grained PAT scoped to your target repo |
 | `GITHUB_OWNER` | GitHub org or username |
 | `GITHUB_REPO` | Repository name |
+| `UPSTASH_REDIS_REST_URL` | Upstash Redis endpoint (Vercel Marketplace integration; legacy `KV_REST_API_*` also read) |
+| `UPSTASH_REDIS_REST_TOKEN` | Upstash Redis token |
+| `CRON_SECRET` | Bearer token for the cron routes (recovery sweep + code-index tick) |
 | `UPSTASH_VECTOR_REST_URL` | Optional — Upstash Vector index (built-in embedding model) for hybrid retrieval |
 | `UPSTASH_VECTOR_REST_TOKEN` | Optional — token for the Vector index; without the pair, search degrades to lexical-only |
+| `SENTRY_DSN` | Optional — structured log capture and error tracking (see [docs/observability.md](docs/observability.md)) |
 
 ## How It Works
 
 ```
 User @mentions @bm in Slack
   → Webhook received, ack'd within 3 seconds
-  → Live progress: 🧠 → 🔍 → 👓 → ✏️
+  → Live progress: 🧠 → 🔍 → 👓
   → Claude reads code, issues, PRs via GitHub API
-  → Answer posted in thread, progress message deleted
+  → Progress message edited in place to become the answer (long answers continue in extra replies)
 ```
 
 For the full architecture walkthrough, see [docs/architecture.md](docs/architecture.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,8 +63,8 @@ When a user types `@bm <question>`, Slack sends an `app_mention` event. The hand
 1. Strips the `<@BOT_ID>` mention from the message text
 2. Posts a thinking message in the thread
 3. Runs the agent loop with live progress updates
-4. Deletes the thinking message
-5. Posts the final answer with references
+4. Edits the thinking message in place with the first chunk of the final answer (reused as chunk 0 — see [One-answer lifecycle](#one-answer-lifecycle))
+5. Posts any remaining chunks as additional thread replies
 
 ### `message` (thread reply) -- Follow-up without re-mention
 
@@ -73,7 +73,8 @@ When a user posts in a thread where the bot has already replied, Slack sends a `
 1. Checks this is a thread reply (not a top-level message)
 2. Skips messages that @mention the bot (those are handled by `app_mention`)
 3. Checks if the bot has previously replied in this thread (via `conversations.replies`)
-4. If yes, processes the message the same way as an `app_mention`
+4. Runs the fail-closed follow-up classifier (Haiku, #126) to decide whether the message is actually addressed to the bot — a decline produces zero Slack output
+5. If yes, processes the message the same way as an `app_mention`
 
 ### `reaction_added` with `white_check_mark` -- Issue creation confirmation
 
@@ -95,13 +96,13 @@ When a user reacts with :white_check_mark: to a bot message containing an issue 
 **Thumbs down (-1)**:
 1. Fetches the Q&A context
 2. Saves a negative feedback entry
-3. Runs auto-correction: identifies stale KB entries (keyword matching) and doc references
-4. Removes stale KB entries from Vercel KV
-5. Replies asking the user what was wrong
+3. Runs auto-correction: identifies stale KB entry candidates (keyword matching) and doc references
+4. Flags the candidates and stores a pending-correction record in KV — nothing is removed
+5. Replies asking the user what was wrong; when the user answers, the correction is saved to the KB and each flagged entry is marked **superseded** by it (retired but kept in history — supersession, not deletion, see #124)
 
 ## The Recovery Sweep — `GET /api/cron/sweep`
 
-A second entry point alongside `/api/slack`, invoked by Vercel Cron every 5 minutes (`vercel.json`) and authenticated via `Authorization: Bearer $CRON_SECRET` (exact match, fail closed). It exists because Vercel can kill the container mid-`after()` — the answer then silently dies.
+A cron entry point alongside `/api/slack` (there are three HTTP entry points in total: `/api/slack`, `/api/cron/sweep`, `/api/cron/code-index`), invoked by Vercel Cron every 5 minutes (`vercel.json`) and authenticated via `Authorization: Bearer $CRON_SECRET` (exact match, fail closed). It exists because Vercel can kill the container mid-`after()` — the answer then silently dies.
 
 1. Every mention/follow-up turn writes a processing marker (`processing:{channel}:{threadTs}` + a `processing:index` zset entry) as the **first step of the `after()` body** and clears it in the `after()` `finally` — so only container death leaves a marker behind. The write stays off the ack path (KV latency must never push the 200 OK past Slack's 3-second deadline); the tiny ack→`after()` death window is an accepted trade
 2. The sweep walks the index and classifies each marker: younger than 15 minutes → wait (could still be a live invocation; the route's `maxDuration` is 300 s, so >15 min is provably dead); stale first attempt → retry; stale retry → give up with a visible failure notice in the thread; index entry without a marker → orphan cleanup
@@ -109,6 +110,10 @@ A second entry point alongside `/api/slack`, invoked by Vercel Cron every 5 minu
 4. Retries verify the bot didn't already answer after the marker was written, then re-run the turn through the **same** turn-runner code path (`src/lib/turn-runner.ts`) the webhook uses — idempotent issue creation makes this safe even for turns that had already filed issues
 
 See `src/lib/recovery.ts` for the marker/staleness model and `TELEMETRY.md` for the recovery-funnel queries.
+
+## The Code Indexer — `GET /api/cron/code-index`
+
+The third entry point, also invoked by Vercel Cron every 5 minutes (`vercel.json`) with the same `Authorization: Bearer $CRON_SECRET` fail-closed auth as the sweep. Each invocation runs one bounded incremental tick: diff the repo tree against the stored manifest cursor, embed/delete the difference into the `{owner}_{repo}:src` vector namespace, persist progress. The route only does auth, dispatch, and observability — indexing invariants live in `src/lib/code-index.ts`. See [Code Index](./features/code-index.md).
 
 ## System Prompt Assembly
 
@@ -120,9 +125,9 @@ The function `assembleSystemPrompt()` takes these inputs:
 |-------|--------|-------------|------|
 | `owner` / `repo` | Environment variables | Target GitHub repository | both |
 | `claudeMd` | `CLAUDE.md` in the target repo | Project-specific context (cached per cold start) | volatile |
-| `knowledge` | Vercel KV + Upstash Vector | Top-k KB recall — the ≤5 entries most relevant to the current question (hybrid lexical + semantic retrieval, see [Hybrid Retrieval](./features/hybrid-retrieval.md)), not the full KB | volatile |
-| `feedback` | Vercel KV | Recent thumbs up/down feedback summaries | volatile |
-| `repoIndex` | Vercel KV (lazy-rebuilt) | Auto-generated topic map of the repository | volatile |
+| `knowledge` | Upstash Redis (Vercel Marketplace) + Upstash Vector | Top-k KB recall — the ≤5 entries most relevant to the current question (hybrid lexical + semantic retrieval, see [Hybrid Retrieval](./features/hybrid-retrieval.md)), not the full KB | volatile |
+| `feedback` | Upstash Redis | Recent thumbs up/down feedback summaries | volatile |
+| `repoIndex` | Upstash Redis (lazy-rebuilt) | Auto-generated topic map of the repository | volatile |
 | `pathAnnotations` | `.battle-mage.json` in target repo | Per-path trust annotations | volatile |
 
 ### Stable zone (XML-tagged, ordered)
@@ -221,7 +226,7 @@ Long threads (Slack Q&A with the bot accumulating over many follow-ups) used to 
 - **Action:** oldest turns are summarized and the summary is embedded as leading context INSIDE the first preserved user turn, prefixed with `[Conversation summary — earlier turns condensed]`. This preserves Anthropic's "first message must be role=user" invariant without needing a synthetic assistant turn. The remaining preserved turns are verbatim so local context (references to "that file we read", etc.) stays intact.
 - **Model:** Haiku 4.5 (`FAST_MODEL`). Runs a single non-streaming `messages.create` with a summarization prompt.
 - **Fail-safe:** if the compactor throws (rate limit, Haiku down), `compactThread` returns the original history and logs `thread_compaction_error`. The agent still runs — uncompacted, which is expensive but correct.
-- **One-shot, not rolling.** Junior's reference implementation uses rolling compaction (up to 16 layers). For battle-mage's QA-shaped threads, one compaction is sufficient; we'll revisit if we ever see a thread that trips the trigger twice.
+- **One-shot, not rolling.** Rolling compaction (re-compacting repeatedly, many layers deep) is an alternative design. For battle-mage's QA-shaped threads, one compaction is sufficient; we'll revisit if we ever see a thread that trips the trigger twice.
 
 Integration point: `runAgent` in `src/lib/claude.ts`. Single check at the top of the function, before the round loop. Covers both mention-follow-up and thread-follow-up flows because both path through `runAgent`.
 
@@ -266,7 +271,9 @@ Eight tools are registered with Claude's tool-use API:
 | `list_prs` | `pulls.list` | Yes — typed as `pr`, includes number + title |
 | `create_issue` | None (proposal only) | No |
 | `search_repo` | `search.code` + Upstash Vector | No (discovery only) — hybrid code + docs search, see [Hybrid Retrieval](./features/hybrid-retrieval.md) |
-| `save_knowledge` | None (Vercel KV + Upstash Vector) | No |
+| `save_knowledge` | None (Upstash Redis + Upstash Vector) | No |
+
+Hybrid retrieval (KB recall and `search_repo`) fuses a lexical arm with a semantic arm backed by Upstash Vector across three namespaces: `{owner}_{repo}:kb` (knowledge entries), `{owner}_{repo}:docs:{sha}` (doc chunks, SHA-pinned and atomically repointed on rebuild), and `{owner}_{repo}:src` (code chunks from the incremental indexer). If the vector layer is unconfigured or errors, retrieval degrades to lexical-only instead of failing the turn. See [Hybrid Retrieval](./features/hybrid-retrieval.md).
 
 The tool registry is in `src/tools/index.ts`. Each tool is a separate file that exports:
 - A `Tool` definition (name, description, input schema) for Claude's API
@@ -342,40 +349,10 @@ This ensures users see the most authoritative sources first.
 | **Search first, read second** | The system prompt instructs Claude to search for code patterns before reading files. A single search returns multiple paths with context, avoiding blind file reads. |
 | **Adaptive tool round budget** | An effort classifier sizes each turn's round cap (quick 4 / standard 10 / deep 15). The hard ceiling of 15 prevents runaway tool loops, and the system prompt instructs Claude to synthesize early rather than exhausting all rounds. See [Effort Routing](./features/effort-routing.md). |
 | **References from reads only** | Search results are discovery aids and do not appear in references. Only files the agent actually reads (via `read_file`) are cited. |
-| **KV for knowledge, not GitHub** | The knowledge base lives in Vercel KV, not in the GitHub repo. The GitHub PAT does not need Contents: Write permission. |
+| **KV for knowledge, not GitHub** | The knowledge base lives in Upstash Redis (Vercel Marketplace), not in the GitHub repo. The GitHub PAT does not need Contents: Write permission. |
 | **Split long answers, don't truncate** | Answers over ~3K chars post as multiple thread replies (`[continued ↓]`) instead of being silently cut off. Makes Slack's `msg_too_long` architecturally unreachable on the happy path. See [Message Splitting](./features/message-splitting.md). |
 | **Thinking message reused as chunk 0** | The "🧠 Battle Mage is working…" message is edited in place with the first chunk of the answer — no delete-and-repost flicker. Subsequent chunks post as new thread replies. |
 
 ## Project Structure
 
-```
-src/
-  app/
-    api/slack/route.ts    -- Webhook handler (mention, reaction, thread follow-up)
-    page.tsx              -- Landing page
-    layout.tsx            -- Root layout
-  lib/
-    slack.ts              -- Slack client, signature verification, message helpers
-    claude.ts             -- Anthropic client, system prompt assembly, agent loop
-    github.ts             -- Octokit client (search, read, issues, PRs, commits, tree)
-    knowledge.ts          -- Knowledge base (Vercel KV sorted set + vector embedding)
-    feedback.ts           -- Feedback storage (Vercel KV) and Q&A context
-    repo-index.ts         -- Repository topic index (lazy rebuild on SHA change) + doc chunk embedding
-    vector.ts             -- Upstash Vector wrapper (non-throwing, observability, timeout)
-    retrieval.ts          -- Pure RRF fusion, age boost, lexical ranking
-    auto-correct.ts       -- Stale KB entry detection and doc reference flagging
-    progress.ts           -- Progress message formatter (tool name to emoji + status)
-    mrkdwn.ts             -- Markdown to Slack mrkdwn converter
-    references.ts         -- Reference deduplication, capping, and formatting
-    split-reply.ts        -- Pure splitter for long Slack replies (paragraph/line/word/fence-aware)
-  tools/
-    index.ts              -- Tool registry and executor
-    search-code.ts        -- GitHub code search
-    search-repo.ts        -- Hybrid code + docs search (lexical + semantic, RRF-fused)
-    read-file.ts          -- GitHub file/directory read
-    list-issues.ts        -- GitHub issue list and lookup
-    list-commits.ts       -- Recent commits on main
-    list-prs.ts           -- Recent pull requests
-    create-issue.ts       -- Issue proposal drafting and message parsing
-    save-knowledge.ts     -- Knowledge base save (Vercel KV)
-```
+The canonical, annotated file tree lives in [CLAUDE.md](../CLAUDE.md#project-structure) at the repo root — one listing, one place to keep current.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,7 +69,7 @@ Clean up the implementation while keeping tests green. Run `npm test` after ever
 - **Colocated**: test files live next to source files (`foo.ts` -> `foo.test.ts`)
 - **Run all tests**: `npm test` (single run, CI mode)
 - **Watch mode**: `npm run test:watch` (re-runs on file changes)
-- **Current count**: 148 tests across 9 test files
+- **Current count**: 945 tests across 47 files (as of July 2026)
 
 ### What to Test
 
@@ -108,7 +108,7 @@ steps:
 All three checks must pass:
 
 1. **Typecheck** -- no TypeScript errors
-2. **Test** -- all 100+ tests pass
+2. **Test** -- the full Vitest suite passes
 3. **Build** -- the Next.js app compiles successfully
 
 CI runs on:
@@ -173,40 +173,7 @@ refactor: Extract keyword matching into pure function
 
 ## Project Structure
 
-```
-src/
-  app/
-    api/slack/route.ts    -- Webhook handler (side-effect layer)
-    page.tsx              -- Landing page
-  lib/
-    claude.ts             -- System prompt + agent loop
-    claude.test.ts        -- 30+ tests for prompt assembly
-    slack.ts              -- Slack API helpers
-    github.ts             -- GitHub API helpers
-    knowledge.ts          -- KV knowledge base
-    feedback.ts           -- KV feedback storage
-    repo-index.ts         -- Topic classification
-    repo-index.test.ts    -- Classification tests
-    auto-correct.ts       -- Stale entry detection
-    auto-correct.test.ts  -- Auto-correction tests
-    progress.ts           -- Progress message formatting
-    progress.test.ts      -- Progress formatting tests
-    mrkdwn.ts             -- Markdown to Slack converter
-    mrkdwn.test.ts        -- Conversion tests
-    references.ts         -- Reference formatting
-    references.test.ts    -- Reference tests
-  tools/
-    index.ts              -- Tool registry + executor
-    search-code.ts        -- search_code tool
-    search-repo.ts        -- search_repo tool (hybrid code + docs)
-    read-file.ts          -- read_file tool
-    list-issues.ts        -- list_issues tool
-    list-commits.ts       -- list_commits tool
-    list-prs.ts           -- list_prs tool
-    create-issue.ts       -- create_issue tool
-    create-issue.test.ts  -- Proposal parsing tests
-    save-knowledge.ts     -- save_knowledge tool
-```
+The canonical, annotated file tree lives in [CLAUDE.md](../CLAUDE.md#project-structure) at the repo root — one listing, one place to keep current. Test files are colocated next to their source files (`foo.ts` -> `foo.test.ts`) and are not repeated in the tree.
 
 ## Local Development Tips
 

--- a/docs/features/knowledge-base.md
+++ b/docs/features/knowledge-base.md
@@ -4,7 +4,7 @@ The knowledge base stores corrections and learned facts from Slack conversations
 
 ## Storage
 
-The knowledge base uses Vercel KV (Upstash Redis). Entries are stored in a sorted set with the key `knowledge:entries`, scored by Unix timestamp (newest first).
+The knowledge base uses Upstash Redis, provisioned via the Vercel Marketplace (post-#117; older deployments provisioned it as "Vercel KV"). Entries are stored in a sorted set with the key `knowledge:entries`, scored by Unix timestamp (newest first).
 
 Each entry is a JSON string:
 
@@ -95,12 +95,12 @@ Each entry should be self-contained -- readable and useful without any surroundi
 
 ## Viewing and Managing Entries
 
-### Via Vercel KV Browser
+### Via the Upstash Data Browser
 
-You can inspect and edit knowledge base entries directly in the Vercel dashboard:
+You can inspect and edit knowledge base entries directly from the Vercel dashboard:
 
 1. Go to your project's **Storage** tab
-2. Open the KV database
+2. Open your Upstash Redis resource (this opens the Upstash data browser)
 3. Find the key `knowledge:entries`
 4. Browse the sorted set members
 
@@ -125,11 +125,11 @@ If you need to retire a KB entry:
 
 1. Let the auto-correction system handle it -- thumbs-down an answer that relied on stale KB data and reply with the correction; flagged entries are superseded by it automatically
 2. Or call `archiveKnowledgeEntry(idOrText, reason)` to soft-delete with a reason
-3. Deleting the raw member in the Vercel KV browser still works but erases history -- prefer the lifecycle functions
+3. Deleting the raw member in the Upstash data browser still works but erases history -- prefer the lifecycle functions
 
 ## Graceful Degradation
 
-If Vercel KV is not configured (common during local development without KV credentials), `getKnowledgeRecallAsMarkdown()` (and `getKnowledgeAsMarkdown()`) catches the error silently and returns `null`. The bot works normally without a knowledge base -- it just does not have persistent memory. If only the *vector* layer is unconfigured, saves and recall still work — recall just runs lexical-only (see [Hybrid Retrieval](./hybrid-retrieval.md)).
+If Upstash Redis is not configured (common during local development without KV credentials), `getKnowledgeRecallAsMarkdown()` (and `getKnowledgeAsMarkdown()`) catches the error silently and returns `null`. The bot works normally without a knowledge base -- it just does not have persistent memory. If only the *vector* layer is unconfigured, saves and recall still work — recall just runs lexical-only (see [Hybrid Retrieval](./hybrid-retrieval.md)).
 
 The knowledge base section is simply omitted from the system prompt when there are no entries.
 
@@ -140,4 +140,4 @@ The knowledge base and the feedback system are separate:
 - **Knowledge base** stores factual corrections ("X lives in Y, not Z"). These are high-signal, specific, and actionable.
 - **Feedback** stores thumbs up/down signals with question/answer context. These are lower-signal and used to calibrate tone and approach.
 
-Both are stored in Vercel KV but under different keys (`knowledge:entries` vs `feedback:entries`). Both are injected into the system prompt but with different headings and different trust levels.
+Both are stored in Upstash Redis but under different keys (`knowledge:entries` vs `feedback:entries`). Both are injected into the system prompt but with different headings and different trust levels.

--- a/docs/features/progress-ux.md
+++ b/docs/features/progress-ux.md
@@ -8,8 +8,8 @@ When the bot starts processing a question:
 
 1. A "thinking" message is posted immediately in the thread
 2. As each tool is called, the message is updated in place with a new status line
-3. When the answer is ready, the thinking message is deleted
-4. The final answer is posted as a new message
+3. When the answer is ready, the thinking message is edited in place to become the first chunk of the final answer (reused as chunk 0 — no delete-and-repost flicker)
+4. If the answer is long, the remaining chunks are posted as new thread replies
 
 The user sees something like:
 
@@ -25,7 +25,7 @@ Then a few seconds later:
 👓 Reading src/middleware/auth.ts...
 ```
 
-Then the thinking message disappears and the final answer appears.
+Then the thinking message transforms into the final answer (the same Slack message, edited in place).
 
 ## Header + Status Line
 
@@ -95,15 +95,17 @@ const result = await runAgent(cleanMessage, async (toolName, input) => {
 
 Before each tool is executed, the callback fires. The route handler uses `updateMessage()` (which calls `slack.chat.update`) to edit the thinking message in place.
 
-After the final answer is ready, a "composing" status is shown briefly, then the thinking message is deleted via `deleteMessage()` and replaced with the final answer.
+After the agent loop returns, the progress throttle is flushed (so no stale status overwrites the answer), and `postReplyInChunks` edits the thinking message in place with the first chunk of the final answer. Remaining chunks, if any, post as new thread replies (see [Message Splitting](./message-splitting.md)).
 
-## Why Delete Instead of Edit?
+## Why Edit Instead of Delete-and-Repost?
 
-The thinking message is deleted rather than edited into the final answer because:
+The thinking message is reused as chunk 0 of the final answer rather than deleted and reposted:
 
-1. The thinking message has a different visual style (emoji + italics) that would need to be completely replaced
-2. Deleting and reposting ensures the message appears at the bottom of the thread, in chronological order
-3. It keeps the thread clean -- only the final answer remains
+1. No flicker — the message never disappears; users watching the thread see the status transform into the answer
+2. The message timestamp (`ts`) is stable, so the Q&A context stored for 👍/👎 reactions keys off the same message users react to
+3. It keeps the thread clean — one message carries both the progress phase and the answer
+
+`deleteMessage()` still runs as a safety net in the `finally` block, but only if the turn crashed before any answer chunk was posted.
 
 ## Testing
 

--- a/docs/features/source-hierarchy.md
+++ b/docs/features/source-hierarchy.md
@@ -75,10 +75,10 @@ Additionally, the knowledge base data section includes a staleness warning, and 
 
 When a user thumbs-down an answer, the [auto-correction system](./auto-correction.md) uses the hierarchy implicitly:
 
-- KB entries that share keywords with the answer's references are presumed stale and removed
+- KB entries that share keywords with the answer's references are flagged as stale candidates; when the user replies with a correction, each flagged entry is marked **superseded** by the new correction entry (retired from recall but kept in history — supersession, not deletion)
 - Documentation files referenced in the answer are flagged as potentially outdated
 
-This creates a self-correcting loop: the bot answers using KB + docs, the user signals the answer was wrong, and the system removes the lower-ranked sources that may have contributed to the bad answer.
+This creates a self-correcting loop: the bot answers using KB + docs, the user signals the answer was wrong, and the system retires the lower-ranked sources that may have contributed to the bad answer — replacing them with the user's correction rather than erasing them.
 
 ## Alignment with Reference Ranking
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -27,7 +27,7 @@ vercel logs --prod --follow # Live tail
 
 **Operator note — data that flows to Sentry.** Structured log payloads include Slack question snippets (first 100 chars), tool input parameters, and GitHub repo paths. `sendDefaultPii` is off by default so IP and user-agent are NOT attached. If your compliance posture forbids this data leaving your tenant, you must (a) remove the hardcoded DSN fallback in the three Sentry config files and leave `SENTRY_DSN` unset so `Sentry.init` receives no DSN and becomes a no-op, (b) self-host Sentry via their on-prem offering, or (c) add a redaction layer inside `src/lib/logger.ts` before the `console.log` call. Simply unsetting `SENTRY_DSN` without removing the fallback will NOT stop data egress.
 
-Why this works on Vercel when stdout doesn't: `@sentry/nextjs` internally calls `vercelWaitUntil(Sentry.flush())` to hold the function container open until events are transmitted. That's the same mechanism `getsentry/junior` uses on their Vercel-hosted Hono agent.
+Why this works on Vercel when stdout doesn't: `@sentry/nextjs` internally calls `vercelWaitUntil(Sentry.flush())` to hold the function container open until events are transmitted.
 
 ### The `after()` tail-drop gotcha (#98)
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -103,7 +103,7 @@ Configuration:
 
 Click **Generate token** and copy it immediately. This is your `GITHUB_PAT_BM`.
 
-> **Tip**: The PAT does NOT need Contents: Write. Battle Mage never pushes code. The knowledge base lives in Vercel KV, not in the GitHub repo.
+> **Tip**: The PAT does NOT need Contents: Write. Battle Mage never pushes code. The knowledge base lives in Upstash Redis (Vercel Marketplace), not in the GitHub repo.
 
 > **Gotcha**: If you select "All repositories" instead of scoping to one repo, Battle Mage will still only operate on the repo specified by `GITHUB_OWNER` and `GITHUB_REPO`. But scoping the PAT to a single repo is better security practice.
 
@@ -247,8 +247,8 @@ You should see:
 
 1. A thinking message appear with a brain emoji header
 2. The status line updating as the bot searches and reads files (magnifying glass for search, glasses for file reads)
-3. The thinking message disappear
-4. A final answer with the project structure, followed by reference links
+3. The thinking message transform in place into the final answer
+4. The answer includes the project structure, followed by reference links
 
 If the bot does not respond, check the [Troubleshooting Guide](./troubleshooting.md).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -22,7 +22,7 @@ The bot will:
 
 1. Post a thinking message with live status updates
 2. Search your codebase, read relevant files, and check issues/PRs
-3. Delete the thinking message and post the final answer with reference links
+3. Edit the thinking message in place so it becomes the final answer with reference links (long answers continue in additional replies)
 
 All replies go in-thread. The bot never posts at channel root.
 
@@ -125,7 +125,7 @@ No, we moved that to config/app.php last month.
   [bot saves correction to knowledge base]
 ```
 
-The bot uses the `save_knowledge` tool to persist the correction in Vercel KV. Future answers will include this correction in the system prompt.
+The bot uses the `save_knowledge` tool to persist the correction in Upstash Redis (Vercel Marketplace). Future answers will include this correction in the system prompt.
 
 ### Option 2: Thumbs down and explain
 
@@ -156,7 +156,7 @@ React to any bot answer with:
 
 - **:thumbsdown:** -- The bot flags possibly related KB entries and docs, asks what was wrong, and saves your correction directly to the knowledge base when you reply. See [auto-correction](features/auto-correction.md) for the full flow.
 
-Feedback is stored in Vercel KV and injected into the system prompt. The bot sees a summary of what worked and what did not when composing future answers.
+Feedback is stored in Upstash Redis and injected into the system prompt. The bot sees a summary of what worked and what did not when composing future answers.
 
 > **Note**: Feedback context expires after 7 days. If you react to a very old message, the bot will not have the Q&A context to process the feedback.
 

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -7,8 +7,7 @@
 // Vercel's log drain before they reach stdout — a known serverless
 // quirk tracked in #90. Sentry's Next.js SDK internally calls
 // `vercelWaitUntil(Sentry.flush())` to keep the function alive until
-// events are transmitted, so after() events land reliably. Same
-// approach getsentry/junior uses on the same stack.
+// events are transmitted, so after() events land reliably.
 //
 // When SENTRY_DSN is unset the SDK falls back to the hardcoded public
 // DSN below (which is safe — it's already in every client bundle).

--- a/src/lib/compaction.ts
+++ b/src/lib/compaction.ts
@@ -9,7 +9,7 @@
  * — NOT a synthetic assistant message, which would break Anthropic's
  * "first message must be role=user" invariant.
  *
- * Design choices (vs junior's reference):
+ * Design choices:
  * - One-shot compaction, not rolling. If threads ever compact twice we'll
  *   revisit; today's QA-shaped threads rarely exceed the trigger.
  * - Character-based trigger (not tokens). `estimateConversationSize` sums

--- a/src/lib/reply-footer.ts
+++ b/src/lib/reply-footer.ts
@@ -3,8 +3,8 @@
  *
  * Appends a single italic Slack line showing duration, token usage, cache
  * metrics, and request ID to answer messages. Disabled by default; enable
- * with `BM_REPLY_FOOTER=1`. Junior's `_45s · 3.2k in · 0.8k out · abc12345_`
- * pattern — turns a black-box agent reply into something you can debug at
+ * with `BM_REPLY_FOOTER=1`. The `_45s · 3.2k in · 0.8k out · abc12345_`
+ * format turns a black-box agent reply into something you can debug at
  * a glance.
  *
  * See #79.

--- a/src/lib/slack-users.ts
+++ b/src/lib/slack-users.ts
@@ -1,7 +1,7 @@
 /**
  * Slack user ID → display name resolution with KV caching.
  *
- * Junior's pattern (see #80): pre-resolve every Slack user in a thread and
+ * Approach (see #80): pre-resolve every Slack user in a thread and
  * inject their IDs into the system prompt as `<@USERID>` tokens so the
  * model can @-mention teammates correctly without a separate tool call.
  *


### PR DESCRIPTION
## Summary

Docs-and-comments-only sweep clearing the pre-existing drift catalogued during the epic work, plus a comment-cleanup policy pass. No behavior changes — every `.ts` diff is comment blocks only, verified by audit and a green suite.

- **architecture.md correctness**: the 👎 flow now describes flag-then-supersede (post-#124) instead of removal; mention-handler steps reflect chunk-0 reuse instead of delete-and-repost; the follow-up handler mentions the fail-closed classifier gate; all three entry points listed with a new code-index section; vector namespaces + lexical degradation documented; the stale inline structure tree replaced with a pointer to CLAUDE.md's canonical one.
- **Cross-doc drift**: source-hierarchy and progress-ux aligned with supersession and edit-in-place reality (progress-ux's "Why Delete?" section is now "Why Edit?"; also removed a documented-but-never-emitted "composing" status); usage/setup wording aligned; README's Feature Deep-Dives table now covers all 13 feature docs (5 rows were missing) and its env table gained the Redis/CRON_SECRET/Sentry rows; CLAUDE.md gained 9 unlisted lib files + 3 missing doc entries; contributing.md's ancient "148 tests" claim now reads 945/47 with a pointer instead of a second structure tree.
- **Naming**: "Vercel KV" → "Upstash Redis (Vercel Marketplace)" across docs, including corrected dashboard navigation. Deliberately NOT changed: the runtime prompt strings in `claude.ts`/`save-knowledge.ts` that still say "Vercel KV" — those are model-facing literals whose edit would invalidate the behavior-eval cassettes; they'll batch with the next cassette re-record, and the two doc passages quoting them verbatim stay verbatim until then.
- **Comment cleanup**: several code comments and doc passages referenced an external reference implementation by name; all rewritten to describe the design decisions generically (6 sites: compaction.ts, sentry.server.config.ts, reply-footer.ts, slack-users.ts, architecture.md, observability.md).

## Verification

Suite green after the comment edits (945/47), full-repo grep confirms zero remaining references, `.ts` diffs audited as comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
